### PR TITLE
docs: add @mast-ai/built-in-ai package plan

### DIFF
--- a/docs/BUILT_IN_AI_PHASE1.md
+++ b/docs/BUILT_IN_AI_PHASE1.md
@@ -1,0 +1,277 @@
+# Built-in AI — Phase 1: `BuiltInAIAdapter` (Prompt API)
+
+## Goal
+
+Implement `BuiltInAIAdapter` using the browser's Prompt API, exposing on-device text generation through the standard MAST `LlmAdapter` interface. No tool calling support (documented limitation).
+
+## Reference Implementation
+
+Use `packages/google-genai/src/GoogleGenAIAdapter.ts` as the structural reference — file layout, copyright header, constructor pattern, and mapping helpers. The core interface to implement lives in `packages/core/src/adapter/index.ts`.
+
+---
+
+## `LlmAdapter` Interface
+
+```typescript
+// packages/core/src/adapter/index.ts
+
+export interface AdapterRequest {
+  messages: Message[];       // full conversation history
+  system?: string;           // system prompt
+  tools: ToolDefinition[];   // always empty for BuiltInAIAdapter (no tool support)
+  outputSchema?: Record<string, unknown>;
+  config?: ModelConfig;
+  signal?: AbortSignal;
+}
+
+export interface AdapterResponse {
+  text?: string;             // undefined when tool calls were issued
+  toolCalls: ToolCall[];     // always [] for BuiltInAIAdapter
+}
+
+export type AdapterStreamChunk =
+  | { type: 'text_delta'; delta: string }
+  | { type: 'thinking';   delta: string }
+  | { type: 'tool_call';  toolCall: ToolCall };
+
+export interface LlmAdapter {
+  generate(request: AdapterRequest): Promise<AdapterResponse>;
+  generateStream?(request: AdapterRequest): AsyncIterable<AdapterStreamChunk>;
+}
+```
+
+`Message` (from `packages/core/src/types.ts`):
+
+```typescript
+export type Role = 'user' | 'assistant';
+
+export type MessageContent =
+  | { type: 'text'; text: string }
+  | { type: 'tool_calls'; calls: ToolCall[] }
+  | { type: 'tool_result'; id: string; name: string; result: unknown };
+
+export interface Message {
+  role: Role;
+  content: MessageContent;
+}
+```
+
+---
+
+## Prompt API Overview
+
+The Prompt API exposes an on-device language model via the `LanguageModel` bare global. Key operations:
+
+```typescript
+// Check availability
+const availability = await LanguageModel.availability(options?);
+// → "readily" | "after-download" | "downloading" | "unavailable"
+
+// Create a session
+const session = await LanguageModel.create(options?);
+
+// Prompt (blocking)
+const text = await session.prompt(input, options?);
+
+// Prompt (streaming)
+const stream = session.promptStreaming(input, options?);
+for await (const chunk of stream) { /* each chunk is a text delta, not cumulative */ }
+
+// Free resources
+session.destroy();
+```
+
+---
+
+## Mapping MAST → Prompt API
+
+### Messages and System Prompt
+
+MAST passes conversation history as `Message[]` and a separate `system` string. The Prompt API maps these to `initialPrompts` on session creation and the ongoing `session.prompt()` call.
+
+**Proposed mapping:**
+
+| MAST | Prompt API |
+|------|-----------|
+| `request.system` | `{ role: "system", content: system }` as first entry in `initialPrompts` |
+| `request.messages` (all but last) | Remaining entries in `initialPrompts` |
+| `request.messages` (last user message) | Argument to `session.prompt()` / `session.promptStreaming()` |
+
+The Prompt API supports `role: "user" | "assistant" | "system"` in `initialPrompts`, so this mapping is clean. The last message is separated out because the API expects prompts to be sent via `prompt()`, not injected into history.
+
+### Session Lifecycle
+
+The Prompt API session is stateful — each `session.prompt()` call appends to its internal context (including KV cache). MAST's `generate()` is stateless (it receives the full history each call), so the adapter must bridge that gap.
+
+**Strategy — cached session with history matching:**
+
+Cache one session alongside the list of messages already fed into it. On each `generate()` call:
+
+- **History is an extension of the cache** (common case — ongoing conversation): the session already holds the earlier context, so call `session.prompt(newTurn)` directly. O(1) cost.
+- **History has diverged** (different conversation, or messages were edited): destroy the cached session and create a new one with the full history in `initialPrompts`. O(n) cost, but only on a cache miss.
+
+`session.clone()` is not used here. Cloning forks the session's KV cache cheaply, but it would require keeping a frozen root session and discarding the clone after every turn — paying the clone cost every turn with no benefit for a linear conversation.
+
+**History comparison:** Use an optimistic length + last-message check. Verify that `cachedHistory.length === request.messages.length - 1`, then spot-check that `request.messages[cachedHistory.length - 1]` matches the last cached message. O(1) cost per turn. This is sound because MAST's `Conversation` is append-only — if length and the most recent message match, the rest is guaranteed to be the same.
+
+### Context Window
+
+The API exposes `session.contextUsage` and `session.contextWindow` (token counts) and fires a `contextoverflow` event when the context is full. On a cache miss, a new session is created with the full history in `initialPrompts`, which could exceed the context window for long conversations.
+
+**Proposed handling:** After session creation, check `contextUsage < contextWindow`. If the context is already full before prompting, throw an `AdapterError` with a descriptive message rather than letting it fail silently.
+
+### AbortSignal
+
+The Prompt API supports `signal` both on `LanguageModel.create()` and on `session.prompt()` / `session.promptStreaming()`. MAST passes `request.signal` through.
+
+**Proposed handling:**
+- Pass `request.signal` to `LanguageModel.create()` so session creation itself is cancellable.
+- Pass `request.signal` to `session.prompt()` / `session.promptStreaming()` for the actual generation.
+- Call `session.destroy()` in a `finally` block to always free resources.
+
+### Availability Checking
+
+`LanguageModel.availability()` should be called before attempting session creation to give meaningful errors.
+
+**Proposed handling:** Export a standalone `checkAvailability()` helper that returns the availability string. Inside the adapter, if availability is `"unavailable"`, throw an `AdapterError` immediately. If `"after-download"` or `"downloading"`, throw with a message instructing the user to wait for the model download — we will not block on the download inside the adapter, as this could hang indefinitely.
+
+### Model Download Progress
+
+`LanguageModel.create()` accepts a `monitor` option for tracking download progress. This is only relevant when availability is `"after-download"`.
+
+**Proposed handling:** Expose an optional `onDownloadProgress` callback in `BuiltInAIAdapterOptions`, mirroring the `onUsageUpdate` pattern in `GoogleGenAIAdapter`. The callback receives `{ loaded: number, total: number }`.
+
+---
+
+## TypeScript Types (`types.ts`)
+
+The Prompt API is not yet in `lib.dom.d.ts`. The package must declare the global interface. Key types to declare:
+
+```typescript
+type LanguageModelAvailability = "readily" | "after-download" | "downloading" | "unavailable";
+
+interface LanguageModelMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+interface LanguageModelCreateOptions {
+  signal?: AbortSignal;
+  initialPrompts?: LanguageModelMessage[];
+  // systemPrompt exists in the spec but is not used — system prompt is
+  // injected as a { role: "system" } entry in initialPrompts instead.
+  monitor?: (monitor: EventTarget) => void;
+  temperature?: number;
+  topK?: number;
+}
+
+interface LanguageModelPromptOptions {
+  signal?: AbortSignal;
+}
+
+interface LanguageModelSession {
+  prompt(input: string, options?: LanguageModelPromptOptions): Promise<string>;
+  promptStreaming(input: string, options?: LanguageModelPromptOptions): ReadableStream<string>;
+  contextUsage: number;
+  contextWindow: number;
+  destroy(): void;
+  addEventListener(type: "contextoverflow", listener: EventListener): void;
+}
+
+declare const LanguageModel: {
+  availability(options?: Partial<LanguageModelCreateOptions>): Promise<LanguageModelAvailability>;
+  create(options?: LanguageModelCreateOptions): Promise<LanguageModelSession>;
+};
+```
+
+
+---
+
+## Documented Limitation
+
+`BuiltInAIAdapter` does not support tool calling. The Prompt API has no native mechanism for structured tool invocation. If tools are registered with a runner backed by this adapter, they will never be called — `toolCalls` in every response will be `[]`. This should be:
+
+1. Stated in the JSDoc on the class.
+2. Logged as a warning if `request.tools.length > 0` is detected at runtime.
+
+---
+
+## Package Config
+
+**`package.json`:**
+```json
+{
+  "name": "@mast-ai/built-in-ai",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
+    "dev": "tsup src/index.ts --format esm --out-dir dist --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.4"
+  }
+}
+```
+
+**`tsconfig.json`** (identical to all other packages):
+```json
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}
+```
+
+---
+
+## `index.ts` Exports
+
+```typescript
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export { BuiltInAIAdapter } from './BuiltInAIAdapter.js';
+export type { BuiltInAIAdapterOptions } from './BuiltInAIAdapter.js';
+```
+
+The `tools/` exports are deferred to later phases.
+
+---
+
+## Files to Create
+
+```
+packages/built-in-ai/
+├── package.json
+├── tsconfig.json
+└── src/
+    ├── index.ts
+    ├── BuiltInAIAdapter.ts
+    ├── BuiltInAIAdapter.test.ts
+    └── types.ts
+```
+
+The `tools/` directory is deferred to Phase 2.
+
+---
+

--- a/docs/BUILT_IN_AI_PLAN.md
+++ b/docs/BUILT_IN_AI_PLAN.md
@@ -1,0 +1,182 @@
+# Plan: `@mast-ai/built-in-ai` — Browser Built-in AI Adapter
+
+## Overview
+
+This document plans the scope and implementation of a new package, `@mast-ai/built-in-ai`, that exposes the browser's Built-in AI APIs as a MAST `LlmAdapter` and as individual MAST tools. These APIs are being proposed as web standards and are intended to be available across browsers. This allows agents to leverage on-device AI capabilities without a remote backend.
+
+---
+
+## Built-in AI APIs
+
+The following APIs are available or in trial in browsers that support them:
+
+| API | Purpose | Status | Docs |
+|-----|---------|--------|------|
+| **Prompt API** | Send natural language prompts to the on-device model | Stable (extensions), Origin trial (web) | https://developer.chrome.com/docs/ai/prompt-api |
+| **Summarizer API** | Condense long-form content | Stable | https://developer.chrome.com/docs/ai/summarizer-api |
+| **Writer API** | Generate new content for writing tasks | Developer trial | https://developer.chrome.com/docs/ai/writer-api |
+| **Rewriter API** | Revise and restructure existing text | Developer trial | https://developer.chrome.com/docs/ai/rewriter-api |
+| **Translator API** | Translate user-generated and dynamic content | Stable | https://developer.chrome.com/docs/ai/translator-api |
+| **Language Detector API** | Detect the language of text | Stable | https://developer.chrome.com/docs/ai/language-detection |
+| **Proofreader API** | Interactive proofreading | Origin trial | https://developer.chrome.com/docs/ai/proofreader-api |
+
+---
+
+## Integration Strategy
+
+The Prompt API is the only Built-in AI API that maps to the general-purpose LLM adapter interface (`LlmAdapter`). The remaining APIs are specialized text-processing utilities that are better exposed as MAST **tools**, allowing an agent (backed by any adapter) to call them during a reasoning loop.
+
+### 1. `BuiltInAIAdapter` — implements `LlmAdapter`
+
+Uses the **Prompt API** to power a full agent loop entirely on-device. This adapter enables a "local-only" mode with no network dependency.
+
+**Scope:**
+- Implement `generate()` using `LanguageModel.create()` and `session.prompt()`
+- Implement `generateStream()` using `session.promptStreaming()`
+- Map MAST `Message[]` history into the Prompt API's `initialPrompts` format
+- Map `system` instruction to a `{ role: "system" }` entry in `initialPrompts`
+- Handle `AbortSignal` via session destroy or by checking signal in the stream loop
+- Tool calling: The Prompt API does **not** natively support structured tool calls. `BuiltInAIAdapter` will always return `toolCalls: []` and ignore any tools passed in the request. This is a known, documented limitation — callers should not register tools with a runner backed by this adapter.
+
+**Constraints:**
+- Browser-only environment (no Node.js support)
+- Availability gated on `typeof LanguageModel !== "undefined"`
+- Model download may be required on first use; expose session `downloadprogress` events
+- Sessions are stateless across page loads; history must be passed via `initialPrompts`
+
+### 2. Built-in AI Tools — MAST `Tool` implementations
+
+Each stable/trial API below maps to one or more MAST tools that any agent can invoke:
+
+| Tool Name | Underlying API | Input | Output |
+|-----------|---------------|-------|--------|
+| `summarize` | Summarizer API | text, optional type/length/format | summary string |
+| `write` | Writer API | task description, optional context/tone/length | generated text |
+| `rewrite` | Rewriter API | text, optional goal/tone/length | rewritten text |
+| `translate` | Translator API | text, source language, target language | translated text |
+| `detectLanguage` | Language Detector API | text | detected language + confidence |
+| `proofread` | Proofreader API | text | corrections/suggestions |
+
+Each tool should:
+- Check for API availability at call time and throw a descriptive `AdapterError` if unavailable
+- Accept the minimal required inputs plus relevant optional parameters
+- Handle `AbortSignal` where the underlying API supports it
+
+---
+
+## Package Structure
+
+```
+packages/built-in-ai/
+├── package.json
+├── tsconfig.json
+└── src/
+    ├── index.ts
+    ├── BuiltInAIAdapter.ts
+    ├── BuiltInAIAdapter.test.ts
+    ├── tools/
+    │   ├── index.ts
+    │   ├── summarize.ts
+    │   ├── write.ts
+    │   ├── rewrite.ts
+    │   ├── translate.ts
+    │   ├── detectLanguage.ts
+    │   └── proofread.ts
+    └── types.ts           ← Built-in AI API type declarations (not yet in lib.dom.d.ts)
+```
+
+### `types.ts`
+
+The Built-in AI APIs are not yet in `lib.dom.d.ts`. This file will declare the bare globals (e.g. `LanguageModel`) and the types for each API (session objects, options, results) so the package compiles under strict TypeScript without `@ts-ignore`.
+
+---
+
+## Package Config
+
+```json
+{
+  "name": "@mast-ai/built-in-ai",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
+    "dev": "tsup src/index.ts --format esm --out-dir dist --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.4"
+  }
+}
+```
+
+No external runtime dependencies — all APIs are accessed via bare globals.
+
+---
+
+## Public API (index.ts exports)
+
+```typescript
+// Adapter
+export { BuiltInAIAdapter } from './BuiltInAIAdapter.js';
+
+// Individual tools (consumers can register whichever they need)
+export { createSummarizeTool } from './tools/summarize.js';
+export { createWriteTool } from './tools/write.js';
+export { createRewriteTool } from './tools/rewrite.js';
+export { createTranslateTool } from './tools/translate.js';
+export { createDetectLanguageTool } from './tools/detectLanguage.js';
+export { createProofreadTool } from './tools/proofread.js';
+
+// Convenience: all tools as an array for bulk registration
+export { createAllBuiltInAITools } from './tools/index.js';
+
+// Types
+export type { BuiltInAIAdapterOptions } from './BuiltInAIAdapter.js';
+```
+
+---
+
+## Phased Delivery
+
+### Phase 1 — Adapter (MVP)
+- `BuiltInAIAdapter` with `generate()` and `generateStream()`
+- Text-only, no tool calling
+- `types.ts` with Prompt API declarations
+- Unit tests with mocked `LanguageModel` global
+
+### Phase 2 — Summarizer Tool
+- `summarize` tool wrapping the Summarizer API
+- Availability guard and tests
+
+### Phase 3 — Translation & Language Detection Tools
+- `translate` and `detectLanguage` tools wrapping the Translator and Language Detector APIs
+- These two APIs are closely related but present different integration challenges from the Summarizer (language pair availability, detection confidence handling)
+- Availability guards and tests
+
+### Phase 4 — Trial Tools
+- `write`, `rewrite`, `proofread` tools (once APIs stabilize)
+- Update `createAllBuiltInAITools` to include them
+
+### Phase 5 — PII Redactor Tool
+A `redactPii` tool that any remote-backed agent can call to sanitize sensitive text on-device before it is processed further. Internally powered by `BuiltInAIAdapter` and `AgentRunner` — the tool spins up a local single-turn agent whose sole job is PII redaction. Raw sensitive data never leaves the browser.
+
+- Accepts a text input and returns the redacted version with PII replaced by typed placeholders (e.g. `[PERSON_NAME]`, `[EMAIL]`, `[PHONE]`, `[ADDRESS]`)
+- System prompt defines PII categories and the replacement format
+- Checks `LanguageModel` availability at call time; throws a descriptive error if unavailable
+- Exposes an optional `onDownloadProgress` callback for the model download case
+- Unit tests with mocked `LanguageModel` global
+
+---
+
+## Open Questions
+
+1. **Testing environment:** Built-in AI APIs only exist in supporting browsers. Unit tests will mock the `LanguageModel` global. Integration/e2e testing requires a browser with the APIs enabled (possibly via Playwright with experimental flags).
+2. **Demo app:** A new `apps/demo-built-in-ai` or a toggle in `apps/demo-basic-chat` to switch to the `BuiltInAIAdapter` when running in a supporting browser would demonstrate the local-only mode effectively.


### PR DESCRIPTION
## Summary

- Adds `BUILT_IN_AI_PLAN.md` — overall plan for the `@mast-ai/built-in-ai` package, covering all seven Browser Built-in AI APIs, integration strategy, package structure, phased delivery (5 phases), and open questions
- Adds `BUILT_IN_AI_PHASE1.md` — detailed implementation plan for Phase 1 (`BuiltInAIAdapter` using the Prompt API), including API mapping, session lifecycle strategy, TypeScript type declarations, package config, and all decisions made during planning

## Key decisions captured

- APIs treated as emerging web standards, not Chrome-specific
- `BuiltInAIAdapter` is text-only; tool calling is an explicit documented limitation
- Session reuse via optimistic history matching (length + last-message spot check)
- System prompt injected as `{ role: "system" }` in `initialPrompts`
- `promptStreaming()` yields deltas (verified by browser test)
- Phased delivery: adapter → Summarizer tool → Translator/Language Detector tools → trial tools → PII redactor tool