### PR TITLE
feat: add @mast-ai/built-in-ai adapter and demo-prompt-api app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Traditional agent frameworks are server-centric, making it difficult for agents 
 This project is an npm workspace containing the core library and several demo applications:
 
 * `packages/core/` — The main MAST TypeScript library (`AgentRunner`, `RunBuilder`, Adapters, Types).
+* `packages/google-genai/` — `LlmAdapter` backed by the Google Generative AI SDK (Gemini models).
+* `packages/built-in-ai/` — `LlmAdapter` backed by the browser's Prompt API for fully on-device inference (no network requests).
 * `apps/demo-basic-chat/` — A Vite-powered frontend demonstrating a Hybrid Mode chat agent with local tools.
+* `apps/demo-prompt-api/` — A Vite-powered frontend demonstrating on-device inference via the browser Prompt API.
 * `apps/demo-rust-server/` — A sample URP reasoning engine backend written in Rust (Axum + async channels).
 
 ## Getting Started
@@ -30,8 +33,9 @@ Clone the repository and install dependencies from the root:
 npm install
 ```
 
-### Running the Demo
-To see MAST in action, start both the Rust URP Server and the basic chat frontend:
+### Running the Demos
+
+**Hybrid Mode** (remote reasoning backend + browser tools):
 
 1. **Start the reasoning backend (Rust):**
    ```bash
@@ -43,6 +47,16 @@ To see MAST in action, start both the Rust URP Server and the basic chat fronten
    cd apps/demo-basic-chat
    npm run dev
    ```
+
+**On-device Mode** (Prompt API — no server required):
+
+Requires Chrome with the built-in AI / Prompt API enabled.
+
+```bash
+cd apps/demo-prompt-api
+npm run dev
+```
+
 Open the provided `localhost` URL in your browser to interact with the agent.
 
 ## Basic Usage

--- a/apps/demo-prompt-api/index.html
+++ b/apps/demo-prompt-api/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAST — Prompt API Demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/demo-prompt-api/package.json
+++ b/apps/demo-prompt-api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "demo-prompt-api",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/built-in-ai": "*",
+    "@mast-ai/core": "*",
+    "marked": "^15.0.0"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/demo-prompt-api/src/main.ts
+++ b/apps/demo-prompt-api/src/main.ts
@@ -1,0 +1,199 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import './style.css';
+import { marked } from 'marked';
+import { VERSION, ToolRegistry, AgentRunner, createAgent, Conversation } from '@mast-ai/core';
+import { BuiltInAIAdapter, checkAvailability } from '@mast-ai/built-in-ai';
+import type { LanguageModelAvailability } from '@mast-ai/built-in-ai';
+
+// --- Setup ---
+const agentConfig = createAgent({
+  name: 'PromptAPIAssistant',
+  instructions: 'You are a helpful assistant running entirely on-device via the browser Prompt API.',
+  tools: [],
+});
+
+// --- UI ---
+document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
+<div class="app-container">
+  <div class="sidebar">
+    <h2>Prompt API Demo <small>v${VERSION}</small></h2>
+
+    <div class="availability-panel">
+      <h3>Model Availability</h3>
+      <div class="availability-row">
+        <span class="availability-badge checking" id="availability-badge">Checking…</span>
+        <button class="refresh-button" id="refresh-button">Refresh</button>
+      </div>
+      <p class="availability-note" id="availability-note"></p>
+    </div>
+
+    <div class="info-panel">
+      <h3>About</h3>
+      Uses the browser's <code>LanguageModel</code> Prompt API to run an
+      on-device model — no network requests. Tool calling is not supported
+      by this adapter.
+    </div>
+  </div>
+
+  <div class="chat-container">
+    <div class="message-list" id="message-list">
+      <div class="message assistant">
+        <div class="bubble">Hello! I'm running on-device via the Prompt API. How can I help?</div>
+      </div>
+    </div>
+
+    <div class="input-area">
+      <div class="status-indicator" id="status-indicator">Idle</div>
+      <div class="input-group">
+        <textarea id="prompt-input" placeholder="Ask something…"></textarea>
+        <button id="send-button" disabled>Send</button>
+        <button id="stop-button" class="stop-button" hidden>Stop</button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+// --- Availability ---
+const availabilityBadge = document.querySelector<HTMLElement>('#availability-badge')!;
+const availabilityNote = document.querySelector<HTMLElement>('#availability-note')!;
+const sendButton = document.querySelector<HTMLButtonElement>('#send-button')!;
+
+const NOTES: Record<string, string> = {
+  readily: 'The model is downloaded and ready.',
+  downloading: 'The model is currently downloading. Please wait.',
+  'after-download': 'The model needs to be downloaded before use.',
+  unavailable: 'On-device AI is not available in this browser.',
+  'no-api': 'The Prompt API (LanguageModel) is not supported in this browser.',
+};
+
+async function refreshAvailability() {
+  availabilityBadge.className = 'availability-badge checking';
+  availabilityBadge.textContent = 'Checking…';
+  availabilityNote.textContent = '';
+  sendButton.disabled = true;
+
+  let status: LanguageModelAvailability | 'no-api';
+  try {
+    status = await checkAvailability();
+  } catch {
+    status = 'no-api';
+  }
+
+  availabilityBadge.className = `availability-badge ${status}`;
+  availabilityBadge.textContent = status;
+  availabilityNote.textContent = NOTES[status] ?? '';
+  sendButton.disabled = status !== 'readily';
+}
+
+document.querySelector('#refresh-button')!.addEventListener('click', refreshAvailability);
+refreshAvailability();
+
+// --- Conversation ---
+function buildConversation(): Conversation {
+  const adapter = new BuiltInAIAdapter();
+  const runner = new AgentRunner(adapter, new ToolRegistry());
+  return runner.conversation(agentConfig);
+}
+
+let conversation = buildConversation();
+
+// --- Chat Logic ---
+const messageList = document.querySelector('#message-list')!;
+const promptInput = document.querySelector<HTMLTextAreaElement>('#prompt-input')!;
+const stopButton = document.querySelector<HTMLButtonElement>('#stop-button')!;
+const statusIndicator = document.querySelector('#status-indicator')!;
+
+let currentController: AbortController | null = null;
+
+function renderMarkdown(text: string): string {
+  return marked.parse(text, { async: false }) as string;
+}
+
+function appendMessage(role: 'user' | 'assistant', content: string): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message ${role}`;
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  if (role === 'assistant') {
+    bubble.innerHTML = renderMarkdown(content);
+  } else {
+    bubble.textContent = content;
+  }
+  msgEl.appendChild(bubble);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return bubble;
+}
+
+function appendError(message: string) {
+  const msgEl = document.createElement('div');
+  msgEl.className = 'message system error';
+  const small = document.createElement('small');
+  small.textContent = message;
+  msgEl.appendChild(small);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+}
+
+async function handleSend() {
+  if (currentController) return;
+
+  const text = promptInput.value.trim();
+  if (!text) return;
+
+  promptInput.value = '';
+  promptInput.disabled = true;
+  sendButton.disabled = true;
+  stopButton.hidden = false;
+  statusIndicator.textContent = 'Running…';
+  statusIndicator.className = 'status-indicator running';
+
+  appendMessage('user', text);
+
+  const controller = new AbortController();
+  currentController = controller;
+
+  let assistantBubble: HTMLElement | null = null;
+  let accumulatedText = '';
+
+  try {
+    const stream = conversation.runStream(text, controller.signal);
+    for await (const event of stream) {
+      if (event.type === 'text_delta') {
+        accumulatedText += event.delta;
+        if (!assistantBubble) assistantBubble = appendMessage('assistant', '');
+        assistantBubble.innerHTML = renderMarkdown(accumulatedText);
+        messageList.scrollTop = messageList.scrollHeight;
+      } else if (event.type === 'done' && !assistantBubble) {
+        appendMessage('assistant', event.output);
+      }
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      console.error(error);
+      appendError(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      // On error, rebuild the conversation so the next turn starts clean.
+      conversation = buildConversation();
+    }
+  } finally {
+    currentController = null;
+    promptInput.disabled = false;
+    sendButton.disabled = false;
+    stopButton.hidden = true;
+    promptInput.focus();
+    statusIndicator.textContent = 'Idle';
+    statusIndicator.className = 'status-indicator';
+  }
+}
+
+sendButton.addEventListener('click', handleSend);
+stopButton.addEventListener('click', () => currentController?.abort());
+promptInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    handleSend();
+  }
+});

--- a/apps/demo-prompt-api/src/style.css
+++ b/apps/demo-prompt-api/src/style.css
@@ -1,0 +1,287 @@
+:root {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  --primary-color: #3b82f6;
+  --bg-color: #f4f4f5;
+  --border-color: #e4e4e7;
+}
+
+body, html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*, *::before, *::after {
+  box-sizing: inherit;
+}
+
+#app {
+  height: 100vh;
+  display: flex;
+}
+
+.app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar {
+  width: 300px;
+  background-color: var(--bg-color);
+  border-right: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.sidebar h2 small {
+  font-size: 0.8rem;
+  color: #71717a;
+  font-weight: normal;
+}
+
+.availability-panel h3 {
+  font-size: 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.availability-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.availability-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex: 1;
+}
+
+.availability-badge.readily     { background: #dcfce7; color: #166534; }
+.availability-badge.downloading { background: #fef9c3; color: #854d0e; }
+.availability-badge.after-download { background: #fef9c3; color: #854d0e; }
+.availability-badge.unavailable { background: #fee2e2; color: #991b1b; }
+.availability-badge.checking    { background: #e4e4e7; color: #52525b; }
+.availability-badge.no-api      { background: #fee2e2; color: #991b1b; }
+
+.refresh-button {
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: normal;
+  background: none;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.refresh-button:hover {
+  background: var(--primary-color);
+  color: white;
+}
+
+.availability-note {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  color: #71717a;
+  line-height: 1.4;
+}
+
+.info-panel {
+  font-size: 0.8rem;
+  color: #71717a;
+  line-height: 1.5;
+}
+
+.info-panel h3 {
+  font-size: 1rem;
+  color: #1a1a1a;
+  margin: 0 0 0.5rem;
+}
+
+.chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+}
+
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+}
+
+.message.assistant {
+  align-self: flex-start;
+}
+
+.message.system {
+  align-self: center;
+  max-width: 90%;
+}
+
+.bubble {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.user .bubble {
+  background-color: var(--primary-color);
+  color: white;
+  border-bottom-right-radius: 0;
+}
+
+.assistant .bubble {
+  background-color: var(--bg-color);
+  color: #1a1a1a;
+  border-bottom-left-radius: 0;
+}
+
+.assistant .bubble > :first-child { margin-top: 0; }
+.assistant .bubble > :last-child  { margin-bottom: 0; }
+
+.assistant .bubble p  { margin: 0.5em 0; }
+.assistant .bubble ul,
+.assistant .bubble ol { margin: 0.5em 0; padding-left: 1.5em; }
+.assistant .bubble li { margin: 0.25em 0; }
+.assistant .bubble h1,
+.assistant .bubble h2,
+.assistant .bubble h3 { margin: 0.75em 0 0.25em; font-size: 1em; font-weight: bold; }
+.assistant .bubble pre {
+  background: #e4e4e7;
+  border-radius: 4px;
+  padding: 0.5em 0.75em;
+  overflow-x: auto;
+  font-size: 0.875em;
+}
+.assistant .bubble code {
+  background: #e4e4e7;
+  border-radius: 3px;
+  padding: 0.1em 0.3em;
+  font-size: 0.875em;
+}
+.assistant .bubble pre code {
+  background: none;
+  padding: 0;
+}
+.assistant .bubble blockquote {
+  border-left: 3px solid #a1a1aa;
+  margin: 0.5em 0;
+  padding-left: 0.75em;
+  color: #52525b;
+}
+
+.system small {
+  color: #71717a;
+  font-family: monospace;
+  background: #f8f8f8;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #e4e4e7;
+}
+
+.system.error small {
+  color: #ef4444;
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.input-area {
+  padding: 1rem 2rem 2rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  color: #71717a;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-indicator.running {
+  color: var(--primary-color);
+  font-weight: bold;
+}
+
+.input-group {
+  display: flex;
+  gap: 1rem;
+}
+
+textarea {
+  flex: 1;
+  resize: none;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 1rem;
+  height: 60px;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+button {
+  padding: 0 1.5rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #2563eb;
+}
+
+button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.stop-button {
+  background-color: #ef4444;
+}
+
+.stop-button:hover {
+  background-color: #dc2626;
+}

--- a/apps/demo-prompt-api/tsconfig.json
+++ b/apps/demo-prompt-api/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/docs/BUILT_IN_AI_PHASE1.md
+++ b/docs/BUILT_IN_AI_PHASE1.md
@@ -161,8 +161,8 @@ interface LanguageModelCreateOptions {
   // systemPrompt exists in the spec but is not used — system prompt is
   // injected as a { role: "system" } entry in initialPrompts instead.
   monitor?: (monitor: EventTarget) => void;
-  temperature?: number;
-  topK?: number;
+  // temperature and topK are only available in the Chrome extension version
+  // of the Prompt API and have been removed from the browser version — omitted.
 }
 
 interface LanguageModelPromptOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,18 @@
         "vite": "^6.0.0"
       }
     },
+    "apps/demo-prompt-api": {
+      "version": "0.0.0",
+      "dependencies": {
+        "@mast-ai/built-in-ai": "*",
+        "@mast-ai/core": "*",
+        "marked": "^15.0.0"
+      },
+      "devDependencies": {
+        "typescript": "~6.0.2",
+        "vite": "^6.0.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -522,6 +534,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mast-ai/built-in-ai": {
+      "resolved": "packages/built-in-ai",
+      "link": true
+    },
     "node_modules/@mast-ai/core": {
       "resolved": "packages/core",
       "link": true
@@ -964,6 +980,10 @@
     },
     "node_modules/demo-basic-chat": {
       "resolved": "apps/demo-basic-chat",
+      "link": true
+    },
+    "node_modules/demo-prompt-api": {
+      "resolved": "apps/demo-prompt-api",
       "link": true
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -1687,6 +1707,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -2540,6 +2572,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "packages/built-in-ai": {
+      "name": "@mast-ai/built-in-ai",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mast-ai/core": "*"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "~6.0.2",
+        "vitest": "^4.1.4"
       }
     },
     "packages/core": {

--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mast-ai/built-in-ai",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
+    "dev": "tsup src/index.ts --format esm --out-dir dist --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/built-in-ai/src/BuiltInAIAdapter.test.ts
+++ b/packages/built-in-ai/src/BuiltInAIAdapter.test.ts
@@ -1,0 +1,257 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BuiltInAIAdapter } from "./BuiltInAIAdapter.js";
+import type { LanguageModelSession } from "./types.js";
+
+function makeSession(overrides: Partial<LanguageModelSession> = {}): LanguageModelSession {
+  return {
+    prompt: vi.fn().mockResolvedValue("response text"),
+    promptStreaming: vi.fn().mockReturnValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue("hello");
+          controller.close();
+        },
+      }),
+    ),
+    contextUsage: 10,
+    contextWindow: 1000,
+    destroy: vi.fn(),
+    addEventListener: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockCreate = vi.fn();
+const mockAvailability = vi.fn();
+
+vi.stubGlobal("LanguageModel", {
+  create: mockCreate,
+  availability: mockAvailability,
+});
+
+describe("BuiltInAIAdapter", () => {
+  let adapter: BuiltInAIAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.mockResolvedValue("readily");
+    mockCreate.mockResolvedValue(makeSession());
+    adapter = new BuiltInAIAdapter();
+  });
+
+  describe("generate", () => {
+    it("returns text response", async () => {
+      const response = await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(response.text).toBe("response text");
+      expect(response.toolCalls).toEqual([]);
+    });
+
+    it("always returns empty toolCalls", async () => {
+      const response = await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [{ name: "myTool", description: "does stuff", parameters: {} }],
+      });
+
+      expect(response.toolCalls).toEqual([]);
+    });
+
+    it("warns when tools are passed", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [{ name: "t", description: "d", parameters: {} }],
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("tool calling is not supported"));
+    });
+
+    it("throws AdapterError when model is unavailable", async () => {
+      mockAvailability.mockResolvedValue("unavailable");
+
+      await expect(
+        adapter.generate({
+          messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+          tools: [],
+        }),
+      ).rejects.toThrow("unavailable on this device");
+    });
+
+    it("throws AdapterError when model is still downloading", async () => {
+      mockAvailability.mockResolvedValue("downloading");
+
+      await expect(
+        adapter.generate({
+          messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+          tools: [],
+        }),
+      ).rejects.toThrow("downloading");
+    });
+
+    it("throws AdapterError when context window is full after session creation", async () => {
+      mockCreate.mockResolvedValue(
+        makeSession({ contextUsage: 1000, contextWindow: 1000 }),
+      );
+
+      await expect(
+        adapter.generate({
+          messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+          tools: [],
+        }),
+      ).rejects.toThrow("context window");
+    });
+
+    it("includes system prompt in initialPrompts", async () => {
+      await adapter.generate({
+        system: "You are terse.",
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      const opts = mockCreate.mock.calls[0][0];
+      expect(opts.initialPrompts[0]).toEqual({ role: "system", content: "You are terse." });
+    });
+
+    it("maps history messages into initialPrompts", async () => {
+      await adapter.generate({
+        messages: [
+          { role: "user", content: { type: "text", text: "Hello" } },
+          { role: "assistant", content: { type: "text", text: "Hi there" } },
+          { role: "user", content: { type: "text", text: "How are you?" } },
+        ],
+        tools: [],
+      });
+
+      const opts = mockCreate.mock.calls[0][0];
+      expect(opts.initialPrompts).toHaveLength(2);
+      expect(opts.initialPrompts[0]).toEqual({ role: "user", content: "Hello" });
+      expect(opts.initialPrompts[1]).toEqual({ role: "assistant", content: "Hi there" });
+    });
+
+    it("calls session.prompt with the last message text", async () => {
+      const session = makeSession();
+      mockCreate.mockResolvedValue(session);
+
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "What time is it?" } }],
+        tools: [],
+      });
+
+      expect(session.prompt).toHaveBeenCalledWith("What time is it?", expect.anything());
+    });
+
+    it("reuses cached session for follow-up turn", async () => {
+      const session = makeSession();
+      mockCreate.mockResolvedValue(session);
+
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+        tools: [],
+      });
+
+      await adapter.generate({
+        messages: [
+          { role: "user", content: { type: "text", text: "Hello" } },
+          { role: "assistant", content: { type: "text", text: "response text" } },
+          { role: "user", content: { type: "text", text: "Follow up" } },
+        ],
+        tools: [],
+      });
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(session.prompt).toHaveBeenCalledTimes(2);
+    });
+
+    it("creates a new session when history diverges", async () => {
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+        tools: [],
+      });
+
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Totally different" } }],
+        tools: [],
+      });
+
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("destroys the old session on cache miss", async () => {
+      const session1 = makeSession();
+      const session2 = makeSession();
+      mockCreate.mockResolvedValueOnce(session1).mockResolvedValueOnce(session2);
+
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "First" } }],
+        tools: [],
+      });
+
+      await adapter.generate({
+        messages: [{ role: "user", content: { type: "text", text: "Different" } }],
+        tools: [],
+      });
+
+      expect(session1.destroy).toHaveBeenCalled();
+    });
+  });
+
+  describe("generateStream", () => {
+    async function collect(
+      request: Parameters<BuiltInAIAdapter["generateStream"]>[0],
+    ) {
+      const chunks: { type: string; delta?: string }[] = [];
+      for await (const chunk of adapter.generateStream(request)) {
+        chunks.push(chunk as never);
+      }
+      return chunks;
+    }
+
+    it("yields text_delta chunks from the stream", async () => {
+      const chunks = await collect({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([{ type: "text_delta", delta: "hello" }]);
+    });
+
+    it("yields multiple chunks", async () => {
+      const session = makeSession({
+        promptStreaming: vi.fn().mockReturnValue(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue("chunk1");
+              controller.enqueue("chunk2");
+              controller.close();
+            },
+          }),
+        ),
+      });
+      mockCreate.mockResolvedValue(session);
+
+      const chunks = await collect({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([
+        { type: "text_delta", delta: "chunk1" },
+        { type: "text_delta", delta: "chunk2" },
+      ]);
+    });
+
+    it("warns when tools are passed", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await collect({
+        messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
+        tools: [{ name: "t", description: "d", parameters: {} }],
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("tool calling is not supported"));
+    });
+  });
+});

--- a/packages/built-in-ai/src/BuiltInAIAdapter.ts
+++ b/packages/built-in-ai/src/BuiltInAIAdapter.ts
@@ -1,0 +1,182 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AdapterError } from "@mast-ai/core";
+import type {
+  LlmAdapter,
+  AdapterRequest,
+  AdapterResponse,
+  AdapterStreamChunk,
+  Message,
+} from "@mast-ai/core";
+import type { LanguageModelSession, LanguageModelMessage } from "./types.js";
+
+export interface BuiltInAIAdapterOptions {
+  onDownloadProgress?: (progress: { loaded: number; total: number }) => void;
+}
+
+/**
+ * LlmAdapter backed by the browser's Prompt API (on-device model).
+ *
+ * Limitation: tool calling is not supported. The Prompt API has no native
+ * mechanism for structured tool invocation — `toolCalls` will always be `[]`.
+ */
+export class BuiltInAIAdapter implements LlmAdapter {
+  private readonly options: BuiltInAIAdapterOptions;
+  private cachedSession: LanguageModelSession | null = null;
+  private cachedHistory: Message[] = [];
+
+  constructor(options: BuiltInAIAdapterOptions = {}) {
+    this.options = options;
+  }
+
+  async generate(request: AdapterRequest): Promise<AdapterResponse> {
+    if (request.tools.length > 0) {
+      console.warn(
+        "BuiltInAIAdapter: tool calling is not supported — tools will never be invoked.",
+      );
+    }
+
+    const { session, lastMessage } = await this.acquireSession(request);
+    try {
+      const input = messageToString(lastMessage);
+      const text = await session.prompt(input, { signal: request.signal });
+      this.cachedHistory = [
+        ...request.messages,
+        { role: "assistant", content: { type: "text", text } },
+      ];
+      return { text, toolCalls: [] };
+    } catch (err) {
+      this.invalidateCache();
+      throw err;
+    }
+  }
+
+  async *generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk> {
+    if (request.tools.length > 0) {
+      console.warn(
+        "BuiltInAIAdapter: tool calling is not supported — tools will never be invoked.",
+      );
+    }
+
+    const { session, lastMessage } = await this.acquireSession(request);
+    try {
+      const input = messageToString(lastMessage);
+      const stream = session.promptStreaming(input, { signal: request.signal });
+      const reader = stream.getReader();
+      let fullText = "";
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          fullText += value;
+          yield { type: "text_delta", delta: value };
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      this.cachedHistory = [
+        ...request.messages,
+        { role: "assistant", content: { type: "text", text: fullText } },
+      ];
+    } catch (err) {
+      this.invalidateCache();
+      throw err;
+    }
+  }
+
+  private async acquireSession(
+    request: AdapterRequest,
+  ): Promise<{ session: LanguageModelSession; lastMessage: Message }> {
+    if (request.messages.length === 0) {
+      throw new AdapterError("Request must contain at least one message.");
+    }
+
+    const lastMessage = request.messages[request.messages.length - 1];
+    const history = request.messages.slice(0, -1);
+
+    if (this.isCacheHit(history)) {
+      return { session: this.cachedSession!, lastMessage };
+    }
+
+    this.invalidateCache();
+
+    const availability = await LanguageModel.availability();
+    if (availability === "unavailable") {
+      throw new AdapterError("Built-in AI model is unavailable on this device.");
+    }
+    if (availability === "after-download" || availability === "downloading") {
+      throw new AdapterError(
+        `Built-in AI model is not ready (status: "${availability}"). Wait for the model to finish downloading.`,
+      );
+    }
+
+    const initialPrompts = buildInitialPrompts(request.system, history);
+    const session = await LanguageModel.create({
+      signal: request.signal,
+      initialPrompts,
+      monitor: this.options.onDownloadProgress
+        ? (m) => {
+            m.addEventListener("downloadprogress", (e) => {
+              const evt = e as ProgressEvent;
+              this.options.onDownloadProgress!({ loaded: evt.loaded, total: evt.total });
+            });
+          }
+        : undefined,
+    });
+
+    if (session.contextUsage >= session.contextWindow) {
+      session.destroy();
+      throw new AdapterError(
+        "Conversation history exceeds the model's context window.",
+      );
+    }
+
+    this.cachedSession = session;
+    this.cachedHistory = history;
+    return { session, lastMessage };
+  }
+
+  private isCacheHit(history: Message[]): boolean {
+    if (!this.cachedSession) return false;
+    // cachedHistory = all prior messages + last assistant response.
+    // history = all messages except the new user turn = cachedHistory when cache is warm.
+    if (history.length !== this.cachedHistory.length) return false;
+    if (history.length === 0) return true;
+    const last = history[history.length - 1];
+    const cachedLast = this.cachedHistory[this.cachedHistory.length - 1];
+    return JSON.stringify(last) === JSON.stringify(cachedLast);
+  }
+
+  private invalidateCache(): void {
+    this.cachedSession?.destroy();
+    this.cachedSession = null;
+    this.cachedHistory = [];
+  }
+}
+
+function buildInitialPrompts(
+  system: string | undefined,
+  history: Message[],
+): LanguageModelMessage[] {
+  const prompts: LanguageModelMessage[] = [];
+  if (system) {
+    prompts.push({ role: "system", content: system });
+  }
+  for (const msg of history) {
+    prompts.push({ role: msg.role, content: messageToString(msg) });
+  }
+  return prompts;
+}
+
+function messageToString(message: Message): string {
+  if (message.content.type === "text") {
+    return message.content.text;
+  }
+  // tool_calls and tool_result have no text representation for the Prompt API
+  return "";
+}
+
+export async function checkAvailability() {
+  return LanguageModel.availability();
+}

--- a/packages/built-in-ai/src/index.ts
+++ b/packages/built-in-ai/src/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export { BuiltInAIAdapter, checkAvailability } from './BuiltInAIAdapter.js';
+export type { BuiltInAIAdapterOptions } from './BuiltInAIAdapter.js';
+export type { LanguageModelAvailability } from './types.js';

--- a/packages/built-in-ai/src/types.ts
+++ b/packages/built-in-ai/src/types.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export type LanguageModelAvailability =
+  | "readily"
+  | "after-download"
+  | "downloading"
+  | "unavailable";
+
+export interface LanguageModelMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+export interface LanguageModelCreateOptions {
+  signal?: AbortSignal;
+  initialPrompts?: LanguageModelMessage[];
+  // systemPrompt exists in the spec but is not used — system prompt is
+  // injected as a { role: "system" } entry in initialPrompts instead.
+  monitor?: (monitor: EventTarget) => void;
+  // temperature and topK are only available in the Chrome extension version
+  // of the Prompt API and have been removed from the browser version — omitted.
+}
+
+export interface LanguageModelPromptOptions {
+  signal?: AbortSignal;
+}
+
+export interface LanguageModelSession {
+  prompt(input: string, options?: LanguageModelPromptOptions): Promise<string>;
+  promptStreaming(input: string, options?: LanguageModelPromptOptions): ReadableStream<string>;
+  contextUsage: number;
+  contextWindow: number;
+  destroy(): void;
+  addEventListener(type: "contextoverflow", listener: EventListener): void;
+}
+
+declare global {
+  const LanguageModel: {
+    availability(options?: Partial<LanguageModelCreateOptions>): Promise<LanguageModelAvailability>;
+    create(options?: LanguageModelCreateOptions): Promise<LanguageModelSession>;
+  };
+}

--- a/packages/built-in-ai/tsconfig.json
+++ b/packages/built-in-ai/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Implements `BuiltInAIAdapter` in the new `@mast-ai/built-in-ai` package, exposing the browser's Prompt API (`LanguageModel` global) through the standard `LlmAdapter` interface
- Session caching with O(1) history-match keeps multi-turn conversations efficient; cache is invalidated on divergence
- Exports `checkAvailability()` helper and `LanguageModelAvailability` type
- Adds `apps/demo-prompt-api`: a Vite chat app with live availability badge, streaming responses, and Markdown rendering via `marked`
- Updates README to document the new package, demo app, and on-device running instructions

## Notable limitations (documented)

- Tool calling is not supported — the Prompt API has no structured invocation mechanism; a runtime warning is emitted if tools are passed
- `temperature` and `topK` are omitted — they exist only in the Chrome extension version of the API, not the browser version

## Test plan

- [x] Run `npm test --workspace=@mast-ai/built-in-ai` — all 15 tests should pass
- [x] Open `apps/demo-prompt-api` in Chrome with the Prompt API enabled and verify the availability badge shows "readily"
- [x] Send a message and confirm streaming response renders correctly with Markdown
- [x] Verify the Send button is disabled when the model is unavailable