### PR TITLE
feat: add TranslateTool wrapping the Translator API (Phase 4)

### DIFF
--- a/apps/demo-translate/index.html
+++ b/apps/demo-translate/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Translate Demo — MAST Built-in AI</title>
+  <link rel="stylesheet" href="/src/style.css" />
+</head>
+<body>
+  <div id="app">
+    <header>
+      <h1>Translation Demo</h1>
+      <p>On-device translation via <code>@mast-ai/built-in-ai</code> and the browser Translator API.</p>
+      <div id="api-status" class="status checking">Checking API availability…</div>
+    </header>
+
+    <main>
+      <form id="translate-form">
+        <div class="lang-row">
+          <div class="field">
+            <label for="source-lang">From</label>
+            <select id="source-lang">
+              <option value="en" selected>English</option>
+              <option value="ar">Arabic</option>
+              <option value="zh">Chinese (Simplified)</option>
+              <option value="zh-Hant">Chinese (Traditional)</option>
+              <option value="nl">Dutch</option>
+              <option value="fr">French</option>
+              <option value="de">German</option>
+              <option value="hi">Hindi</option>
+              <option value="it">Italian</option>
+              <option value="ja">Japanese</option>
+              <option value="ko">Korean</option>
+              <option value="pl">Polish</option>
+              <option value="pt">Portuguese</option>
+              <option value="ru">Russian</option>
+              <option value="es">Spanish</option>
+              <option value="tr">Turkish</option>
+            </select>
+          </div>
+          <button type="button" id="swap-btn" title="Swap languages">⇄</button>
+          <div class="field">
+            <label for="target-lang">To</label>
+            <select id="target-lang">
+              <option value="ar">Arabic</option>
+              <option value="zh">Chinese (Simplified)</option>
+              <option value="zh-Hant">Chinese (Traditional)</option>
+              <option value="nl">Dutch</option>
+              <option value="en">English</option>
+              <option value="fr" selected>French</option>
+              <option value="de">German</option>
+              <option value="hi">Hindi</option>
+              <option value="it">Italian</option>
+              <option value="ja">Japanese</option>
+              <option value="ko">Korean</option>
+              <option value="pl">Polish</option>
+              <option value="pt">Portuguese</option>
+              <option value="ru">Russian</option>
+              <option value="es">Spanish</option>
+              <option value="tr">Turkish</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="panels">
+          <div class="panel">
+            <label for="source-text">Source</label>
+            <textarea id="source-text" placeholder="Enter text to translate…" rows="8"></textarea>
+          </div>
+          <div class="panel">
+            <label>Translation</label>
+            <div id="result" class="result-box" aria-live="polite"></div>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button type="submit" id="translate-btn">Translate</button>
+          <span id="progress-msg" class="progress hidden"></span>
+        </div>
+
+        <div id="error-msg" class="error hidden"></div>
+      </form>
+    </main>
+  </div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/apps/demo-translate/package.json
+++ b/apps/demo-translate/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demo-translate",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/built-in-ai": "*",
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/demo-translate/src/main.ts
+++ b/apps/demo-translate/src/main.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { TranslateTool } from '@mast-ai/built-in-ai';
+
+const tool = new TranslateTool({
+  onDownloadProgress: ({ loaded, total, sourceLanguage, targetLanguage }) => {
+    const pct = total > 0 ? Math.round((loaded / total) * 100) : 0;
+    setProgress(`Downloading ${sourceLanguage}→${targetLanguage} model… ${pct}%`);
+  },
+});
+
+// ── DOM refs ──────────────────────────────────────────────────────────────
+
+const form       = document.getElementById('translate-form') as HTMLFormElement;
+const sourceLang = document.getElementById('source-lang')    as HTMLSelectElement;
+const targetLang = document.getElementById('target-lang')    as HTMLSelectElement;
+const swapBtn    = document.getElementById('swap-btn')       as HTMLButtonElement;
+const sourceText = document.getElementById('source-text')    as HTMLTextAreaElement;
+const result     = document.getElementById('result')         as HTMLDivElement;
+const statusEl   = document.getElementById('api-status')     as HTMLDivElement;
+const progressEl = document.getElementById('progress-msg')   as HTMLSpanElement;
+const errorEl    = document.getElementById('error-msg')      as HTMLDivElement;
+const submitBtn  = document.getElementById('translate-btn')  as HTMLButtonElement;
+
+// ── Availability ──────────────────────────────────────────────────────────
+
+function isGlobal(name: string) {
+  return typeof (globalThis as Record<string, unknown>)[name] !== 'undefined';
+}
+
+if (isGlobal('Translator')) {
+  statusEl.textContent = 'Translator API available';
+  statusEl.className = 'status available';
+} else {
+  statusEl.textContent = 'Translator API not supported in this browser';
+  statusEl.className = 'status unavailable';
+  submitBtn.disabled = true;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function setProgress(msg: string) {
+  progressEl.textContent = msg;
+  progressEl.classList.remove('hidden');
+}
+
+function clearProgress() {
+  progressEl.classList.add('hidden');
+  progressEl.textContent = '';
+}
+
+function showError(msg: string) {
+  errorEl.textContent = msg;
+  errorEl.classList.remove('hidden');
+}
+
+function clearError() {
+  errorEl.classList.add('hidden');
+  errorEl.textContent = '';
+}
+
+// ── Swap button ───────────────────────────────────────────────────────────
+
+swapBtn.addEventListener('click', () => {
+  const tmp = sourceLang.value;
+  sourceLang.value = targetLang.value;
+  targetLang.value = tmp;
+});
+
+// ── Form submit ───────────────────────────────────────────────────────────
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const text = sourceText.value.trim();
+  if (!text) return;
+
+  clearError();
+  clearProgress();
+  result.textContent = '';
+  submitBtn.disabled = true;
+
+  try {
+    const translation = await tool.call(
+      { text, sourceLanguage: sourceLang.value, targetLanguage: targetLang.value },
+      {},
+    );
+    result.textContent = String(translation);
+  } catch (err) {
+    showError(err instanceof Error ? err.message : String(err));
+  } finally {
+    clearProgress();
+    submitBtn.disabled = false;
+  }
+});

--- a/apps/demo-translate/src/style.css
+++ b/apps/demo-translate/src/style.css
@@ -1,0 +1,182 @@
+:root {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #1a1a1a;
+  --primary: #3b82f6;
+  --primary-dark: #2563eb;
+  --bg: #f4f4f5;
+  --border: #e4e4e7;
+  --muted: #71717a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: var(--bg);
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin: 0 0 0.375rem;
+  font-size: 1.75rem;
+}
+
+header p {
+  margin: 0 0 1rem;
+  color: var(--muted);
+}
+
+code {
+  font-size: 0.9em;
+  background: #e4e4e7;
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+/* Status badge */
+.status {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+}
+.status.checking  { background: #fef9c3; color: #854d0e; }
+.status.available { background: #dcfce7; color: #166534; }
+.status.unavailable { background: #fee2e2; color: #991b1b; }
+
+/* Card */
+main {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.75rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Language row */
+.lang-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+select, textarea {
+  font-family: inherit;
+  font-size: 0.95rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  background: #fff;
+  color: inherit;
+  width: 100%;
+}
+
+select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(59,130,246,0.15);
+}
+
+#swap-btn {
+  padding: 0.5rem 0.875rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: inherit;
+  flex-shrink: 0;
+  align-self: flex-end;
+}
+#swap-btn:hover { background: var(--border); }
+
+/* Side-by-side panels */
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+textarea {
+  resize: vertical;
+  line-height: 1.6;
+}
+
+.result-box {
+  min-height: 176px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  color: #374151;
+  background: var(--bg);
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+button[type="submit"] {
+  padding: 0.6rem 1.5rem;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+button[type="submit"]:hover   { background: var(--primary-dark); }
+button[type="submit"]:disabled { background: #93c5fd; cursor: not-allowed; }
+
+.progress {
+  font-size: 0.85rem;
+  color: var(--primary);
+}
+
+.error {
+  font-size: 0.875rem;
+  color: #991b1b;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  padding: 0.625rem 0.875rem;
+}
+
+.hidden { display: none; }

--- a/apps/demo-translate/tsconfig.json
+++ b/apps/demo-translate/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/docs/BUILT_IN_AI_PHASE4.md
+++ b/docs/BUILT_IN_AI_PHASE4.md
@@ -1,0 +1,327 @@
+# Built-in AI — Phase 4: Translation Tool
+
+## Goal
+
+Implement a `translate` MAST `Tool` backed by the browser's Translator API, and add it to the `@mast-ai/built-in-ai` package. Any agent — regardless of which `LlmAdapter` it uses — can register this tool to translate text on-device between supported language pairs.
+
+---
+
+## Reference
+
+Use `packages/built-in-ai/src/tools/detectLanguage.ts` as the structural reference for copyright header, import style, `AdapterError` usage, and the `addToRegistry` / `call()` pattern.
+
+The `Tool` interface to implement lives in `packages/core/src/tool.ts`:
+
+```typescript
+export interface Tool<TArgs = unknown, TResult = unknown> {
+  definition(): ToolDefinition;
+  call(args: TArgs, context: ToolContext): Promise<TResult>;
+}
+```
+
+`ToolContext` carries an optional `AbortSignal`:
+
+```typescript
+export interface ToolContext {
+  signal?: AbortSignal;
+}
+```
+
+---
+
+## Translator API Overview
+
+The Translator API exposes on-device translation via the `Translator` bare global.
+
+```typescript
+// Check availability for a specific language pair
+const availability = await Translator.availability({ sourceLanguage, targetLanguage });
+// → "readily" | "after-download" | "downloading" | "unavailable"
+
+// Create a translator (language pair is baked in at creation time)
+const translator = await Translator.create({ sourceLanguage, targetLanguage, signal?, monitor? });
+
+// Translate (blocking)
+const result = await translator.translate(text, { signal? });
+
+// Free resources
+translator.destroy();
+```
+
+### Creation options
+
+| Option | Type | Notes |
+|--------|------|-------|
+| `sourceLanguage` | `string` | BCP 47 language tag (e.g. `"en"`, `"fr"`) |
+| `targetLanguage` | `string` | BCP 47 language tag |
+| `signal` | `AbortSignal` | Cancels session creation |
+| `monitor` | `(m: EventTarget) => void` | Download progress |
+
+### Per-call options
+
+| Option | Type | Notes |
+|--------|------|-------|
+| `signal` | `AbortSignal` | Cancels this call |
+
+### Key design constraint
+
+The `sourceLanguage` and `targetLanguage` are **baked into the translator instance at creation time**. Unlike the Summarizer (which has one default session that can be recreated if options change), the Translator has no meaningful default language pair to pre-warm. Sessions must be created lazily, on first use for each language pair. The tool caches one session per `sourceLanguage:targetLanguage` pair and reuses it across calls.
+
+---
+
+## Tool Design
+
+### Input schema
+
+```typescript
+export interface TranslateArgs {
+  text: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+```
+
+### Output
+
+The tool returns the translated text as a plain `string`.
+
+### Tool name
+
+`"translate"`
+
+### Tool description
+
+`"Translate a piece of text from one language to another using an on-device AI model. Languages are specified as BCP 47 tags (e.g. 'en', 'fr', 'ja')."`
+
+### `definition()` parameters JSON Schema
+
+```typescript
+{
+  type: 'object',
+  properties: {
+    text:           { type: 'string', description: 'The text to translate.' },
+    sourceLanguage: { type: 'string', description: 'BCP 47 language tag of the source language (e.g. "en").' },
+    targetLanguage: { type: 'string', description: 'BCP 47 language tag of the target language (e.g. "fr").' },
+  },
+  required: ['text', 'sourceLanguage', 'targetLanguage'],
+}
+```
+
+---
+
+## Implementation: `TranslateTool`
+
+The tool is implemented as a class. Consumers never instantiate it directly — they call the static `TranslateTool.addToRegistry()` method.
+
+```typescript
+// packages/built-in-ai/src/tools/translate.ts
+
+export interface TranslateToolOptions {
+  onDownloadProgress?: (progress: { loaded: number; total: number }) => void;
+}
+
+export class TranslateTool implements Tool<TranslateArgs, string> {
+  static async addToRegistry(
+    registry: ToolRegistry,
+    options?: TranslateToolOptions,
+  ): Promise<void> { ... }
+
+  definition(): ToolDefinition { ... }
+  call(args: TranslateArgs, context: ToolContext): Promise<string> { ... }
+}
+```
+
+### `addToRegistry` — availability and registration
+
+Because the Translator API requires a specific language pair to check availability, there is no meaningful session to pre-warm at registration time. `addToRegistry` only verifies the global exists and registers the tool immediately.
+
+**Step 1 — API existence check:**
+```typescript
+if (typeof Translator === 'undefined') {
+  throw new AdapterError('Translator API is not supported in this browser.');
+}
+```
+
+**Step 2 — Register.** If the check passes, construct a new `TranslateTool` (passing through `options` for later use in `call()`) and call `registry.register(tool)`. The returned `Promise<void>` resolves immediately after registration.
+
+Unlike `SummarizeTool`, there is no `"unavailable"` guard at registration time — language pair availability is checked lazily in `call()`.
+
+### Session caching in `call()`
+
+`call()` also guards against the API being absent:
+
+```typescript
+if (typeof Translator === 'undefined') {
+  throw new AdapterError('Translator API is not supported in this browser.');
+}
+```
+
+Maintain a `Map<string, TranslatorSession>` keyed on `"${sourceLanguage}:${targetLanguage}"`. On each `call()`:
+
+1. Look up the cache key. If a session exists, reuse it.
+2. If no session exists:
+   a. Check availability for the language pair via `Translator.availability({ sourceLanguage, targetLanguage })`.
+   b. If `"unavailable"`, throw `AdapterError('Translation from <src> to <tgt> is not available on this device.')`.
+   c. Otherwise call `Translator.create({ sourceLanguage, targetLanguage, signal: context.signal, monitor })` where `monitor` is built from `this.options?.onDownloadProgress` (same pattern as `DetectLanguageTool`).
+   d. Store the created session in the cache.
+3. Call `session.translate(args.text, { signal: context.signal })` and return the result.
+
+### AbortSignal
+
+Pass `context.signal` to both `Translator.create()` and `session.translate()`. Note that when the signal aborts during `create()`, the cache entry is never written, so the next call for the same language pair will retry creation.
+
+---
+
+## TypeScript Types (`types.ts` additions)
+
+The Translator API is not in `lib.dom.d.ts`. Add the following to `packages/built-in-ai/src/types.ts`:
+
+```typescript
+export type TranslatorAvailability =
+  | "readily"
+  | "after-download"
+  | "downloading"
+  | "unavailable";
+
+export interface TranslatorAvailabilityOptions {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+export interface TranslatorCreateOptions {
+  sourceLanguage: string;
+  targetLanguage: string;
+  signal?: AbortSignal;
+  monitor?: (monitor: EventTarget) => void;
+}
+
+export interface TranslatorCallOptions {
+  signal?: AbortSignal;
+}
+
+export interface TranslatorSession {
+  translate(text: string, options?: TranslatorCallOptions): Promise<string>;
+  destroy(): void;
+}
+
+declare global {
+  const Translator: {
+    availability(options: TranslatorAvailabilityOptions): Promise<TranslatorAvailability>;
+    create(options: TranslatorCreateOptions): Promise<TranslatorSession>;
+  };
+}
+```
+
+---
+
+## Testing (`translate.test.ts`)
+
+The Translator API only exists in supporting browsers; tests must mock it via `vi.stubGlobal`.
+
+### Cases to cover
+
+| Case | Expected behaviour |
+|------|--------------------|
+| `addToRegistry` — `Translator` global absent | Rejects with `AdapterError`; tool not registered |
+| `addToRegistry` — global present | Resolves; tool is registered immediately (no session created yet) |
+| `call()` — `Translator` global absent | Rejects with `AdapterError` |
+| `call()` — pair `"unavailable"` | Rejects with `AdapterError` mentioning the language pair; no session created |
+| `call()` — pair `"readily"` | `Translator.create` called once; returns translated string |
+| `call()` — pair `"after-download"` | `Translator.create` called with monitor; returns translated string after mock create resolves |
+| `onDownloadProgress` callback | Mock `downloadprogress` event fires; callback receives `{ loaded, total }` |
+| `call()` — same pair called twice | `Translator.create` called only once; session reused |
+| `call()` — different pairs | `Translator.create` called once per unique pair; both sessions cached |
+| `call()` — `context.signal` forwarded | Mock verifies signal passed to both `create()` and `translate()` |
+| `call()` — `translate()` throws | Error propagates from `call()` |
+| `call()` — `create()` aborted | Session not cached; subsequent call retries `create()` |
+
+---
+
+## Package Structure Changes
+
+```
+packages/built-in-ai/src/
+├── index.ts                  ← updated exports
+├── BuiltInAIAdapter.ts       (unchanged)
+├── BuiltInAIAdapter.test.ts  (unchanged)
+├── types.ts                  ← Translator types added
+└── tools/
+    ├── index.ts              ← TranslateTool added to addAllBuiltInAITools
+    ├── summarize.ts          (unchanged)
+    ├── summarize.test.ts     (unchanged)
+    ├── detectLanguage.ts     (unchanged)
+    ├── detectLanguage.test.ts (unchanged)
+    ├── translate.ts          ← new
+    └── translate.test.ts     ← new
+```
+
+---
+
+## `index.ts` Export Updates
+
+```typescript
+// Phase 4 additions
+export { TranslateTool } from './tools/translate.js';
+export type { TranslateToolOptions } from './tools/translate.js';
+```
+
+### `tools/index.ts` changes
+
+Add `TranslateTool` to the `Promise.allSettled` call in `addAllBuiltInAITools`:
+
+```typescript
+import { TranslateTool } from './translate.js';
+
+// Inside addAllBuiltInAITools:
+TranslateTool.addToRegistry(registry, {
+  onDownloadProgress: options?.onDownloadProgress
+    ? (p) => options.onDownloadProgress!('translate', p)
+    : undefined,
+}),
+```
+
+---
+
+## Sample Usage
+
+```typescript
+import { TranslateTool } from '@mast-ai/built-in-ai';
+import { ToolRegistry } from '@mast-ai/core';
+
+const registry = new ToolRegistry();
+
+// Registers immediately — no session created until first call
+await TranslateTool.addToRegistry(registry);
+
+// With download progress reporting for new language pairs
+await TranslateTool.addToRegistry(registry, {
+  onDownloadProgress: ({ loaded, total }) => {
+    console.log(`Downloading translation model: ${loaded}/${total} bytes`);
+  },
+});
+
+// Language pair unavailable — rejects at call time, not registration time
+try {
+  await runner.run('Translate "hello" from en to xx');
+} catch (err) {
+  // AdapterError: Translation from en to xx is not available on this device.
+}
+
+// Bulk registration
+import { addAllBuiltInAITools } from '@mast-ai/built-in-ai';
+await addAllBuiltInAITools(registry);
+```
+
+---
+
+## Files to Create / Modify
+
+| Path | Action |
+|------|--------|
+| `packages/built-in-ai/src/types.ts` | Add Translator API types |
+| `packages/built-in-ai/src/tools/translate.ts` | Create |
+| `packages/built-in-ai/src/tools/translate.test.ts` | Create |
+| `packages/built-in-ai/src/tools/index.ts` | Add `TranslateTool` to `addAllBuiltInAITools` |
+| `packages/built-in-ai/src/index.ts` | Add `TranslateTool` and `TranslateToolOptions` exports |
+
+---

--- a/packages/built-in-ai/src/index.ts
+++ b/packages/built-in-ai/src/index.ts
@@ -9,5 +9,7 @@ export { SummarizeTool } from './tools/summarize.js';
 export type { SummarizeToolOptions, SummarizeArgs } from './tools/summarize.js';
 export { DetectLanguageTool } from './tools/detectLanguage.js';
 export type { DetectLanguageToolOptions, DetectLanguageArgs } from './tools/detectLanguage.js';
+export { TranslateTool } from './tools/translate.js';
+export type { TranslateToolOptions, TranslateArgs } from './tools/translate.js';
 export { addAllBuiltInAITools } from './tools/index.js';
 export type { AddAllBuiltInAIToolsOptions } from './tools/index.js';

--- a/packages/built-in-ai/src/tools/index.ts
+++ b/packages/built-in-ai/src/tools/index.ts
@@ -32,5 +32,11 @@ export async function addAllBuiltInAITools(
         ? (p) => options.onDownloadProgress!("detectLanguage", p)
         : undefined,
     }),
+    // TranslateTool disabled: Translator API crashes in Chrome as of 2026-04-22.
+    // TranslateTool.addToRegistry(registry, {
+    //   onDownloadProgress: options?.onDownloadProgress
+    //     ? (p) => options.onDownloadProgress!("translate", p)
+    //     : undefined,
+    // }),
   ]);
 }

--- a/packages/built-in-ai/src/tools/translate.test.ts
+++ b/packages/built-in-ai/src/tools/translate.test.ts
@@ -1,0 +1,224 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TranslateTool } from "./translate.js";
+import { ToolRegistry } from "@mast-ai/core";
+import type { TranslatorSession } from "../types.js";
+
+function makeSession(overrides: Partial<TranslatorSession> = {}): TranslatorSession {
+  return {
+    translate: vi.fn().mockResolvedValue("translated text"),
+    destroy: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockCreate = vi.fn();
+const mockAvailability = vi.fn();
+
+vi.stubGlobal("Translator", {
+  create: mockCreate,
+  availability: mockAvailability,
+});
+
+describe("TranslateTool", () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.mockResolvedValue("readily");
+    mockCreate.mockResolvedValue(makeSession());
+    registry = new ToolRegistry();
+  });
+
+  describe("addToRegistry", () => {
+    it("rejects with AdapterError when Translator global is absent", async () => {
+      vi.stubGlobal("Translator", undefined);
+
+      await expect(TranslateTool.addToRegistry(registry)).rejects.toThrow(
+        "not supported in this browser",
+      );
+      expect(registry.definitions()).toHaveLength(0);
+
+      vi.stubGlobal("Translator", { create: mockCreate, availability: mockAvailability });
+    });
+
+    it("registers the tool immediately without creating a session", async () => {
+      await TranslateTool.addToRegistry(registry);
+
+      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.definitions()[0].name).toBe("translate");
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("call()", () => {
+    it("rejects with AdapterError when Translator global is absent", async () => {
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      vi.stubGlobal("Translator", undefined);
+      await expect(
+        tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {}),
+      ).rejects.toThrow("not supported in this browser");
+
+      vi.stubGlobal("Translator", { create: mockCreate, availability: mockAvailability });
+    });
+
+    it("rejects with AdapterError when the language pair is unavailable", async () => {
+      mockAvailability.mockResolvedValue("unavailable");
+
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      await expect(
+        tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "xx" }, {}),
+      ).rejects.toThrow("Translation from en to xx is not available on this device.");
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("resolves with translated string when pair is readily available", async () => {
+      const session = makeSession({ translate: vi.fn().mockResolvedValue("bonjour") });
+      mockCreate.mockResolvedValue(session);
+
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      const result = await tool.call(
+        { text: "hello", sourceLanguage: "en", targetLanguage: "fr" },
+        {},
+      );
+      expect(result).toBe("bonjour");
+    });
+
+    it("creates a session with monitor when pair is after-download", async () => {
+      mockAvailability.mockResolvedValue("after-download");
+      const onDownloadProgress = vi.fn();
+
+      await TranslateTool.addToRegistry(registry, { onDownloadProgress });
+      const tool = registry.get("translate")!;
+
+      await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
+
+      const createOpts = mockCreate.mock.calls[0][0];
+      expect(typeof createOpts.monitor).toBe("function");
+    });
+
+    it("fires onDownloadProgress callback when downloadprogress event fires", async () => {
+      mockAvailability.mockResolvedValue("after-download");
+
+      let capturedMonitor: EventTarget | null = null;
+      mockCreate.mockImplementation(
+        async (opts: { monitor?: (m: EventTarget) => void }) => {
+          if (opts?.monitor) {
+            const et = new EventTarget();
+            opts.monitor(et);
+            capturedMonitor = et;
+          }
+          return makeSession();
+        },
+      );
+
+      const onDownloadProgress = vi.fn();
+      await TranslateTool.addToRegistry(registry, { onDownloadProgress });
+      const tool = registry.get("translate")!;
+
+      await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
+
+      const evt = Object.assign(new Event("downloadprogress"), { loaded: 50, total: 100 });
+      capturedMonitor!.dispatchEvent(evt);
+
+      expect(onDownloadProgress).toHaveBeenCalledWith({
+        loaded: 50,
+        total: 100,
+        sourceLanguage: "en",
+        targetLanguage: "fr",
+      });
+    });
+
+    it("reuses a cached session for the same language pair", async () => {
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
+      await tool.call({ text: "world", sourceLanguage: "en", targetLanguage: "fr" }, {});
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates separate sessions for different language pairs", async () => {
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
+      await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "ja" }, {});
+
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      expect(mockCreate.mock.calls[0][0]).toMatchObject({
+        sourceLanguage: "en",
+        targetLanguage: "fr",
+      });
+      expect(mockCreate.mock.calls[1][0]).toMatchObject({
+        sourceLanguage: "en",
+        targetLanguage: "ja",
+      });
+    });
+
+    it("forwards context.signal to create() and translate()", async () => {
+      const session = makeSession();
+      mockCreate.mockResolvedValue(session);
+
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      const controller = new AbortController();
+      await tool.call(
+        { text: "hello", sourceLanguage: "en", targetLanguage: "fr" },
+        { signal: controller.signal },
+      );
+
+      expect(mockCreate.mock.calls[0][0]).toMatchObject({ signal: controller.signal });
+      expect(session.translate).toHaveBeenCalledWith(
+        "hello",
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it("does not cache session when create() is aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      mockCreate.mockRejectedValue(new DOMException("Aborted", "AbortError"));
+
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      await expect(
+        tool.call(
+          { text: "hello", sourceLanguage: "en", targetLanguage: "fr" },
+          { signal: controller.signal },
+        ),
+      ).rejects.toThrow();
+
+      // Second call should retry create()
+      mockCreate.mockResolvedValue(makeSession());
+      await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates error thrown by translate()", async () => {
+      const session = makeSession({
+        translate: vi.fn().mockRejectedValue(new Error("translate failed")),
+      });
+      mockCreate.mockResolvedValue(session);
+
+      await TranslateTool.addToRegistry(registry);
+      const tool = registry.get("translate")!;
+
+      await expect(
+        tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {}),
+      ).rejects.toThrow("translate failed");
+    });
+  });
+});

--- a/packages/built-in-ai/src/tools/translate.ts
+++ b/packages/built-in-ai/src/tools/translate.ts
@@ -1,0 +1,139 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AdapterError } from "@mast-ai/core";
+import type { Tool, ToolDefinition, ToolContext, ToolRegistry } from "@mast-ai/core";
+import type { TranslatorSession } from "../types.js";
+
+/** Arguments passed by the model when invoking the `translate` tool. */
+export interface TranslateArgs {
+  /** The text to translate. */
+  text: string;
+  /** BCP 47 language tag of the source language (e.g. `"en"`). */
+  sourceLanguage: string;
+  /** BCP 47 language tag of the target language (e.g. `"fr"`). */
+  targetLanguage: string;
+}
+
+/** Options for {@link TranslateTool}. */
+export interface TranslateToolOptions {
+  /** Called during model download for a new language pair with the pair and bytes loaded / total. */
+  onDownloadProgress?: (progress: {
+    loaded: number;
+    total: number;
+    sourceLanguage: string;
+    targetLanguage: string;
+  }) => void;
+}
+
+/**
+ * {@link Tool} that translates text between languages using the browser's
+ * Translator API.
+ *
+ * Use {@link TranslateTool.addToRegistry} to register the tool — direct
+ * construction is not recommended. Sessions are created lazily per language
+ * pair on first use and cached for subsequent calls.
+ */
+export class TranslateTool implements Tool<TranslateArgs, string> {
+  private sessions = new Map<string, TranslatorSession>();
+
+  constructor(private readonly options?: TranslateToolOptions) {}
+
+  /**
+   * Registers a `TranslateTool` instance into `registry`.
+   *
+   * Throws immediately if the Translator API global is absent. No session is
+   * created at registration time — sessions are created lazily in `call()`.
+   */
+  static async addToRegistry(
+    registry: ToolRegistry,
+    options?: TranslateToolOptions,
+  ): Promise<void> {
+    if (typeof Translator === "undefined") {
+      throw new AdapterError("Translator API is not supported in this browser.");
+    }
+
+    registry.register(new TranslateTool(options));
+  }
+
+  /** {@inheritDoc Tool.definition} */
+  definition(): ToolDefinition {
+    return {
+      name: "translate",
+      description:
+        "Translate a piece of text from one language to another using an on-device AI model. " +
+        "Languages are specified as BCP 47 tags (e.g. 'en', 'fr', 'ja').",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: "The text to translate.",
+          },
+          sourceLanguage: {
+            type: "string",
+            description: 'BCP 47 language tag of the source language (e.g. "en").',
+          },
+          targetLanguage: {
+            type: "string",
+            description: 'BCP 47 language tag of the target language (e.g. "fr").',
+          },
+        },
+        required: ["text", "sourceLanguage", "targetLanguage"],
+      },
+    };
+  }
+
+  /** {@inheritDoc Tool.call} */
+  async call(args: TranslateArgs, context: ToolContext): Promise<string> {
+    if (typeof Translator === "undefined") {
+      throw new AdapterError("Translator API is not supported in this browser.");
+    }
+
+    const session = await this.acquireSession(args.sourceLanguage, args.targetLanguage, context);
+    return session.translate(args.text, { signal: context.signal });
+  }
+
+  private async acquireSession(
+    sourceLanguage: string,
+    targetLanguage: string,
+    context: ToolContext,
+  ): Promise<TranslatorSession> {
+    const key = `${sourceLanguage}:${targetLanguage}`;
+    const cached = this.sessions.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const availability = await Translator.availability({ sourceLanguage, targetLanguage });
+    if (availability === "unavailable") {
+      throw new AdapterError(
+        `Translation from ${sourceLanguage} to ${targetLanguage} is not available on this device.`,
+      );
+    }
+
+    const monitor = this.options?.onDownloadProgress
+      ? (m: EventTarget) => {
+          m.addEventListener("downloadprogress", (e) => {
+            const evt = e as ProgressEvent;
+            this.options!.onDownloadProgress!({
+              loaded: evt.loaded,
+              total: evt.total,
+              sourceLanguage,
+              targetLanguage,
+            });
+          });
+        }
+      : undefined;
+
+    const session = await Translator.create({
+      sourceLanguage,
+      targetLanguage,
+      signal: context.signal,
+      monitor,
+    });
+
+    this.sessions.set(key, session);
+    return session;
+  }
+}

--- a/packages/built-in-ai/src/types.ts
+++ b/packages/built-in-ai/src/types.ts
@@ -157,3 +157,50 @@ declare global {
     create(options?: LanguageDetectorCreateOptions): Promise<LanguageDetectorSession>;
   };
 }
+
+/**
+ * Availability status of the on-device Translator API for a given language pair.
+ *
+ * - `"readily"` — ready to use immediately.
+ * - `"after-download"` — must be downloaded before use.
+ * - `"downloading"` — download is in progress.
+ * - `"unavailable"` — not supported on this device or browser.
+ */
+export type TranslatorAvailability =
+  | "readily"
+  | "after-download"
+  | "downloading"
+  | "unavailable";
+
+/** Options for checking Translator availability for a specific language pair. */
+export interface TranslatorAvailabilityOptions {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+/** Options accepted by `Translator.create`. */
+export interface TranslatorCreateOptions {
+  sourceLanguage: string;
+  targetLanguage: string;
+  signal?: AbortSignal;
+  /** Callback invoked with a download progress monitor target. */
+  monitor?: (monitor: EventTarget) => void;
+}
+
+/** Per-call options passed to `TranslatorSession.translate`. */
+export interface TranslatorCallOptions {
+  signal?: AbortSignal;
+}
+
+/** A live session obtained from `Translator.create`. */
+export interface TranslatorSession {
+  translate(text: string, options?: TranslatorCallOptions): Promise<string>;
+  destroy(): void;
+}
+
+declare global {
+  const Translator: {
+    availability(options: TranslatorAvailabilityOptions): Promise<TranslatorAvailability>;
+    create(options: TranslatorCreateOptions): Promise<TranslatorSession>;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `TranslateTool` implementing the MAST `Tool` interface via the browser's Translator API
- Sessions are created lazily and cached per `sourceLanguage:targetLanguage` pair to avoid redundant downloads
- `onDownloadProgress` callback includes `sourceLanguage` and `targetLanguage` so callers know which pair triggered the download
- `TranslateTool` is disabled in `addAllBuiltInAITools` — the Translator API is currently crashing in Chrome (as of 2026-04-22); the implementation is complete and will be re-enabled once the API stabilises
- Adds `apps/demo-translate`: a self-contained Vite app demonstrating on-device translation in the browser
- Adds `docs/BUILT_IN_AI_PHASE4.md` implementation plan

## Test plan

- [ ] Run `npm test` in `packages/built-in-ai` — all 53 tests pass (12 new for TranslateTool)
- [ ] Build packages: `npm run build -w packages/core -w packages/built-in-ai`
- [ ] Run `npm run dev` in `apps/demo-translate` and open in Chrome with Translator API enabled; verify translation works and download progress appears for new language pairs