### PR TITLE
feat(rust-server): switch to gemini-3.1-flash-lite-preview with thinking enabled

### DIFF
--- a/apps/demo-rust-server/Cargo.lock
+++ b/apps/demo-rust-server/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "axum",
  "dotenvy",
  "futures-util",
+ "geologia",
  "serde",
  "serde_json",
  "tokio",
@@ -522,7 +523,7 @@ dependencies = [
 [[package]]
 name = "geologia"
 version = "0.1.0"
-source = "git+https://github.com/andreban/geologia#08ad998601db705bda409a445a83251c462597d3"
+source = "git+https://github.com/andreban/geologia.git#08ad998601db705bda409a445a83251c462597d3"
 dependencies = [
  "reqwest",
  "serde",

--- a/apps/demo-rust-server/Cargo.toml
+++ b/apps/demo-rust-server/Cargo.toml
@@ -12,6 +12,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 anyhow = "1.0"
 dotenvy = "0.15"
 agent-rig = { git = "https://github.com/andreban/agent-rig.git", version = "0.1.0", features = ["full"] }
+geologia = { git = "https://github.com/andreban/geologia.git", version = "0.1.0" }
 async-stream = "0.3.6"
 futures-util = "0.3.32"
 tokio-stream = { version = "0.1.18", features = ["sync"] }

--- a/apps/demo-rust-server/src/main.rs
+++ b/apps/demo-rust-server/src/main.rs
@@ -10,6 +10,7 @@ use axum::{
     Json, Router,
 };
 use dotenvy::dotenv;
+use geologia::prelude::{ThinkingConfig, ThinkingLevel};
 use std::{env, sync::Arc};
 use tower_http::cors::{Any, CorsLayer};
 
@@ -36,9 +37,14 @@ async fn main() {
 
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set in .env");
 
-    println!("Initializing URP Server with Gemini (gemini-2.5-flash)");
+    println!("Initializing URP Server with Gemini (gemini-3.1-flash-lite-preview)");
     let model: Arc<dyn LlmModel> = Arc::new(
-        GeminiModel::builder(api_key, "gemini-2.5-flash")
+        GeminiModel::builder(api_key, "gemini-3.1-flash-lite-preview")
+            .thinking_config(ThinkingConfig {
+                include_thoughts: true,
+                thinking_level: Some(ThinkingLevel::High),
+                ..Default::default()
+            })
             .temperature(0.7)
             .build(),
     );


### PR DESCRIPTION
## Summary

- Adds `geologia` dependency for `ThinkingConfig` support
- Switches model from `gemini-2.5-flash` to `gemini-3.1-flash-lite-preview`
- Enables thinking with `ThinkingLevel::High` and `include_thoughts: true`

## Test plan

- [ ] Start the Rust server (`cargo run`) and verify it starts without errors
- [ ] Send a prompt from the demo UI and verify thinking deltas appear
- [ ] Confirm tool calls still work end-to-end