### PR TITLE
refactor(rust-server): code review fixes and provider cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,94 @@
-# mast-ai
+# MAST (Modular Agent State Toolkit)
 
-To install dependencies:
+MAST is a TypeScript library that shifts the execution of AI agent loops from the server directly into the web browser. 
 
+Traditional agent frameworks are server-centric, making it difficult for agents to securely access client-side DOM, browser APIs, or local user state without complex and high-latency callback plumbing. MAST solves this by treating the **browser as the primary orchestrator**.
+
+## Key Features
+
+* **Client-Led Orchestration:** The "think-act" loop (`thought -> tool_call -> execution -> result`) runs entirely in the browser using the `AgentRunner`.
+* **Native Tool Integration:** Write tools as standard TypeScript functions that have direct, synchronous access to the browser's DOM, `localStorage`, and client state.
+* **Environment Agnostic Inference:** Keep your agent logic in TypeScript, but use high-performance reasoning engines written in Go, Rust, or Python via the **Universal Remote Protocol (URP)**.
+* **Hybrid & Client-Side Modes:** Run inference remotely via a URP server, or fully locally on-device using the Chrome Prompt API (Gemini Nano).
+
+## Monorepo Structure
+
+This project is a [Bun](https://bun.sh) workspace containing the core library and several demo applications:
+
+* `packages/core/` — The main MAST TypeScript library (`AgentRunner`, `RunBuilder`, Adapters, Types).
+* `apps/demo-basic-chat/` — A Vite-powered frontend demonstrating a Hybrid Mode chat agent with local tools.
+* `apps/demo-rust-server/` — A sample URP reasoning engine backend written in Rust (Axum + async channels).
+
+## Getting Started
+
+### Prerequisites
+Make sure you have [Bun](https://bun.sh/) installed.
+
+### Installation
+Clone the repository and install dependencies from the root:
 ```bash
 bun install
 ```
 
-To run:
+### Running the Demo
+To see MAST in action, start both the Rust URP Server and the basic chat frontend:
 
-```bash
-bun run index.ts
+1. **Start the reasoning backend (Rust):**
+   ```bash
+   cd apps/demo-rust-server
+   cargo run
+   ```
+2. **Start the frontend (in a new terminal):**
+   ```bash
+   cd apps/demo-basic-chat
+   bun run dev
+   ```
+Open the provided `localhost` URL in your browser to interact with the agent.
+
+## Basic Usage
+
+Here's a quick example of how to configure an agent, provide a local tool, and run a conversational turn:
+
+```typescript
+import { 
+  ToolRegistry, 
+  HttpTransport, 
+  UrpAdapter, 
+  AgentRunner, 
+  createAgent 
+} from '@mast-ai/core';
+
+// 1. Define a tool that runs in the browser
+const registry = new ToolRegistry().register({
+  definition: () => ({
+    name: 'getScreenResolution',
+    description: 'Returns the user\'s current screen width and height.',
+    parameters: { type: 'object', properties: {}, required: [] }
+  }),
+  call: async () => ({ width: window.innerWidth, height: window.innerHeight })
+});
+
+// 2. Define the Agent
+const agent = createAgent({
+  name: 'BrowserAssistant',
+  instructions: 'You are a helpful UI assistant. Use tools to answer questions about the screen.',
+  tools: ['getScreenResolution']
+});
+
+// 3. Connect to a reasoning backend (Hybrid Mode)
+const transport = new HttpTransport({ url: 'http://localhost:3000/api/chat' });
+const adapter = new UrpAdapter(transport);
+const runner = new AgentRunner(adapter, registry);
+
+// 4. Run the loop
+const result = await runner.run(agent, 'How big is my screen?');
+console.log(result.output);
 ```
 
-This project was created using `bun init` in bun v1.1.32. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+## Documentation
+
+For deep dives into the architecture and protocol definitions, please see our technical documentation:
+* [Product Requirements (PRD)](./docs/PRD.md)
+* [Technical Specification](./docs/SPEC.md)
+* [Implementation Plan](./docs/PLAN.md)
+* [URP Server Implementation Guide](./docs/URP_SERVER_IMPLEMENTATION.md)

--- a/apps/demo-rust-server/Cargo.lock
+++ b/apps/demo-rust-server/Cargo.lock
@@ -225,17 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,15 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +351,6 @@ dependencies = [
  "axum",
  "dotenvy",
  "futures-util",
- "rand 0.10.1",
  "serde",
  "serde_json",
  "tokio",
@@ -464,12 +443,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -583,23 +556,9 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -629,24 +588,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -868,12 +812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,12 +948,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1190,16 +1122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,7 +1160,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1280,30 +1202,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1313,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1324,12 +1229,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1580,12 +1479,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2053,12 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,16 +2000,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2181,28 +2059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,18 +2069,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -2485,97 +2329,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/apps/demo-rust-server/Cargo.toml
+++ b/apps/demo-rust-server/Cargo.toml
@@ -14,5 +14,4 @@ dotenvy = "0.15"
 agent-rig = { git = "https://github.com/andreban/agent-rig.git", version = "0.1.0", features = ["full"] }
 async-stream = "0.3.6"
 futures-util = "0.3.32"
-rand = "0.10.1"
 tokio-stream = { version = "0.1.18", features = ["sync"] }

--- a/apps/demo-rust-server/src/main.rs
+++ b/apps/demo-rust-server/src/main.rs
@@ -18,12 +18,8 @@ use crate::types::UrpRequest;
 
 use axum::response::Response;
 
-// -----------------------------------------------------------------------------
-// Server Logic
-// -----------------------------------------------------------------------------
-
 struct AppState {
-    model: Arc<Box<dyn LlmModel>>,
+    model: Arc<dyn LlmModel>,
 }
 
 async fn handle_urp(
@@ -41,16 +37,15 @@ async fn main() {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set in .env");
 
     println!("Initializing URP Server with Gemini (gemini-2.5-flash)");
-    let model: Box<dyn LlmModel> = Box::new(
+    let model: Arc<dyn LlmModel> = Arc::new(
         GeminiModel::builder(api_key, "gemini-2.5-flash")
             .temperature(0.7)
             .build(),
     );
 
-    let state = Arc::new(AppState {
-        model: Arc::new(model),
-    });
+    let state = Arc::new(AppState { model });
 
+    // Dev-only: allow all origins. Restrict this before any network-accessible deployment.
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods([Method::POST])

--- a/apps/demo-rust-server/src/provider.rs
+++ b/apps/demo-rust-server/src/provider.rs
@@ -2,6 +2,7 @@ use crate::types::{UrpMessageContent, UrpRequest, UrpResponse, UrpStreamChunk, U
 use agent_rig::model::{
     LlmModel, Message, MessageContent, ModelRequest, ModelStreamChunk, Role, ToolCall,
 };
+use async_stream::stream;
 use axum::{
     http::StatusCode,
     response::{
@@ -13,18 +14,23 @@ use axum::{
 use futures_util::StreamExt;
 use std::convert::Infallible;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 
 pub async fn handle_urp_request(
-    model: Arc<Box<dyn LlmModel>>,
+    model: Arc<dyn LlmModel>,
     payload: UrpRequest,
 ) -> Result<Response, (StatusCode, String)> {
-    // 1. Identify the system prompt if present in messages and map URP messages
+    let (request, is_streaming) = build_model_request(payload)?;
+
+    if is_streaming {
+        handle_streaming(model, request).await
+    } else {
+        handle_non_streaming(model, request).await
+    }
+}
+
+fn build_model_request(payload: UrpRequest) -> Result<(ModelRequest, bool), (StatusCode, String)> {
     let mut rig_messages = Vec::new();
     let mut system_prompt = None;
-
-    let is_streaming = payload.stream;
 
     for msg in payload.messages {
         let role = match msg.role.as_str() {
@@ -34,9 +40,14 @@ pub async fn handle_urp_request(
                 if let UrpMessageContent::Text { text } = msg.content {
                     system_prompt = Some(text);
                 }
-                continue; // System prompt handled separately, skip adding to general history
+                continue;
             }
-            _ => Role::User, // Fallback
+            other => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("Unknown message role: {other}"),
+                ));
+            }
         };
 
         match msg.content {
@@ -62,7 +73,6 @@ pub async fn handle_urp_request(
         }
     }
 
-    // 2. Build ModelRequest
     let request = ModelRequest {
         messages: rig_messages,
         system: system_prompt,
@@ -70,69 +80,61 @@ pub async fn handle_urp_request(
         output_schema: None,
     };
 
-    // 3. Initialize and run generic model
-    if is_streaming {
-        let (tx, rx) = mpsc::channel(100);
+    Ok((request, payload.stream))
+}
 
-        tokio::spawn(async move {
-            let mut response_stream = model.generate_stream(request);
+async fn handle_streaming(
+    model: Arc<dyn LlmModel>,
+    request: ModelRequest,
+) -> Result<Response, (StatusCode, String)> {
+    let sse_stream = stream! {
+        let mut response_stream = model.generate_stream(request);
 
-            while let Some(event) = response_stream.next().await {
-                let chunk = match event {
-                    Ok(ModelStreamChunk::TextDelta(delta)) => {
-                        Some(UrpStreamChunk::TextDelta { delta })
-                    }
-                    Ok(ModelStreamChunk::Thinking(delta)) => {
-                        Some(UrpStreamChunk::Thinking { delta })
-                    }
-                    Ok(ModelStreamChunk::ToolCall(tc)) => Some(UrpStreamChunk::ToolCall {
-                        tool_call: UrpToolCall {
-                            id: tc.id,
-                            name: tc.name,
-                            arguments: tc.args,
-                        },
-                    }),
-                    _ => None, // Ignore errors or other types for simplicity
-                };
-                if let Some(c) = chunk {
-                    let json_str = serde_json::to_string(&c).unwrap();
-                    if tx
-                        .send(Ok::<_, Infallible>(Event::default().data(json_str)))
-                        .await
-                        .is_err()
-                    {
-                        break; // Receiver dropped
-                    }
+        while let Some(event) = response_stream.next().await {
+            let chunk = match event {
+                Ok(ModelStreamChunk::TextDelta(delta)) => UrpStreamChunk::TextDelta { delta },
+                Ok(ModelStreamChunk::Thinking(delta)) => UrpStreamChunk::Thinking { delta },
+                Ok(ModelStreamChunk::ToolCall(tc)) => UrpStreamChunk::ToolCall {
+                    tool_call: UrpToolCall {
+                        id: tc.id,
+                        name: tc.name,
+                        arguments: tc.args,
+                    },
+                },
+                Err(e) => {
+                    eprintln!("Stream error: {:?}", e);
+                    UrpStreamChunk::Error { message: e.to_string() }
                 }
+            };
+
+            match serde_json::to_string(&chunk) {
+                Ok(json) => yield Ok::<_, Infallible>(Event::default().data(json)),
+                Err(e) => eprintln!("Failed to serialize stream chunk: {:?}", e),
             }
-            // Signal the end of the stream for the client parser
-            let _ = tx
-                .send(Ok::<_, Infallible>(Event::default().data("[DONE]")))
-                .await;
-        });
+        }
 
-        Ok(Sse::new(ReceiverStream::new(rx)).into_response())
-    } else {
-        let response = model.generate(request).await.map_err(|e| {
-            eprintln!("Model execution failed: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Model execution failed: {}", e),
-            )
-        })?;
+        yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
+    };
 
-        let urp_tool_calls: Vec<agent_rig::model::ToolCall> = response
-            .tool_calls
-            .into_iter()
-            .map(|c| agent_rig::model::ToolCall::new(c.id, c.name, c.args))
-            .collect();
+    Ok(Sse::new(sse_stream).into_response())
+}
 
-        // 4. Map Agent-Rig Response -> URP Response
-        Ok(Json(UrpResponse {
-            text_content: response.text,
-            tool_calls: urp_tool_calls,
-            usage_metrics: None,
-        })
-        .into_response())
-    }
+async fn handle_non_streaming(
+    model: Arc<dyn LlmModel>,
+    request: ModelRequest,
+) -> Result<Response, (StatusCode, String)> {
+    let response = model.generate(request).await.map_err(|e| {
+        eprintln!("Model execution failed: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Model execution failed: {}", e),
+        )
+    })?;
+
+    Ok(Json(UrpResponse {
+        text_content: response.text,
+        tool_calls: response.tool_calls,
+        usage_metrics: None,
+    })
+    .into_response())
 }

--- a/apps/demo-rust-server/src/types.rs
+++ b/apps/demo-rust-server/src/types.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 pub struct UrpRequest {
     pub messages: Vec<UrpMessage>,
     pub available_tools: Option<Vec<ToolDefinition>>,
+    // Accepted for protocol compatibility but not used by this backend.
     #[allow(dead_code)]
     pub configuration: Option<Value>,
     #[serde(default)]
@@ -21,6 +22,8 @@ pub enum UrpStreamChunk {
     Thinking { delta: String },
     #[serde(rename = "tool_call")]
     ToolCall { tool_call: UrpToolCall },
+    #[serde(rename = "error")]
+    Error { message: String },
 }
 
 #[derive(Deserialize, Debug)]
@@ -38,7 +41,6 @@ pub enum UrpMessageContent {
     ToolCalls { calls: Vec<UrpToolCall> },
     #[serde(rename = "tool_result")]
     ToolResult {
-        #[allow(dead_code)]
         id: String,
         name: String,
         result: Value,


### PR DESCRIPTION
## Summary

- **Correctness:** `UrpStreamChunk::Error` variant added; stream errors are now forwarded to the client instead of silently dropped. Unknown message roles return `400 Bad Request` instead of silently coercing to `User`. Serialization `unwrap()` in the streaming path replaced with a handled `match`.
- **Dead code removal:** No-op `ToolCall` remapping in the non-streaming path removed; unused `rand` dependency removed; `#[allow(dead_code)]` on `ToolResult.id` removed (field is now used).
- **Type simplification:** `Arc<Box<dyn LlmModel>>` → `Arc<dyn LlmModel>` throughout.
- **Refactor — provider split:** `handle_urp_request` broken into three focused functions: `build_model_request` (sync, validation + message mapping), `handle_streaming`, and `handle_non_streaming`.
- **Refactor — streaming simplification:** `mpsc` channel + `tokio::spawn` + `ReceiverStream` replaced with `async_stream::stream!`, which moves the model into an owned generator and eliminates the channel entirely. `tokio-stream` import removed.
- **Docs:** CORS `allow_origin(Any)` annotated as dev-only. README updated with full project documentation.

## Test plan

- [ ] `cargo clippy` passes with zero warnings
- [ ] `cargo fmt` produces no diff
- [ ] Non-streaming response returns correct JSON with `text_content` and `tool_calls`
- [ ] Streaming response emits SSE chunks and terminates with `[DONE]`
- [ ] A request with an unknown role (e.g. `"role": "banana"`) returns HTTP 400
- [ ] Full stack demo (`cargo run` + `bun run dev`) works end-to-end