### PR TITLE
docs: add TSDoc to all exported library members

### DIFF
--- a/packages/built-in-ai/src/BuiltInAIAdapter.ts
+++ b/packages/built-in-ai/src/BuiltInAIAdapter.ts
@@ -11,7 +11,9 @@ import type {
 } from "@mast-ai/core";
 import type { LanguageModelSession, LanguageModelMessage } from "./types.js";
 
+/** Options for {@link BuiltInAIAdapter}. */
 export interface BuiltInAIAdapterOptions {
+  /** Called during model download with bytes loaded and total bytes. */
   onDownloadProgress?: (progress: { loaded: number; total: number }) => void;
 }
 
@@ -26,10 +28,12 @@ export class BuiltInAIAdapter implements LlmAdapter {
   private cachedSession: LanguageModelSession | null = null;
   private cachedHistory: Message[] = [];
 
+  /** @param options - Optional configuration such as a download-progress callback. */
   constructor(options: BuiltInAIAdapterOptions = {}) {
     this.options = options;
   }
 
+  /** {@inheritDoc LlmAdapter.generate} */
   async generate(request: AdapterRequest): Promise<AdapterResponse> {
     if (request.tools.length > 0) {
       console.warn(
@@ -52,6 +56,7 @@ export class BuiltInAIAdapter implements LlmAdapter {
     }
   }
 
+  /** {@inheritDoc LlmAdapter.generateStream} */
   async *generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk> {
     if (request.tools.length > 0) {
       console.warn(
@@ -181,6 +186,7 @@ function messageToString(message: Message): string {
   return "";
 }
 
+/** Returns the availability of the browser's on-device language model via `LanguageModel.availability()`. */
 export async function checkAvailability() {
   return LanguageModel.availability();
 }

--- a/packages/built-in-ai/src/tools/index.ts
+++ b/packages/built-in-ai/src/tools/index.ts
@@ -4,10 +4,18 @@
 import { SummarizeTool } from "./summarize.js";
 import type { ToolRegistry } from "@mast-ai/core";
 
+/** Options for {@link addAllBuiltInAITools}. */
 export interface AddAllBuiltInAIToolsOptions {
+  /** Called during model download with the tool name and bytes loaded / total bytes. */
   onDownloadProgress?: (tool: string, progress: { loaded: number; total: number }) => void;
 }
 
+/**
+ * Convenience helper that registers all available built-in AI tools into `registry`.
+ *
+ * Uses `Promise.allSettled` internally so a single unavailable tool does not
+ * prevent the others from being registered.
+ */
 export async function addAllBuiltInAITools(
   registry: ToolRegistry,
   options?: AddAllBuiltInAIToolsOptions,

--- a/packages/built-in-ai/src/tools/summarize.ts
+++ b/packages/built-in-ai/src/tools/summarize.ts
@@ -10,15 +10,20 @@ import type {
   SummarizerLength,
 } from "../types.js";
 
+/** Arguments passed by the model when invoking the `summarize` tool. */
 export interface SummarizeArgs {
+  /** The full text to summarize. */
   text: string;
   type?: SummarizerType;
   format?: SummarizerFormat;
   length?: SummarizerLength;
+  /** Optional hint to guide the summarization (e.g. `"meeting transcript"`). */
   context?: string;
 }
 
+/** Options for {@link SummarizeTool}. */
 export interface SummarizeToolOptions {
+  /** Called during model download with bytes loaded and total bytes. */
   onDownloadProgress?: (progress: { loaded: number; total: number }) => void;
 }
 
@@ -29,9 +34,22 @@ interface CachedInstance {
   length: SummarizerLength | undefined;
 }
 
+/**
+ * {@link Tool} that condenses text using the browser's Summarizer API.
+ *
+ * Use {@link SummarizeTool.addToRegistry} to register the tool — direct
+ * construction is not recommended because the session is created asynchronously.
+ */
 export class SummarizeTool implements Tool<SummarizeArgs, string> {
   private cached: CachedInstance | null = null;
 
+  /**
+   * Registers a `SummarizeTool` instance into `registry` once the underlying
+   * Summarizer session is ready.
+   *
+   * Throws immediately if the Summarizer API is unsupported or unavailable.
+   * The tool is silently skipped if background session creation fails.
+   */
   static async addToRegistry(
     registry: ToolRegistry,
     options?: SummarizeToolOptions,
@@ -67,6 +85,7 @@ export class SummarizeTool implements Tool<SummarizeArgs, string> {
     });
   }
 
+  /** {@inheritDoc Tool.definition} */
   definition(): ToolDefinition {
     return {
       name: "summarize",
@@ -117,6 +136,7 @@ export class SummarizeTool implements Tool<SummarizeArgs, string> {
     };
   }
 
+  /** {@inheritDoc Tool.call} */
   async call(args: SummarizeArgs, context: ToolContext): Promise<string> {
     if (typeof Summarizer === "undefined") {
       throw new AdapterError("Summarizer API is not supported in this browser.");

--- a/packages/built-in-ai/src/types.ts
+++ b/packages/built-in-ai/src/types.ts
@@ -1,35 +1,50 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Availability status of the on-device language model returned by `LanguageModel.availability()`.
+ *
+ * - `"readily"` — model is ready to use immediately.
+ * - `"after-download"` — model must be downloaded before use.
+ * - `"downloading"` — download is in progress.
+ * - `"unavailable"` — not supported on this device or browser.
+ */
 export type LanguageModelAvailability =
   | "readily"
   | "after-download"
   | "downloading"
   | "unavailable";
 
+/** A single message passed to `LanguageModel.create` as part of `initialPrompts`. */
 export interface LanguageModelMessage {
   role: "user" | "assistant" | "system";
   content: string;
 }
 
+/** Options accepted by `LanguageModel.create`. */
 export interface LanguageModelCreateOptions {
   signal?: AbortSignal;
   initialPrompts?: LanguageModelMessage[];
   // systemPrompt exists in the spec but is not used — system prompt is
   // injected as a { role: "system" } entry in initialPrompts instead.
+  /** Callback invoked with a download progress monitor target. */
   monitor?: (monitor: EventTarget) => void;
   // temperature and topK are only available in the Chrome extension version
   // of the Prompt API and have been removed from the browser version — omitted.
 }
 
+/** Options accepted by `LanguageModelSession.prompt` and `promptStreaming`. */
 export interface LanguageModelPromptOptions {
   signal?: AbortSignal;
 }
 
+/** A live session obtained from `LanguageModel.create`. */
 export interface LanguageModelSession {
   prompt(input: string, options?: LanguageModelPromptOptions): Promise<string>;
   promptStreaming(input: string, options?: LanguageModelPromptOptions): ReadableStream<string>;
+  /** Number of tokens currently consumed in the session context. */
   contextUsage: number;
+  /** Maximum number of tokens the session context can hold. */
   contextWindow: number;
   destroy(): void;
   addEventListener(type: "contextoverflow", listener: EventListener): void;
@@ -42,30 +57,47 @@ declare global {
   };
 }
 
+/**
+ * Availability status of the on-device Summarizer API returned by `Summarizer.availability()`.
+ *
+ * - `"readily"` — ready to use immediately.
+ * - `"after-download"` — must be downloaded before use.
+ * - `"downloading"` — download is in progress.
+ * - `"unavailable"` — not supported on this device or browser.
+ */
 export type SummarizerAvailability =
   | "readily"
   | "after-download"
   | "downloading"
   | "unavailable";
 
+/** Shape of the summary output. */
 export type SummarizerType = "key-points" | "tldr" | "teaser" | "headline";
+/** Output format of the summary. */
 export type SummarizerFormat = "plain-text" | "markdown";
+/** Target length of the summary relative to the source text. */
 export type SummarizerLength = "short" | "medium" | "long";
 
+/** Options accepted by `Summarizer.create`. */
 export interface SummarizerCreateOptions {
   type?: SummarizerType;
   format?: SummarizerFormat;
   length?: SummarizerLength;
+  /** Shared context prepended to every summarization call made on this session. */
   sharedContext?: string;
   signal?: AbortSignal;
+  /** Callback invoked with a download progress monitor target. */
   monitor?: (monitor: EventTarget) => void;
 }
 
+/** Per-call options passed to `SummarizerSession.summarize` / `summarizeStreaming`. */
 export interface SummarizerCallOptions {
+  /** Optional hint providing additional context for this specific call. */
   context?: string;
   signal?: AbortSignal;
 }
 
+/** A live session obtained from `Summarizer.create`. */
 export interface SummarizerSession {
   summarize(text: string, options?: SummarizerCallOptions): Promise<string>;
   summarizeStreaming(text: string, options?: SummarizerCallOptions): ReadableStream<string>;

--- a/packages/core/src/adapter/index.ts
+++ b/packages/core/src/adapter/index.ts
@@ -4,34 +4,51 @@
 import type { Message, ToolCall } from '../types';
 import type { ToolDefinition } from '../tool';
 
+/** Provider-specific model configuration options forwarded verbatim to the adapter. */
 export interface ModelConfig {
   temperature?: number;
   maxTokens?: number;
   topP?: number;
   stopSequences?: string[];
-  [key: string]: unknown;   // pass-through for provider-specific fields
+  /** Pass-through for provider-specific fields not covered above. */
+  [key: string]: unknown;
 }
 
+/** Normalised request sent from the runner to an {@link LlmAdapter}. */
 export interface AdapterRequest {
   messages: Message[];
+  /** System prompt / instructions for the model. */
   system?: string;
   tools: ToolDefinition[];
-  outputSchema?: Record<string, unknown>;  // JSON Schema
+  /** JSON Schema for structured output; passed through to adapters that support it. */
+  outputSchema?: Record<string, unknown>;
   config?: ModelConfig;
   signal?: AbortSignal;
 }
 
+/** Normalised response returned by an {@link LlmAdapter} from a non-streaming call. */
 export interface AdapterResponse {
-  text?: string;            // undefined when tool calls were issued
-  toolCalls: ToolCall[];    // empty on a final text response
+  /** Final text output; `undefined` when the model issued tool calls instead. */
+  text?: string;
+  /** Empty on a final text response; non-empty when the model wants to call tools. */
+  toolCalls: ToolCall[];
 }
 
+/** A single chunk emitted by a streaming {@link LlmAdapter}. */
 export type AdapterStreamChunk =
   | { type: 'text_delta'; delta: string }
   | { type: 'thinking';   delta: string }
   | { type: 'tool_call';  toolCall: ToolCall };
 
+/**
+ * Adapter interface that bridges the runner to a specific LLM provider.
+ *
+ * Implement this interface to connect any model backend.
+ * `generateStream` is optional — the runner falls back to `generate` when absent.
+ */
 export interface LlmAdapter {
+  /** Generates a response in a single round-trip. */
   generate(request: AdapterRequest): Promise<AdapterResponse>;
+  /** Streams response chunks incrementally. Optional — the runner falls back to `generate` if absent. */
   generateStream?(request: AdapterRequest): AsyncIterable<AdapterStreamChunk>;
 }

--- a/packages/core/src/adapter/urp.ts
+++ b/packages/core/src/adapter/urp.ts
@@ -5,6 +5,7 @@ import type { LlmAdapter, AdapterRequest, AdapterResponse, AdapterStreamChunk } 
 import type { Message } from '../types';
 import type { ToolDefinition } from '../tool';
 
+/** Wire format for a request sent over the Universal Runtime Protocol (URP). */
 export interface UrpRequest {
   messages: Message[];
   available_tools: ToolDefinition[];
@@ -12,29 +13,45 @@ export interface UrpRequest {
   stream?: boolean;
 }
 
+/** A tool call as represented in the URP wire format. */
 export interface UrpToolCall {
   id: string;
   name: string;
   arguments: unknown;
 }
 
+/** Wire format for a non-streaming URP response. */
 export interface UrpResponse {
   text_content?: string;
   tool_calls: UrpToolCall[];
   usage_metrics?: Record<string, unknown>;
 }
 
+/** A single chunk emitted by a streaming URP response. */
 export interface UrpStreamChunk {
   type: 'text_delta' | 'tool_call' | 'thinking';
   delta?: string;
   tool_call?: UrpToolCall;
 }
 
+/**
+ * Low-level transport abstraction for the Universal Runtime Protocol.
+ *
+ * Implement this to connect `UrpAdapter` to a custom backend (e.g. `HttpTransport`).
+ */
 export interface UrpTransport {
+  /** Sends a non-streaming request and returns the full response. */
   send(request: UrpRequest, signal?: AbortSignal): Promise<UrpResponse>;
+  /** Sends a streaming request and yields response chunks. Optional. */
   sendStream?(request: UrpRequest, signal?: AbortSignal): AsyncIterable<UrpStreamChunk>;
 }
 
+/**
+ * {@link LlmAdapter} implementation backed by any {@link UrpTransport}.
+ *
+ * Translates between the normalised {@link AdapterRequest}/{@link AdapterResponse} types
+ * and the URP wire format.
+ */
 export class UrpAdapter implements LlmAdapter {
   constructor(private transport: UrpTransport) {}
 
@@ -60,6 +77,7 @@ export class UrpAdapter implements LlmAdapter {
     return urpRequest;
   }
 
+  /** {@inheritDoc LlmAdapter.generate} */
   async generate(request: AdapterRequest): Promise<AdapterResponse> {
     const urpRequest = this.prepareRequest(request, false);
     const response = await this.transport.send(urpRequest, request.signal);
@@ -74,6 +92,7 @@ export class UrpAdapter implements LlmAdapter {
     };
   }
 
+  /** {@inheritDoc LlmAdapter.generateStream} */
   async *generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk> {
     if (!this.transport.sendStream) {
       // Fallback to non-streaming if transport doesn't support it

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -4,6 +4,13 @@
 import type { AgentConfig } from './types';
 import { AgentError } from './error';
 
+/**
+ * Validates and returns an {@link AgentConfig}.
+ *
+ * Throws {@link AgentError} if `name` or `instructions` are missing.
+ * The return value is the same object passed in — use it as a typed
+ * constant so TypeScript can narrow the config at call sites.
+ */
 export function createAgent(config: AgentConfig): AgentConfig {
   if (!config.name) {
     throw new AgentError('Agent name is required');

--- a/packages/core/src/conversation.ts
+++ b/packages/core/src/conversation.ts
@@ -4,6 +4,13 @@
 import type { AgentConfig, AgentEvent, AgentResult, Message } from './types';
 import type { AgentRunner } from './runner';
 
+/**
+ * Stateful wrapper around {@link AgentRunner} that automatically accumulates
+ * conversation history across multiple turns.
+ *
+ * Obtain an instance from {@link AgentRunner.conversation} rather than
+ * constructing one directly.
+ */
 export class Conversation {
   /** Full conversation history, including all turns. May be trimmed via direct mutation. */
   history: Message[] = [];
@@ -19,6 +26,7 @@ export class Conversation {
     return builder.runStream(input);
   }
 
+  /** Runs a single turn and waits for the agent to finish, then returns the result. */
   async run(input: string, signal?: AbortSignal): Promise<AgentResult> {
     let output = '';
     for await (const event of this.buildStream(input, signal)) {
@@ -32,6 +40,7 @@ export class Conversation {
     return { output };
   }
 
+  /** Runs a single turn and returns a stream of {@link AgentEvent} objects. History is updated once the stream is fully consumed. */
   runStream(input: string, signal?: AbortSignal): AsyncIterable<AgentEvent> {
     return this._streamWithHistoryUpdate(input, signal);
   }

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -1,6 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+/** Thrown by the agent runner for logical errors such as missing tools or aborted runs. */
 export class AgentError extends Error {
   constructor(
     message: string,
@@ -11,9 +12,11 @@ export class AgentError extends Error {
   }
 }
 
+/** Thrown by an {@link LlmAdapter} or {@link UrpTransport} when a backend request fails. */
 export class AdapterError extends Error {
   constructor(
     message: string,
+    /** HTTP status code, when applicable. */
     public readonly statusCode?: number,
     public readonly cause?: unknown,
   ) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+/** Current version of the `@mast-ai/core` package. */
 export const VERSION = '0.1.0';
 
 export * from './types';

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -9,6 +9,12 @@ import { Conversation } from './conversation';
 
 type StreamExecutor = (input: string, history: Message[], signal?: AbortSignal) => AsyncIterable<AgentEvent>;
 
+/**
+ * Fluent builder for a single agent run.
+ *
+ * Obtain an instance from {@link AgentRunner.runBuilder} rather than
+ * constructing one directly.
+ */
 export class RunBuilder {
   private _history: Message[] = [];
   private _signal?: AbortSignal;
@@ -30,10 +36,12 @@ export class RunBuilder {
     return this;
   }
 
+  /** Executes the run and returns a stream of {@link AgentEvent} objects. */
   runStream(input: string): AsyncIterable<AgentEvent> {
     return this.execute(input, this._history, this._signal);
   }
 
+  /** Executes the run and returns the final text output. */
   async run(input: string): Promise<AgentResult> {
     let output = '';
     for await (const event of this.runStream(input)) {
@@ -44,6 +52,11 @@ export class RunBuilder {
     return { output };
   }
 
+  /**
+   * Executes the run and parses the final output as JSON into `T`.
+   *
+   * Throws {@link AgentError} if the output cannot be parsed.
+   */
   async runTyped<T>(input: string): Promise<T> {
     const result = await this.run(input);
     try {
@@ -54,9 +67,18 @@ export class RunBuilder {
   }
 }
 
+/**
+ * Core execution engine that drives the agent agentic loop.
+ *
+ * Pair an {@link LlmAdapter} with a {@link ToolRegistry} and use
+ * {@link AgentRunner.runBuilder} (multi-turn) or the convenience methods
+ * {@link AgentRunner.run} / {@link AgentRunner.runStream} (single-turn).
+ */
 export class AgentRunner {
   constructor(
+    /** The LLM adapter used to generate responses. */
     public readonly adapter: LlmAdapter,
+    /** Registry of tools the runner may invoke on behalf of agents. */
     public readonly registry: ToolRegistry = new ToolRegistry()
   ) {}
 
@@ -77,10 +99,16 @@ export class AgentRunner {
     return this.runBuilder(agent).runStream(input);
   }
 
+  /** Single-turn convenience method — runs the agent and returns the final text output. */
   run(agent: AgentConfig, input: string): Promise<AgentResult> {
     return this.runBuilder(agent).run(input);
   }
 
+  /**
+   * Single-turn convenience method — runs the agent and parses the output as JSON into `T`.
+   *
+   * Throws {@link AgentError} if parsing fails.
+   */
   runTyped<T>(agent: AgentConfig, input: string): Promise<T> {
     return this.runBuilder(agent).runTyped<T>(input);
   }

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -1,24 +1,41 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+/** Static description of a tool that is sent to the model so it can decide when to call it. */
 export interface ToolDefinition {
   name: string;
   description: string;
-  parameters: Record<string, unknown>;  // JSON Schema object
+  /** JSON Schema object describing the tool's arguments. */
+  parameters: Record<string, unknown>;
 }
 
+/** Runtime context passed to every {@link Tool.call} invocation. */
 export interface ToolContext {
-  signal?: AbortSignal;  // forwarded from the runner; allows long-running tools to be cancelled
+  /** Forwarded from the runner; allows long-running tools to be cancelled. */
+  signal?: AbortSignal;
 }
 
+/**
+ * A callable tool that can be registered with a {@link ToolRegistry}.
+ *
+ * @typeParam TArgs - Shape of the arguments object the model passes to `call`.
+ * @typeParam TResult - Value returned by `call` and forwarded to the model as the tool result.
+ */
 export interface Tool<TArgs = unknown, TResult = unknown> {
+  /** Returns the static description used to advertise this tool to the model. */
   definition(): ToolDefinition;
+  /** Executes the tool with the given arguments. */
   call(args: TArgs, context: ToolContext): Promise<TResult>;
 }
 
+/** Holds all tools available to an {@link AgentRunner} and resolves them by name during execution. */
 export class ToolRegistry {
   private _tools = new Map<string, Tool>();
 
+  /**
+   * Registers a tool. Throws if a tool with the same name is already registered.
+   * Returns `this` for chaining.
+   */
   register(tool: Tool): this {
     const name = tool.definition().name;
     if (this._tools.has(name)) {
@@ -28,10 +45,12 @@ export class ToolRegistry {
     return this;
   }
 
+  /** Returns the tool registered under `name`, or `undefined` if not found. */
   get(name: string): Tool | undefined {
     return this._tools.get(name);
   }
 
+  /** Returns the definitions of all registered tools for inclusion in an adapter request. */
   definitions(): ToolDefinition[] {
     return Array.from(this._tools.values()).map(t => t.definition());
   }

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -4,14 +4,23 @@
 import type { UrpRequest, UrpResponse, UrpTransport, UrpStreamChunk } from '../adapter/urp';
 import { AdapterError } from '../error';
 
+/** Configuration for {@link HttpTransport}. */
 export interface HttpTransportOptions {
+  /** Endpoint URL that accepts URP-formatted POST requests. */
   url: string;
+  /** Additional headers merged into every request (e.g. `Authorization`). */
   headers?: Record<string, string>;
 }
 
+/**
+ * {@link UrpTransport} implementation that sends URP requests over HTTP/HTTPS.
+ *
+ * Supports both non-streaming (JSON) and streaming (NDJSON / SSE) responses.
+ */
 export class HttpTransport implements UrpTransport {
   constructor(private options: HttpTransportOptions) {}
 
+  /** {@inheritDoc UrpTransport.send} */
   async send(request: UrpRequest, signal?: AbortSignal): Promise<UrpResponse> {
     try {
       const response = await fetch(this.options.url, {
@@ -45,6 +54,7 @@ export class HttpTransport implements UrpTransport {
     }
   }
 
+  /** {@inheritDoc UrpTransport.sendStream} */
   async *sendStream(request: UrpRequest, signal?: AbortSignal): AsyncIterable<UrpStreamChunk> {
     let response: Response;
     try {

--- a/packages/google-genai/src/GoogleGenAIAdapter.ts
+++ b/packages/google-genai/src/GoogleGenAIAdapter.ts
@@ -13,17 +13,29 @@ import type {
   ToolCall,
 } from "@mast-ai/core";
 
+/** Token-usage statistics reported by the Gemini API. */
 export interface UsageMetadata {
   promptTokenCount?: number;
   candidatesTokenCount?: number;
   totalTokenCount?: number;
 }
 
+/**
+ * {@link LlmAdapter} implementation backed by the Google Gemini API via `@google/genai`.
+ *
+ * Supports tool calling, structured output, and streaming. Thinking mode is
+ * enabled by default (`ThinkingLevel.HIGH`).
+ */
 export class GoogleGenAIAdapter implements LlmAdapter {
   private client: GoogleGenAI;
   private modelName: string;
   private onUsageUpdate?: (usage: UsageMetadata) => void;
 
+  /**
+   * @param apiKey - Google AI API key.
+   * @param modelName - Gemini model identifier (defaults to `"gemini-3.1-flash-lite-preview"`).
+   * @param onUsageUpdate - Optional callback invoked with token-usage data after each response.
+   */
   constructor(
     apiKey: string,
     modelName: string = "gemini-3.1-flash-lite-preview",
@@ -34,6 +46,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
     this.onUsageUpdate = onUsageUpdate;
   }
 
+  /** {@inheritDoc LlmAdapter.generate} */
   async generate(request: AdapterRequest): Promise<AdapterResponse> {
     const contents = this.mapMessages(request.messages);
     const systemInstruction = this.mapSystemInstruction(request.system);
@@ -97,6 +110,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
     };
   }
 
+  /** {@inheritDoc LlmAdapter.generateStream} */
   async *generateStream(
     request: AdapterRequest,
   ): AsyncIterable<AdapterStreamChunk> {


### PR DESCRIPTION
## Summary

- Adds TSDoc comments to every exported type, interface, class, function, and public member across all three packages (`@mast-ai/core`, `@mast-ai/built-in-ai`, `@mast-ai/google-genai`)
- Covers class-level descriptions, method descriptions, `@param` / `@typeParam` annotations, and `{@inheritDoc}` tags on adapter implementations
- No logic changes — documentation only

## Test plan

- [x] `npm run build` passes cleanly across all packages