### PR TITLE
feat: Built-in AI Phase 2 — SummarizeTool

### DIFF
--- a/apps/demo-basic-chat/index.html
+++ b/apps/demo-basic-chat/index.html
@@ -5,9 +5,41 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MAST Demo</title>
+    <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>
-    <div id="app"></div>
+    <div class="app-container">
+      <div class="sidebar">
+        <h2>MAST Demo <small id="version"></small></h2>
+
+        <div class="config-panel">
+          <label>Remote Endpoint URL</label>
+          <input type="text" id="endpoint-url" value="http://127.0.0.1:3000/api/chat" />
+        </div>
+
+        <div class="tools-panel">
+          <h3>Available Tools</h3>
+          <ul id="tools-list"></ul>
+        </div>
+      </div>
+
+      <div class="chat-container">
+        <div class="message-list" id="message-list">
+          <div class="message assistant">
+            <div class="bubble">Hello! I'm ready to help. I can check the time and do math.</div>
+          </div>
+        </div>
+
+        <div class="input-area">
+          <div class="status-indicator" id="status-indicator">Idle</div>
+          <div class="input-group">
+            <textarea id="prompt-input" placeholder="Ask something (e.g., 'What time is it?' or 'What is 54 * 23?')"></textarea>
+            <button id="send-button">Send</button>
+            <button id="stop-button" class="stop-button" hidden>Stop</button>
+          </div>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/apps/demo-basic-chat/src/main.ts
+++ b/apps/demo-basic-chat/src/main.ts
@@ -1,7 +1,6 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import './style.css'
 import {
   VERSION,
   ToolRegistry,
@@ -25,44 +24,15 @@ const agentConfig = createAgent({
   tools: ['getCurrentTime', 'calculate']
 });
 
-
-// --- UI Framework ---
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-<div class="app-container">
-  <div class="sidebar">
-    <h2>MAST Demo <small>v${VERSION}</small></h2>
-
-    <div class="config-panel">
-      <label>Remote Endpoint URL</label>
-      <input type="text" id="endpoint-url" value="http://127.0.0.1:3000/api/chat" />
-    </div>
-
-    <div class="tools-panel">
-      <h3>Available Tools</h3>
-      <ul>
-        ${registry.definitions().map(d => `<li><code>${d.name}</code></li>`).join('')}
-      </ul>
-    </div>
-  </div>
-
-  <div class="chat-container">
-    <div class="message-list" id="message-list">
-      <div class="message assistant">
-        <div class="bubble">Hello! I'm ready to help. I can check the time and do math.</div>
-      </div>
-    </div>
-
-    <div class="input-area">
-      <div class="status-indicator" id="status-indicator">Idle</div>
-      <div class="input-group">
-        <textarea id="prompt-input" placeholder="Ask something (e.g., 'What time is it?' or 'What is 54 * 23?')"></textarea>
-        <button id="send-button">Send</button>
-        <button id="stop-button" class="stop-button" hidden>Stop</button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
+const toolsList = document.querySelector<HTMLUListElement>('#tools-list')!;
+for (const { name } of registry.definitions()) {
+  const li = document.createElement('li');
+  const code = document.createElement('code');
+  code.textContent = name;
+  li.appendChild(code);
+  toolsList.appendChild(li);
+}
 
 // --- Chat Logic ---
 const messageList = document.querySelector('#message-list')!;

--- a/apps/demo-prompt-api/index.html
+++ b/apps/demo-prompt-api/index.html
@@ -5,9 +5,47 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MAST — Prompt API Demo</title>
+    <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>
-    <div id="app"></div>
+    <div class="app-container">
+      <div class="sidebar">
+        <h2>Prompt API Demo <small id="version"></small></h2>
+
+        <div class="availability-panel">
+          <h3>Model Availability</h3>
+          <div class="availability-row">
+            <span class="availability-badge checking" id="availability-badge">Checking…</span>
+            <button class="refresh-button" id="refresh-button">Refresh</button>
+          </div>
+          <p class="availability-note" id="availability-note"></p>
+        </div>
+
+        <div class="info-panel">
+          <h3>About</h3>
+          Uses the browser's <code>LanguageModel</code> Prompt API to run an
+          on-device model — no network requests. Tool calling is not supported
+          by this adapter.
+        </div>
+      </div>
+
+      <div class="chat-container">
+        <div class="message-list" id="message-list">
+          <div class="message assistant">
+            <div class="bubble">Hello! I'm running on-device via the Prompt API. How can I help?</div>
+          </div>
+        </div>
+
+        <div class="input-area">
+          <div class="status-indicator" id="status-indicator">Idle</div>
+          <div class="input-group">
+            <textarea id="prompt-input" placeholder="Ask something…"></textarea>
+            <button id="send-button" disabled>Send</button>
+            <button id="stop-button" class="stop-button" hidden>Stop</button>
+          </div>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/apps/demo-prompt-api/src/main.ts
+++ b/apps/demo-prompt-api/src/main.ts
@@ -1,11 +1,12 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import './style.css';
 import { marked } from 'marked';
 import { VERSION, ToolRegistry, AgentRunner, createAgent, Conversation } from '@mast-ai/core';
 import { BuiltInAIAdapter, checkAvailability } from '@mast-ai/built-in-ai';
 import type { LanguageModelAvailability } from '@mast-ai/built-in-ai';
+
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
 
 // --- Setup ---
 const agentConfig = createAgent({
@@ -13,48 +14,6 @@ const agentConfig = createAgent({
   instructions: 'You are a helpful assistant running entirely on-device via the browser Prompt API.',
   tools: [],
 });
-
-// --- UI ---
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-<div class="app-container">
-  <div class="sidebar">
-    <h2>Prompt API Demo <small>v${VERSION}</small></h2>
-
-    <div class="availability-panel">
-      <h3>Model Availability</h3>
-      <div class="availability-row">
-        <span class="availability-badge checking" id="availability-badge">Checking…</span>
-        <button class="refresh-button" id="refresh-button">Refresh</button>
-      </div>
-      <p class="availability-note" id="availability-note"></p>
-    </div>
-
-    <div class="info-panel">
-      <h3>About</h3>
-      Uses the browser's <code>LanguageModel</code> Prompt API to run an
-      on-device model — no network requests. Tool calling is not supported
-      by this adapter.
-    </div>
-  </div>
-
-  <div class="chat-container">
-    <div class="message-list" id="message-list">
-      <div class="message assistant">
-        <div class="bubble">Hello! I'm running on-device via the Prompt API. How can I help?</div>
-      </div>
-    </div>
-
-    <div class="input-area">
-      <div class="status-indicator" id="status-indicator">Idle</div>
-      <div class="input-group">
-        <textarea id="prompt-input" placeholder="Ask something…"></textarea>
-        <button id="send-button" disabled>Send</button>
-        <button id="stop-button" class="stop-button" hidden>Stop</button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
 
 // --- Availability ---
 const availabilityBadge = document.querySelector<HTMLElement>('#availability-badge')!;

--- a/apps/demo-summarizer/index.html
+++ b/apps/demo-summarizer/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAST — Summarizer API Demo</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <div class="sidebar">
+        <h2>Summarizer Demo <small id="version"></small></h2>
+
+        <div class="availability-panel">
+          <h3>Model Availability</h3>
+          <div class="availability-row">
+            <span class="availability-badge checking" id="availability-badge">Checking…</span>
+            <button class="refresh-button" id="refresh-button">Refresh</button>
+          </div>
+          <p class="availability-note" id="availability-note"></p>
+        </div>
+
+        <div class="options-panel">
+          <h3>Summary Options</h3>
+
+          <label>Type
+            <select id="opt-type">
+              <option value="">default (key-points)</option>
+              <option value="key-points">key-points</option>
+              <option value="tldr">tldr</option>
+              <option value="teaser">teaser</option>
+              <option value="headline">headline</option>
+            </select>
+          </label>
+
+          <label>Format
+            <select id="opt-format">
+              <option value="">default (plain-text)</option>
+              <option value="plain-text">plain-text</option>
+              <option value="markdown">markdown</option>
+            </select>
+          </label>
+
+          <label>Length
+            <select id="opt-length">
+              <option value="">default (medium)</option>
+              <option value="short">short</option>
+              <option value="medium">medium</option>
+              <option value="long">long</option>
+            </select>
+          </label>
+
+          <label>Context hint
+            <input type="text" id="opt-context" placeholder="e.g. scientific paper" />
+          </label>
+        </div>
+
+        <div class="info-panel">
+          <h3>About</h3>
+          Uses the browser's <code>Summarizer</code> API to condense text
+          on-device — no network requests.
+        </div>
+      </div>
+
+      <div class="main-container">
+        <div class="panes">
+          <div class="pane">
+            <label class="pane-label">Input text</label>
+            <textarea id="input-text" placeholder="Paste or type the text to summarize…"></textarea>
+          </div>
+          <div class="pane output-pane">
+            <label class="pane-label">Summary</label>
+            <div class="output-box" id="output-box">
+              <span class="placeholder">The summary will appear here.</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="action-bar">
+          <div class="status-indicator" id="status-indicator">Idle</div>
+          <div class="action-buttons">
+            <button id="summarize-button" disabled>Summarize</button>
+            <button id="stop-button" class="stop-button" hidden>Stop</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/demo-summarizer/package.json
+++ b/apps/demo-summarizer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demo-summarizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/built-in-ai": "*",
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/demo-summarizer/src/main.ts
+++ b/apps/demo-summarizer/src/main.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { VERSION, ToolRegistry } from '@mast-ai/core';
+import { SummarizeTool } from '@mast-ai/built-in-ai';
+import type { SummarizeArgs } from '@mast-ai/built-in-ai';
+
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
+
+// --- Elements ---
+const availabilityBadge = document.querySelector<HTMLElement>('#availability-badge')!;
+const availabilityNote = document.querySelector<HTMLElement>('#availability-note')!;
+const summarizeButton = document.querySelector<HTMLButtonElement>('#summarize-button')!;
+const stopButton = document.querySelector<HTMLButtonElement>('#stop-button')!;
+const inputText = document.querySelector<HTMLTextAreaElement>('#input-text')!;
+const outputBox = document.querySelector<HTMLElement>('#output-box')!;
+const statusIndicator = document.querySelector<HTMLElement>('#status-indicator')!;
+const optType = document.querySelector<HTMLSelectElement>('#opt-type')!;
+const optFormat = document.querySelector<HTMLSelectElement>('#opt-format')!;
+const optLength = document.querySelector<HTMLSelectElement>('#opt-length')!;
+const optContext = document.querySelector<HTMLInputElement>('#opt-context')!;
+
+// --- Availability + Registration ---
+const registry = new ToolRegistry();
+let registered = false;
+
+function onReady() {
+  registered = true;
+  availabilityBadge.className = 'availability-badge readily';
+  availabilityBadge.textContent = 'ready';
+  availabilityNote.textContent = 'The model is downloaded and ready.';
+  summarizeButton.disabled = false;
+}
+
+function onUnavailable(err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  const key = msg.includes('not supported') ? 'no-api' : 'unavailable';
+  const notes: Record<string, string> = {
+    unavailable: 'Summarizer API is not available on this device.',
+    'no-api': 'The Summarizer API is not supported in this browser.',
+  };
+  availabilityBadge.className = `availability-badge ${key}`;
+  availabilityBadge.textContent = key;
+  availabilityNote.textContent = notes[key] ?? '';
+}
+
+async function startRegistration() {
+  if (registered) return;
+
+  availabilityBadge.className = 'availability-badge checking';
+  availabilityBadge.textContent = 'Checking…';
+  availabilityNote.textContent = '';
+  summarizeButton.disabled = true;
+
+  try {
+    // addToRegistry resolves once availability is confirmed. The tool is added
+    // to the registry in the background (after any model download completes).
+    await SummarizeTool.addToRegistry(registry, {
+      onDownloadProgress: ({ loaded, total }: { loaded: number; total: number }) => {
+        const pct = total > 0 ? Math.round((loaded / total) * 100) : 0;
+        availabilityBadge.className = 'availability-badge downloading';
+        availabilityBadge.textContent = `Downloading ${pct}%`;
+        availabilityNote.textContent = `${loaded.toLocaleString()} / ${total.toLocaleString()} bytes`;
+      },
+    });
+    // API is available — show downloading state while background session is created.
+    availabilityBadge.className = 'availability-badge downloading';
+    availabilityBadge.textContent = 'Loading…';
+    availabilityNote.textContent = 'Preparing the on-device model…';
+    // Poll until the tool appears in the registry (background registration complete).
+    await waitForTool();
+    onReady();
+  } catch (err) {
+    onUnavailable(err);
+  }
+}
+
+function waitForTool(): Promise<void> {
+  return new Promise((resolve) => {
+    function check() {
+      if (registry.get('summarize')) {
+        resolve();
+      } else {
+        setTimeout(check, 50);
+      }
+    }
+    check();
+  });
+}
+
+document.querySelector('#refresh-button')!.addEventListener('click', startRegistration);
+startRegistration();
+
+// --- Summarize ---
+let currentController: AbortController | null = null;
+
+function setOutput(text: string, isError = false) {
+  outputBox.innerHTML = '';
+  outputBox.className = isError ? 'output-box error' : 'output-box';
+  outputBox.textContent = text;
+}
+
+async function handleSummarize() {
+  if (currentController) return;
+  const text = inputText.value.trim();
+  if (!text) return;
+
+  const tool = registry.get('summarize');
+  if (!tool) return;
+
+  const args: SummarizeArgs = {
+    text,
+    type: (optType.value || undefined) as SummarizeArgs['type'],
+    format: (optFormat.value || undefined) as SummarizeArgs['format'],
+    length: (optLength.value || undefined) as SummarizeArgs['length'],
+    context: optContext.value.trim() || undefined,
+  };
+
+  const controller = new AbortController();
+  currentController = controller;
+
+  summarizeButton.disabled = true;
+  stopButton.hidden = false;
+  statusIndicator.textContent = 'Summarizing…';
+  statusIndicator.className = 'status-indicator running';
+  outputBox.innerHTML = '<span class="placeholder">Working…</span>';
+  outputBox.className = 'output-box';
+
+  try {
+    const result = await tool.call(args, { signal: controller.signal }) as string;
+    setOutput(result);
+  } catch (err) {
+    if (!controller.signal.aborted) {
+      setOutput(err instanceof Error ? err.message : String(err), true);
+    }
+  } finally {
+    currentController = null;
+    summarizeButton.disabled = false;
+    stopButton.hidden = true;
+    statusIndicator.textContent = 'Idle';
+    statusIndicator.className = 'status-indicator';
+  }
+}
+
+summarizeButton.addEventListener('click', handleSummarize);
+stopButton.addEventListener('click', () => currentController?.abort());

--- a/apps/demo-summarizer/src/style.css
+++ b/apps/demo-summarizer/src/style.css
@@ -1,0 +1,289 @@
+:root {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  --primary-color: #3b82f6;
+  --bg-color: #f4f4f5;
+  --border-color: #e4e4e7;
+}
+
+body, html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*, *::before, *::after {
+  box-sizing: inherit;
+}
+
+#app {
+  height: 100vh;
+  display: flex;
+}
+
+.app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+/* ---- Sidebar ---- */
+
+.sidebar {
+  width: 280px;
+  background-color: var(--bg-color);
+  border-right: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sidebar h2 small {
+  font-size: 0.8rem;
+  color: #71717a;
+  font-weight: normal;
+}
+
+.sidebar h3 {
+  font-size: 0.95rem;
+  margin: 0 0 0.75rem;
+}
+
+/* Availability */
+
+.availability-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.availability-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex: 1;
+}
+
+.availability-badge.readily     { background: #dcfce7; color: #166534; }
+.availability-badge.downloading { background: #fef9c3; color: #854d0e; }
+.availability-badge.unavailable { background: #fee2e2; color: #991b1b; }
+.availability-badge.checking    { background: #e4e4e7; color: #52525b; }
+.availability-badge.no-api      { background: #fee2e2; color: #991b1b; }
+
+.refresh-button {
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: normal;
+  background: none;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.refresh-button:hover {
+  background: var(--primary-color);
+  color: white;
+}
+
+.availability-note {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #71717a;
+  line-height: 1.4;
+}
+
+/* Options */
+
+.options-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.options-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #3f3f46;
+}
+
+.options-panel select,
+.options-panel input[type="text"] {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: #fff;
+}
+
+.options-panel select:focus,
+.options-panel input[type="text"]:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* Info */
+
+.info-panel {
+  font-size: 0.8rem;
+  color: #71717a;
+  line-height: 1.5;
+  margin-top: auto;
+}
+
+.info-panel h3 {
+  color: #1a1a1a;
+}
+
+/* ---- Main area ---- */
+
+.main-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.panes {
+  flex: 1;
+  display: flex;
+  gap: 0;
+  min-height: 0;
+}
+
+.pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  min-width: 0;
+}
+
+.pane + .pane {
+  border-left: 1px solid var(--border-color);
+}
+
+.pane-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #71717a;
+  margin-bottom: 0.5rem;
+}
+
+textarea {
+  flex: 1;
+  resize: none;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.output-box {
+  flex: 1;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-color);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+.output-box.error {
+  color: #ef4444;
+  background: #fef2f2;
+  border-color: #fca5a5;
+}
+
+.output-box .placeholder {
+  color: #a1a1aa;
+  font-style: italic;
+}
+
+/* ---- Action bar ---- */
+
+.action-bar {
+  padding: 1rem 1.5rem 1.5rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  color: #71717a;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex: 1;
+}
+
+.status-indicator.running {
+  color: var(--primary-color);
+  font-weight: bold;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button {
+  padding: 0.6rem 1.5rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #2563eb;
+}
+
+button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.stop-button {
+  background-color: #ef4444;
+}
+
+.stop-button:hover {
+  background-color: #dc2626;
+}

--- a/apps/demo-summarizer/tsconfig.json
+++ b/apps/demo-summarizer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,17 @@
         "vite": "^6.0.0"
       }
     },
+    "apps/demo-summarizer": {
+      "version": "0.0.0",
+      "dependencies": {
+        "@mast-ai/built-in-ai": "*",
+        "@mast-ai/core": "*"
+      },
+      "devDependencies": {
+        "typescript": "~6.0.2",
+        "vite": "^6.0.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -984,6 +995,10 @@
     },
     "node_modules/demo-prompt-api": {
       "resolved": "apps/demo-prompt-api",
+      "link": true
+    },
+    "node_modules/demo-summarizer": {
+      "resolved": "apps/demo-summarizer",
       "link": true
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/packages/built-in-ai/src/index.ts
+++ b/packages/built-in-ai/src/index.ts
@@ -4,3 +4,8 @@
 export { BuiltInAIAdapter, checkAvailability } from './BuiltInAIAdapter.js';
 export type { BuiltInAIAdapterOptions } from './BuiltInAIAdapter.js';
 export type { LanguageModelAvailability } from './types.js';
+
+export { SummarizeTool } from './tools/summarize.js';
+export type { SummarizeToolOptions, SummarizeArgs } from './tools/summarize.js';
+export { addAllBuiltInAITools } from './tools/index.js';
+export type { AddAllBuiltInAIToolsOptions } from './tools/index.js';

--- a/packages/built-in-ai/src/tools/index.ts
+++ b/packages/built-in-ai/src/tools/index.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { SummarizeTool } from "./summarize.js";
+import type { ToolRegistry } from "@mast-ai/core";
+
+export interface AddAllBuiltInAIToolsOptions {
+  onDownloadProgress?: (tool: string, progress: { loaded: number; total: number }) => void;
+}
+
+export async function addAllBuiltInAITools(
+  registry: ToolRegistry,
+  options?: AddAllBuiltInAIToolsOptions,
+): Promise<void> {
+  await Promise.allSettled([
+    SummarizeTool.addToRegistry(registry, {
+      onDownloadProgress: options?.onDownloadProgress
+        ? (p) => options.onDownloadProgress!("summarize", p)
+        : undefined,
+    }),
+  ]);
+}

--- a/packages/built-in-ai/src/tools/summarize.test.ts
+++ b/packages/built-in-ai/src/tools/summarize.test.ts
@@ -1,0 +1,194 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SummarizeTool } from "./summarize.js";
+import { ToolRegistry } from "@mast-ai/core";
+import type { SummarizerSession } from "../types.js";
+
+function makeSession(overrides: Partial<SummarizerSession> = {}): SummarizerSession {
+  return {
+    summarize: vi.fn().mockResolvedValue("summary text"),
+    summarizeStreaming: vi.fn(),
+    destroy: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Drain all pending microtasks so the background registration completes.
+const flush = () => Promise.resolve();
+
+const mockCreate = vi.fn();
+const mockAvailability = vi.fn();
+
+vi.stubGlobal("Summarizer", {
+  create: mockCreate,
+  availability: mockAvailability,
+});
+
+describe("SummarizeTool", () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.mockResolvedValue("readily");
+    mockCreate.mockResolvedValue(makeSession());
+    registry = new ToolRegistry();
+  });
+
+  describe("addToRegistry", () => {
+    it("rejects with AdapterError when Summarizer global is absent", async () => {
+      vi.stubGlobal("Summarizer", undefined);
+
+      await expect(SummarizeTool.addToRegistry(registry)).rejects.toThrow(
+        "not supported in this browser",
+      );
+      expect(registry.definitions()).toHaveLength(0);
+
+      vi.stubGlobal("Summarizer", { create: mockCreate, availability: mockAvailability });
+    });
+
+    it("resolves and registers tool in background when readily available", async () => {
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+
+      expect(mockCreate).toHaveBeenCalled();
+      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.definitions()[0].name).toBe("summarize");
+    });
+
+    it("resolves and registers tool in background when after-download", async () => {
+      mockAvailability.mockResolvedValue("after-download");
+      const onDownloadProgress = vi.fn();
+
+      await SummarizeTool.addToRegistry(registry, { onDownloadProgress });
+      await flush();
+
+      const createOpts = mockCreate.mock.calls[0][0];
+      expect(typeof createOpts.monitor).toBe("function");
+      expect(registry.definitions()).toHaveLength(1);
+    });
+
+    it("resolves and registers tool in background when downloading", async () => {
+      mockAvailability.mockResolvedValue("downloading");
+
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+
+      expect(mockCreate).toHaveBeenCalled();
+      expect(registry.definitions()).toHaveLength(1);
+    });
+
+    it("rejects with AdapterError when unavailable", async () => {
+      mockAvailability.mockResolvedValue("unavailable");
+
+      await expect(SummarizeTool.addToRegistry(registry)).rejects.toThrow(
+        "unavailable on this device",
+      );
+      expect(registry.definitions()).toHaveLength(0);
+    });
+
+    it("fires onDownloadProgress callback when downloadprogress event fires", async () => {
+      mockAvailability.mockResolvedValue("after-download");
+
+      let capturedMonitor: EventTarget | null = null;
+      mockCreate.mockImplementation(async (opts: { monitor?: (m: EventTarget) => void }) => {
+        if (opts?.monitor) {
+          const et = new EventTarget();
+          opts.monitor(et);
+          capturedMonitor = et;
+        }
+        return makeSession();
+      });
+
+      const onDownloadProgress = vi.fn();
+      await SummarizeTool.addToRegistry(registry, { onDownloadProgress });
+
+      // Summarizer.create() was called synchronously before addToRegistry resolved,
+      // so capturedMonitor is already set — no flush needed here.
+      const evt = Object.assign(new Event("downloadprogress"), { loaded: 50, total: 100 });
+      capturedMonitor!.dispatchEvent(evt);
+
+      expect(onDownloadProgress).toHaveBeenCalledWith({ loaded: 50, total: 100 });
+    });
+  });
+
+  describe("call()", () => {
+    it("rejects with AdapterError when Summarizer global is absent", async () => {
+      vi.stubGlobal("Summarizer", undefined);
+
+      const tool = new SummarizeTool();
+      await expect(tool.call({ text: "hello" }, {})).rejects.toThrow(
+        "not supported in this browser",
+      );
+
+      vi.stubGlobal("Summarizer", { create: mockCreate, availability: mockAvailability });
+    });
+
+    it("resolves with the summary string", async () => {
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("summarize")!;
+
+      const result = await tool.call({ text: "long text" }, {});
+      expect(result).toBe("summary text");
+    });
+
+    it("reuses the cached instance when options match", async () => {
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("summarize")!;
+
+      await tool.call({ text: "first" }, {});
+      await tool.call({ text: "second" }, {});
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("destroys old instance and creates new one when options differ", async () => {
+      const session1 = makeSession();
+      const session2 = makeSession();
+      mockCreate.mockResolvedValueOnce(session1).mockResolvedValueOnce(session2);
+
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("summarize")!;
+
+      await tool.call({ text: "first" }, {});
+      await tool.call({ text: "second", type: "tldr" }, {});
+
+      expect(session1.destroy).toHaveBeenCalled();
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("forwards context.signal to summarize()", async () => {
+      const session = makeSession();
+      mockCreate.mockResolvedValue(session);
+
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("summarize")!;
+
+      const controller = new AbortController();
+      await tool.call({ text: "text" }, { signal: controller.signal });
+
+      expect(session.summarize).toHaveBeenCalledWith(
+        "text",
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it("propagates error thrown by summarize()", async () => {
+      const session = makeSession({
+        summarize: vi.fn().mockRejectedValue(new Error("summarize failed")),
+      });
+      mockCreate.mockResolvedValue(session);
+
+      await SummarizeTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("summarize")!;
+
+      await expect(tool.call({ text: "text" }, {})).rejects.toThrow("summarize failed");
+    });
+  });
+});

--- a/packages/built-in-ai/src/tools/summarize.ts
+++ b/packages/built-in-ai/src/tools/summarize.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AdapterError } from "@mast-ai/core";
+import type { Tool, ToolDefinition, ToolContext, ToolRegistry } from "@mast-ai/core";
+import type {
+  SummarizerSession,
+  SummarizerType,
+  SummarizerFormat,
+  SummarizerLength,
+} from "../types.js";
+
+export interface SummarizeArgs {
+  text: string;
+  type?: SummarizerType;
+  format?: SummarizerFormat;
+  length?: SummarizerLength;
+  context?: string;
+}
+
+export interface SummarizeToolOptions {
+  onDownloadProgress?: (progress: { loaded: number; total: number }) => void;
+}
+
+interface CachedInstance {
+  session: SummarizerSession;
+  type: SummarizerType | undefined;
+  format: SummarizerFormat | undefined;
+  length: SummarizerLength | undefined;
+}
+
+export class SummarizeTool implements Tool<SummarizeArgs, string> {
+  private cached: CachedInstance | null = null;
+
+  static async addToRegistry(
+    registry: ToolRegistry,
+    options?: SummarizeToolOptions,
+  ): Promise<void> {
+    if (typeof Summarizer === "undefined") {
+      throw new AdapterError("Summarizer API is not supported in this browser.");
+    }
+
+    const availability = await Summarizer.availability();
+
+    if (availability === "unavailable") {
+      throw new AdapterError("Summarizer API is unavailable on this device.");
+    }
+
+    const tool = new SummarizeTool();
+
+    const monitor = options?.onDownloadProgress
+      ? (m: EventTarget) => {
+          m.addEventListener("downloadprogress", (e) => {
+            const evt = e as ProgressEvent;
+            options.onDownloadProgress!({ loaded: evt.loaded, total: evt.total });
+          });
+        }
+      : undefined;
+
+    // Return immediately — session creation (including any download) happens in the background.
+    // The tool is registered once the session is ready.
+    Summarizer.create({ monitor }).then((session) => {
+      tool.cached = { session, type: undefined, format: undefined, length: undefined };
+      registry.register(tool);
+    }).catch(() => {
+      // Background creation failed — tool remains unregistered.
+    });
+  }
+
+  definition(): ToolDefinition {
+    return {
+      name: "summarize",
+      description:
+        "Condense a long piece of text into a shorter form. " +
+        "Use when the user asks to summarize, shorten, or extract the key points of a document, " +
+        "article, or any other lengthy content.",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: "The full text to summarize.",
+          },
+          type: {
+            type: "string",
+            enum: ["key-points", "tldr", "teaser", "headline"],
+            description:
+              "Shape of the summary. " +
+              "'key-points' returns a bullet-point list of the main ideas (default). " +
+              "'tldr' returns a short paragraph capturing the essence. " +
+              "'teaser' returns an engaging excerpt meant to entice reading the full text. " +
+              "'headline' returns a single-sentence title.",
+          },
+          format: {
+            type: "string",
+            enum: ["plain-text", "markdown"],
+            description:
+              "Output format. Use 'markdown' when the result will be rendered; " +
+              "'plain-text' otherwise. Defaults to 'plain-text'.",
+          },
+          length: {
+            type: "string",
+            enum: ["short", "medium", "long"],
+            description:
+              "Target length of the summary relative to the input. " +
+              "Defaults to 'medium'.",
+          },
+          context: {
+            type: "string",
+            description:
+              "Optional hint to guide the summarization, e.g. 'scientific paper', " +
+              "'meeting transcript', or 'news article for a general audience'.",
+          },
+        },
+        required: ["text"],
+      },
+    };
+  }
+
+  async call(args: SummarizeArgs, context: ToolContext): Promise<string> {
+    if (typeof Summarizer === "undefined") {
+      throw new AdapterError("Summarizer API is not supported in this browser.");
+    }
+
+    const session = await this.acquireSession(args, context);
+    return session.summarize(args.text, {
+      context: args.context,
+      signal: context.signal,
+    });
+  }
+
+  private async acquireSession(args: SummarizeArgs, context: ToolContext): Promise<SummarizerSession> {
+    if (
+      this.cached &&
+      this.cached.type === args.type &&
+      this.cached.format === args.format &&
+      this.cached.length === args.length
+    ) {
+      return this.cached.session;
+    }
+
+    const old = this.cached;
+    this.cached = null;
+
+    let session: SummarizerSession;
+    try {
+      session = await Summarizer.create({
+        type: args.type,
+        format: args.format,
+        length: args.length,
+        signal: context.signal,
+      });
+    } finally {
+      old?.session.destroy();
+    }
+
+    this.cached = {
+      session,
+      type: args.type,
+      format: args.format,
+      length: args.length,
+    };
+    return session;
+  }
+}

--- a/packages/built-in-ai/src/types.ts
+++ b/packages/built-in-ai/src/types.ts
@@ -41,3 +41,40 @@ declare global {
     create(options?: LanguageModelCreateOptions): Promise<LanguageModelSession>;
   };
 }
+
+export type SummarizerAvailability =
+  | "readily"
+  | "after-download"
+  | "downloading"
+  | "unavailable";
+
+export type SummarizerType = "key-points" | "tldr" | "teaser" | "headline";
+export type SummarizerFormat = "plain-text" | "markdown";
+export type SummarizerLength = "short" | "medium" | "long";
+
+export interface SummarizerCreateOptions {
+  type?: SummarizerType;
+  format?: SummarizerFormat;
+  length?: SummarizerLength;
+  sharedContext?: string;
+  signal?: AbortSignal;
+  monitor?: (monitor: EventTarget) => void;
+}
+
+export interface SummarizerCallOptions {
+  context?: string;
+  signal?: AbortSignal;
+}
+
+export interface SummarizerSession {
+  summarize(text: string, options?: SummarizerCallOptions): Promise<string>;
+  summarizeStreaming(text: string, options?: SummarizerCallOptions): ReadableStream<string>;
+  destroy(): void;
+}
+
+declare global {
+  const Summarizer: {
+    availability(options?: Partial<SummarizerCreateOptions>): Promise<SummarizerAvailability>;
+    create(options?: SummarizerCreateOptions): Promise<SummarizerSession>;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `SummarizeTool` to `@mast-ai/built-in-ai`, backed by the browser's Summarizer API
- `addToRegistry` resolves as soon as availability is confirmed; session creation (including any model download) happens in the background and the tool is registered once ready
- Adds `addAllBuiltInAITools` convenience function that registers all available built-in AI tools via `Promise.allSettled`
- Adds `demo-summarizer` app with type/format/length/context controls and live download-progress feedback
- Moves HTML out of `main.ts` and into `index.html` across all three demo apps

## Test plan

- [ ] Run `npm test --workspace=packages/built-in-ai` — all 28 tests pass
- [ ] Open `demo-summarizer` in a Chrome build with the Summarizer API enabled; verify the availability badge transitions through Loading → ready and the Summarize button enables
- [ ] Summarize text with each `type`, `format`, and `length` combination
- [ ] Verify the Stop button aborts an in-flight request
- [ ] Open `demo-prompt-api` and `demo-basic-chat`; verify they render correctly with HTML now in `index.html`