### PR TITLE
fix: include tool call history in done event for correct multi-turn context

### DIFF
--- a/apps/demo-basic-chat/src/main.ts
+++ b/apps/demo-basic-chat/src/main.ts
@@ -145,8 +145,7 @@ async function handleSend() {
       } else if (event.type === 'tool_call_completed') {
         appendSystemMessage(`✅ Result: ${JSON.stringify(event.result)}`, 'tool');
       } else if (event.type === 'done') {
-        history.push({ role: 'user', content: { type: 'text', text } });
-        history.push({ role: 'assistant', content: { type: 'text', text: event.output } });
+        history = event.history;
       }
     }
   } catch (error) {

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -180,7 +180,8 @@ export class AgentRunner {
         continue;
       }
 
-      yield { type: 'done', output: finalOutput };
+      currentHistory.push({ role: 'assistant', content: { type: 'text', text: finalOutput } });
+      yield { type: 'done', output: finalOutput, history: currentHistory };
       return;
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,7 +36,7 @@ export type AgentEvent =
   | { type: 'tool_call_completed'; name: string; result: unknown }
   | { type: 'text_delta';          delta: string }
   | { type: 'thinking';            delta: string }
-  | { type: 'done';                output: string };
+  | { type: 'done';                output: string; history: Message[] };
 
 /**
  * Pure data blueprint for an agent.


### PR DESCRIPTION
## Summary

- `done` event now carries `history: Message[]` with the full updated conversation, including intermediate `tool_calls` and `tool_result` messages
- `AgentRunner` pushes the final assistant text message into `currentHistory` before yielding `done`
- `demo-basic-chat` replaces history with `event.history` on `done` instead of manually reconstructing only the user/assistant text turns

## Test plan

- [ ] Send a message that triggers a tool call (e.g. "Add 10 + 10") and verify it executes correctly
- [ ] Send a follow-up message and verify the LLM has full context of the previous tool interaction