### PR TITLE
feat: DetectLanguageTool — Phase 3 of built-in-ai package

### DIFF
--- a/packages/built-in-ai/src/index.ts
+++ b/packages/built-in-ai/src/index.ts
@@ -7,5 +7,7 @@ export type { LanguageModelAvailability } from './types.js';
 
 export { SummarizeTool } from './tools/summarize.js';
 export type { SummarizeToolOptions, SummarizeArgs } from './tools/summarize.js';
+export { DetectLanguageTool } from './tools/detectLanguage.js';
+export type { DetectLanguageToolOptions, DetectLanguageArgs } from './tools/detectLanguage.js';
 export { addAllBuiltInAITools } from './tools/index.js';
 export type { AddAllBuiltInAIToolsOptions } from './tools/index.js';

--- a/packages/built-in-ai/src/tools/detectLanguage.test.ts
+++ b/packages/built-in-ai/src/tools/detectLanguage.test.ts
@@ -1,0 +1,196 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DetectLanguageTool } from "./detectLanguage.js";
+import { ToolRegistry } from "@mast-ai/core";
+import type { LanguageDetectorSession } from "../types.js";
+
+function makeSession(overrides: Partial<LanguageDetectorSession> = {}): LanguageDetectorSession {
+  return {
+    detect: vi.fn().mockResolvedValue([{ detectedLanguage: "en", confidence: 0.97 }]),
+    destroy: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Drain all pending microtasks so the background registration completes.
+const flush = () => Promise.resolve();
+
+const mockCreate = vi.fn();
+const mockAvailability = vi.fn();
+
+vi.stubGlobal("LanguageDetector", {
+  create: mockCreate,
+  availability: mockAvailability,
+});
+
+describe("DetectLanguageTool", () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.mockResolvedValue("readily");
+    mockCreate.mockResolvedValue(makeSession());
+    registry = new ToolRegistry();
+  });
+
+  describe("addToRegistry", () => {
+    it("rejects with AdapterError when LanguageDetector global is absent", async () => {
+      vi.stubGlobal("LanguageDetector", undefined);
+
+      await expect(DetectLanguageTool.addToRegistry(registry)).rejects.toThrow(
+        "not supported in this browser",
+      );
+      expect(registry.definitions()).toHaveLength(0);
+
+      vi.stubGlobal("LanguageDetector", { create: mockCreate, availability: mockAvailability });
+    });
+
+    it("resolves and registers tool in background when readily available", async () => {
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+
+      expect(mockCreate).toHaveBeenCalled();
+      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.definitions()[0].name).toBe("detectLanguage");
+    });
+
+    it("resolves and registers tool in background when after-download", async () => {
+      mockAvailability.mockResolvedValue("after-download");
+      const onDownloadProgress = vi.fn();
+
+      await DetectLanguageTool.addToRegistry(registry, { onDownloadProgress });
+      await flush();
+
+      const createOpts = mockCreate.mock.calls[0][0];
+      expect(typeof createOpts.monitor).toBe("function");
+      expect(registry.definitions()).toHaveLength(1);
+    });
+
+    it("resolves and registers tool in background when downloading", async () => {
+      mockAvailability.mockResolvedValue("downloading");
+
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+
+      expect(mockCreate).toHaveBeenCalled();
+      expect(registry.definitions()).toHaveLength(1);
+    });
+
+    it("rejects with AdapterError when unavailable", async () => {
+      mockAvailability.mockResolvedValue("unavailable");
+
+      await expect(DetectLanguageTool.addToRegistry(registry)).rejects.toThrow(
+        "unavailable on this device",
+      );
+      expect(registry.definitions()).toHaveLength(0);
+    });
+
+    it("fires onDownloadProgress callback when downloadprogress event fires", async () => {
+      mockAvailability.mockResolvedValue("after-download");
+
+      let capturedMonitor: EventTarget | null = null;
+      mockCreate.mockImplementation(async (opts: { monitor?: (m: EventTarget) => void }) => {
+        if (opts?.monitor) {
+          const et = new EventTarget();
+          opts.monitor(et);
+          capturedMonitor = et;
+        }
+        return makeSession();
+      });
+
+      const onDownloadProgress = vi.fn();
+      await DetectLanguageTool.addToRegistry(registry, { onDownloadProgress });
+
+      const evt = Object.assign(new Event("downloadprogress"), { loaded: 50, total: 100 });
+      capturedMonitor!.dispatchEvent(evt);
+
+      expect(onDownloadProgress).toHaveBeenCalledWith({ loaded: 50, total: 100 });
+    });
+
+    it("does not register tool when background session creation fails", async () => {
+      mockCreate.mockRejectedValue(new Error("creation failed"));
+
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+
+      expect(registry.definitions()).toHaveLength(0);
+    });
+  });
+
+  describe("call()", () => {
+    it("rejects with AdapterError when LanguageDetector global is absent", async () => {
+      vi.stubGlobal("LanguageDetector", undefined);
+
+      const tool = new DetectLanguageTool();
+      await expect(tool.call({ text: "hello" }, {})).rejects.toThrow(
+        "not supported in this browser",
+      );
+
+      vi.stubGlobal("LanguageDetector", { create: mockCreate, availability: mockAvailability });
+    });
+
+    it("resolves with the top detection result", async () => {
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("detectLanguage")!;
+
+      const result = await tool.call({ text: "Hello world" }, {});
+      expect(result).toEqual({ detectedLanguage: "en", confidence: 0.97 });
+    });
+
+    it("reuses the cached session across calls", async () => {
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("detectLanguage")!;
+
+      await tool.call({ text: "first" }, {});
+      await tool.call({ text: "second" }, {});
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards context.signal to detect()", async () => {
+      const session = makeSession();
+      mockCreate.mockResolvedValue(session);
+
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("detectLanguage")!;
+
+      const controller = new AbortController();
+      await tool.call({ text: "text" }, { signal: controller.signal });
+
+      expect(session.detect).toHaveBeenCalledWith(
+        "text",
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it("returns null language and zero confidence when detect returns empty array", async () => {
+      const session = makeSession({ detect: vi.fn().mockResolvedValue([]) });
+      mockCreate.mockResolvedValue(session);
+
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("detectLanguage")!;
+
+      const result = await tool.call({ text: "???" }, {});
+      expect(result).toEqual({ detectedLanguage: null, confidence: 0 });
+    });
+
+    it("propagates error thrown by detect()", async () => {
+      const session = makeSession({
+        detect: vi.fn().mockRejectedValue(new Error("detect failed")),
+      });
+      mockCreate.mockResolvedValue(session);
+
+      await DetectLanguageTool.addToRegistry(registry);
+      await flush();
+      const tool = registry.get("detectLanguage")!;
+
+      await expect(tool.call({ text: "text" }, {})).rejects.toThrow("detect failed");
+    });
+  });
+});

--- a/packages/built-in-ai/src/tools/detectLanguage.ts
+++ b/packages/built-in-ai/src/tools/detectLanguage.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AdapterError } from "@mast-ai/core";
+import type { Tool, ToolDefinition, ToolContext, ToolRegistry } from "@mast-ai/core";
+import type {
+  LanguageDetectionResult,
+  LanguageDetectorSession,
+} from "../types.js";
+
+/** Arguments passed by the model when invoking the `detectLanguage` tool. */
+export interface DetectLanguageArgs {
+  /** The text whose language should be detected. */
+  text: string;
+}
+
+/** Options for {@link DetectLanguageTool}. */
+export interface DetectLanguageToolOptions {
+  /** Called during model download with bytes loaded and total bytes. */
+  onDownloadProgress?: (progress: { loaded: number; total: number }) => void;
+}
+
+/**
+ * {@link Tool} that identifies the language of a piece of text using the
+ * browser's Language Detector API.
+ *
+ * Use {@link DetectLanguageTool.addToRegistry} to register the tool — direct
+ * construction is not recommended because the session is created asynchronously.
+ */
+export class DetectLanguageTool implements Tool<DetectLanguageArgs, LanguageDetectionResult> {
+  private session: LanguageDetectorSession | null = null;
+
+  /**
+   * Registers a `DetectLanguageTool` instance into `registry` once the
+   * underlying Language Detector session is ready.
+   *
+   * Throws immediately if the Language Detector API is unsupported or unavailable.
+   * The tool is silently skipped if background session creation fails.
+   */
+  static async addToRegistry(
+    registry: ToolRegistry,
+    options?: DetectLanguageToolOptions,
+  ): Promise<void> {
+    if (typeof LanguageDetector === "undefined") {
+      throw new AdapterError("Language Detector API is not supported in this browser.");
+    }
+
+    const availability = await LanguageDetector.availability();
+
+    if (availability === "unavailable") {
+      throw new AdapterError("Language Detector API is unavailable on this device.");
+    }
+
+    const tool = new DetectLanguageTool();
+
+    const monitor = options?.onDownloadProgress
+      ? (m: EventTarget) => {
+          m.addEventListener("downloadprogress", (e) => {
+            const evt = e as ProgressEvent;
+            options.onDownloadProgress!({ loaded: evt.loaded, total: evt.total });
+          });
+        }
+      : undefined;
+
+    LanguageDetector.create({ monitor }).then((session) => {
+      tool.session = session;
+      registry.register(tool);
+    }).catch(() => {
+      // Background creation failed — tool remains unregistered.
+    });
+  }
+
+  /** {@inheritDoc Tool.definition} */
+  definition(): ToolDefinition {
+    return {
+      name: "detectLanguage",
+      description:
+        "Detect the language of a piece of text. " +
+        "Returns the most likely BCP 47 language tag (e.g. 'en', 'fr', 'ja') " +
+        "and a confidence score between 0 and 1.",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: "The text whose language should be detected.",
+          },
+        },
+        required: ["text"],
+      },
+    };
+  }
+
+  /** {@inheritDoc Tool.call} */
+  async call(args: DetectLanguageArgs, context: ToolContext): Promise<LanguageDetectionResult> {
+    if (typeof LanguageDetector === "undefined") {
+      throw new AdapterError("Language Detector API is not supported in this browser.");
+    }
+
+    const session = await this.acquireSession(context);
+    const results = await session.detect(args.text, { signal: context.signal });
+    return results[0] ?? { detectedLanguage: null, confidence: 0 };
+  }
+
+  private async acquireSession(context: ToolContext): Promise<LanguageDetectorSession> {
+    if (this.session) {
+      return this.session;
+    }
+
+    this.session = await LanguageDetector.create({ signal: context.signal });
+    return this.session;
+  }
+}

--- a/packages/built-in-ai/src/tools/index.ts
+++ b/packages/built-in-ai/src/tools/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SummarizeTool } from "./summarize.js";
+import { DetectLanguageTool } from "./detectLanguage.js";
 import type { ToolRegistry } from "@mast-ai/core";
 
 /** Options for {@link addAllBuiltInAITools}. */
@@ -24,6 +25,11 @@ export async function addAllBuiltInAITools(
     SummarizeTool.addToRegistry(registry, {
       onDownloadProgress: options?.onDownloadProgress
         ? (p) => options.onDownloadProgress!("summarize", p)
+        : undefined,
+    }),
+    DetectLanguageTool.addToRegistry(registry, {
+      onDownloadProgress: options?.onDownloadProgress
+        ? (p) => options.onDownloadProgress!("detectLanguage", p)
         : undefined,
     }),
   ]);

--- a/packages/built-in-ai/src/types.ts
+++ b/packages/built-in-ai/src/types.ts
@@ -110,3 +110,50 @@ declare global {
     create(options?: SummarizerCreateOptions): Promise<SummarizerSession>;
   };
 }
+
+/**
+ * Availability status of the on-device Language Detector API.
+ *
+ * - `"readily"` — ready to use immediately.
+ * - `"after-download"` — must be downloaded before use.
+ * - `"downloading"` — download is in progress.
+ * - `"unavailable"` — not supported on this device or browser.
+ */
+export type LanguageDetectorAvailability =
+  | "readily"
+  | "after-download"
+  | "downloading"
+  | "unavailable";
+
+/** Options accepted by `LanguageDetector.create`. */
+export interface LanguageDetectorCreateOptions {
+  signal?: AbortSignal;
+  /** Callback invoked with a download progress monitor target. */
+  monitor?: (monitor: EventTarget) => void;
+}
+
+/** A single language detection result. */
+export interface LanguageDetectionResult {
+  /** BCP 47 language tag (e.g. `"en"`, `"fr"`), or `null` if undetermined. */
+  detectedLanguage: string | null;
+  /** Confidence score in the range [0, 1]. */
+  confidence: number;
+}
+
+/** Per-call options passed to `LanguageDetectorSession.detect`. */
+export interface LanguageDetectorCallOptions {
+  signal?: AbortSignal;
+}
+
+/** A live session obtained from `LanguageDetector.create`. */
+export interface LanguageDetectorSession {
+  detect(text: string, options?: LanguageDetectorCallOptions): Promise<LanguageDetectionResult[]>;
+  destroy(): void;
+}
+
+declare global {
+  const LanguageDetector: {
+    availability(options?: Partial<LanguageDetectorCreateOptions>): Promise<LanguageDetectorAvailability>;
+    create(options?: LanguageDetectorCreateOptions): Promise<LanguageDetectorSession>;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `LanguageDetector` API type declarations to `types.ts` (`LanguageDetectorAvailability`, `LanguageDetectorCreateOptions`, `LanguageDetectionResult`, `LanguageDetectorSession`)
- Implements `DetectLanguageTool` wrapping the browser's Language Detector API — availability guard, background session creation, session caching, `AbortSignal` forwarding, and fallback for empty results
- Wires the tool into `addAllBuiltInAITools` and the package's public exports
- 10 unit tests covering all availability states, download progress callback, caching behaviour, signal forwarding, empty-result fallback, and error propagation

## Test plan

- [x] `bunx vitest run` in `packages/built-in-ai` — all 41 tests pass
- [x] Manual: register `DetectLanguageTool` in a Chrome Origin Trial build and call it with text in a known language