### PR TITLE
feat: default to all registered tools when agent.tools is omitted

### DIFF
--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -119,16 +119,18 @@ export class AgentRunner {
     history: Message[],
     signal?: AbortSignal
   ): AsyncIterable<AgentEvent> {
-    // Validate that all names in agent.tools exist in the registry.
-    const tools = agent.tools || [];
-    const toolDefinitions = [];
-    for (const toolName of tools) {
-      const tool = this.registry.get(toolName);
-      if (!tool) {
-        throw new AgentError(`Tool '${toolName}' requested by agent '${agent.name}' is not registered.`);
-      }
-      toolDefinitions.push(tool.definition());
-    }
+    // Use the explicit tool list when provided; otherwise expose all registered tools.
+    const toolDefinitions = agent.tools
+      ? agent.tools.map((toolName) => {
+          const tool = this.registry.get(toolName);
+          if (!tool) {
+            throw new AgentError(
+              `Tool '${toolName}' requested by agent '${agent.name}' is not registered.`,
+            );
+          }
+          return tool.definition();
+        })
+      : this.registry.definitions();
 
     // Clone history and add new user message
     const currentHistory: Message[] = [


### PR DESCRIPTION
## Summary

- When `AgentConfig.tools` is not specified, `AgentRunner` now exposes all tools in the registry to the model instead of an empty list
- An explicit `tools` list continues to work exactly as before, with the same validation that each named tool is registered

## Why

Requiring callers to maintain a static list of tool names is brittle — new tools registered into the registry (including tools that register themselves asynchronously, like `SummarizeTool`) are silently invisible to the model unless the list is manually updated. Defaulting to all registered tools removes that coupling.

## Test plan

- [x] Verify an agent with no `tools` in its config receives definitions for all registered tools
- [x] Verify an agent with an explicit `tools` list still receives only the listed tools
- [x] Verify an explicit list with an unregistered name still throws `AgentError`