### PR TITLE
docs: update README and skills to reflect current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Traditional agent frameworks are server-centric, making it difficult for agents 
 
 This project is an npm workspace containing the core library and several demo applications:
 
-* `packages/core/` — The main MAST TypeScript library (`AgentRunner`, `RunBuilder`, Adapters, Types).
-* `packages/google-genai/` — `LlmAdapter` backed by the Google Generative AI SDK (Gemini models).
-* `packages/built-in-ai/` — `LlmAdapter` backed by the browser's Prompt API for fully on-device inference (no network requests).
+* `packages/core/` — The main MAST TypeScript library (`AgentRunner`, `RunBuilder`, `Conversation`, Adapters, Types).
+* `packages/google-genai/` — `LlmAdapter` backed by the Google Generative AI SDK (`GoogleGenAIAdapter` for Gemini models with tool calling, streaming, and thinking mode).
+* `packages/built-in-ai/` — `LlmAdapter` for fully on-device inference via the browser Prompt API (`BuiltInAIAdapter`), plus browser-native tools: `SummarizeTool`, `DetectLanguageTool`, and `TranslateTool`.
 * `apps/demo-basic-chat/` — A Vite-powered frontend demonstrating a Hybrid Mode chat agent with local tools.
 * `apps/demo-prompt-api/` — A Vite-powered frontend demonstrating on-device inference via the browser Prompt API.
+* `apps/demo-summarizer/` — A Vite-powered frontend demonstrating the `SummarizeTool` backed by the browser Summarizer API.
+* `apps/demo-translate/` — A Vite-powered frontend demonstrating the `TranslateTool` backed by the browser Translator API.
 * `apps/demo-rust-server/` — A sample URP reasoning engine backend written in Rust (Axum + async channels).
 
 ## Getting Started

--- a/skills/mast-ai/SKILL.md
+++ b/skills/mast-ai/SKILL.md
@@ -13,16 +13,17 @@ This skill provides expert guidance for implementing AI agents using the MAST li
 - **ToolRegistry**: Registers standard TypeScript functions that have direct, synchronous access to the browser's DOM, `localStorage`, etc.
 - **Adapters**: Connect the agent to a reasoning engine. 
   - `UrpAdapter` connects to a remote backend (Hybrid Mode).
-  - **Planned**: `PromptApiAdapter` for the Chrome Prompt API.
-  - **Custom**: Implement `LlmAdapter` for Google AI SDK, Transformers.js, etc.
+  - `GoogleGenAIAdapter` (`@mast-ai/google-genai`) calls the Gemini API directly with tool calling, streaming, and thinking mode.
+  - `BuiltInAIAdapter` (`@mast-ai/built-in-ai`) runs inference fully on-device via the browser Prompt API (no tool calling).
+  - **Custom**: Implement `LlmAdapter` for other providers (Transformers.js, MediaPipe, etc.).
 
 ## Component References
 
 When implementing MAST features, consult these references for API details and patterns:
 
 - **Core API & Agent Configuration**: See [references/core-api.md](references/core-api.md) for `AgentConfig`, `AgentRunner`, `ToolRegistry`, and `Conversation`.
-- **Adapters (URP & Custom)**: See [references/adapters.md](references/adapters.md) for configuring HTTP/WebSocket transports and information on custom implementations.
-- **Custom Adapters**: See [references/custom-adapters.md](references/custom-adapters.md) for implementing your own `LlmAdapter` using Google AI SDK, Transformers.js, etc.
+- **Adapters**: See [references/adapters.md](references/adapters.md) for `UrpAdapter` (HTTP transport), `GoogleGenAIAdapter`, and `BuiltInAIAdapter` with its built-in browser tools.
+- **Custom Adapters**: See [references/custom-adapters.md](references/custom-adapters.md) for implementing your own `LlmAdapter` using Transformers.js, MediaPipe, etc.
 - **Protocols (URP & ACP)**: See [references/protocols.md](references/protocols.md) if implementing a backend reasoning engine in Rust, Go, or Python.
 
 ## Installation

--- a/skills/mast-ai/references/adapters.md
+++ b/skills/mast-ai/references/adapters.md
@@ -4,31 +4,78 @@ Adapters implement the `LlmAdapter` interface to connect the `AgentRunner` to an
 
 ## UrpAdapter (Hybrid Mode)
 
-Connects to a remote Universal Remote Protocol (URP) server. Requires a transport layer.
+Connects to a remote Universal Remote Protocol (URP) server via `HttpTransport`.
 
 ```typescript
-import { UrpAdapter, HttpTransport, WebSocketTransport } from '@mast-ai/core';
+import { UrpAdapter, HttpTransport } from '@mast-ai/core';
 
-// HTTP Transport
-const httpTransport = new HttpTransport({ 
+const transport = new HttpTransport({ 
   url: 'http://localhost:3000/api/chat',
-  headers: { 'Authorization': 'Bearer ...' }
+  headers: { 'Authorization': 'Bearer ...' }  // optional
 });
-const httpAdapter = new UrpAdapter(httpTransport);
-
-// WebSocket Transport
-const wsTransport = new WebSocketTransport({ 
-  url: 'ws://localhost:3000/api/chat/ws' 
-});
-const wsAdapter = new UrpAdapter(wsTransport);
+const adapter = new UrpAdapter(transport);
 ```
 
-## PromptApiAdapter (Planned)
+## GoogleGenAIAdapter
 
-The `PromptApiAdapter` for the Chrome Prompt API (Gemini Nano) is currently in the project roadmap but not yet implemented in the core library.
+Calls the Gemini API directly from the browser. Supports tool calling, structured output, streaming, and thinking mode (enabled by default at `ThinkingLevel.HIGH`).
+
+```typescript
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+
+const adapter = new GoogleGenAIAdapter(
+  'YOUR_API_KEY',
+  'gemini-3.1-flash-lite-preview',  // optional, this is the default
+  (usage) => console.log('Tokens used:', usage)  // optional usage callback
+);
+```
+
+## BuiltInAIAdapter (On-device)
+
+Runs inference fully on-device via the browser Prompt API (no network requests). Does not support tool calling — `toolCalls` is always empty.
+
+```typescript
+import { BuiltInAIAdapter, checkAvailability } from '@mast-ai/built-in-ai';
+
+const availability = await checkAvailability();
+// availability: 'readily' | 'after-download' | 'downloading' | 'unavailable'
+
+const adapter = new BuiltInAIAdapter({
+  onDownloadProgress: (progress) => console.log(progress)  // optional
+});
+```
+
+## Built-in AI Browser Tools (`@mast-ai/built-in-ai`)
+
+These tools wrap browser-native APIs and can be registered alongside any adapter.
+
+```typescript
+import { 
+  SummarizeTool, 
+  DetectLanguageTool, 
+  TranslateTool, 
+  addAllBuiltInAITools 
+} from '@mast-ai/built-in-ai';
+import { ToolRegistry } from '@mast-ai/core';
+
+const registry = new ToolRegistry();
+
+// Register individually
+await SummarizeTool.addToRegistry(registry);
+await DetectLanguageTool.addToRegistry(registry);
+await TranslateTool.addToRegistry(registry);
+
+// Or register all at once
+await addAllBuiltInAITools(registry);
+```
+
+Tool arguments:
+- **SummarizeTool**: `{ text, type?, format?, length?, context? }` → `string`
+- **DetectLanguageTool**: `{ text }` → `{ detectedLanguage: string | null, confidence: number }`
+- **TranslateTool**: `{ text, sourceLanguage, targetLanguage }` → `string`
 
 ## Custom Adapters
 
-For developers who wish to use other LLM providers (e.g., Google AI SDK, Transformers.js, MediaPipe), MAST provides the `LlmAdapter` interface. 
+For other LLM providers (Transformers.js, MediaPipe, etc.), implement the `LlmAdapter` interface.
 
-See [references/custom-adapters.md](custom-adapters.md) for a detailed implementation guide and boilerplate.
+See [references/custom-adapters.md](custom-adapters.md) for a detailed implementation guide.

--- a/skills/mast-ai/references/core-api.md
+++ b/skills/mast-ai/references/core-api.md
@@ -77,14 +77,3 @@ const result = await conv.run('Hello!');
 // conv.history is automatically updated.
 ```
 
-## Sub-Agents (AgentTool)
-
-Wrap an entire agent as a tool using `AgentTool` and `localAgent` or `AcpAgent`.
-
-```typescript
-const childRunner = new AgentRunner(new PromptApiAdapter());
-const classifyTool = new AgentTool(
-  { name: 'classify', description: '...', parameters: { ... } },
-  localAgent(childAgentConfig, childRunner)
-);
-```


### PR DESCRIPTION
## Summary

- Add `demo-summarizer` and `demo-translate` to the monorepo app list in README
- Update `@mast-ai/built-in-ai` description to name `SummarizeTool`, `DetectLanguageTool`, and `TranslateTool`
- Update `@mast-ai/google-genai` description to name `GoogleGenAIAdapter` and its capabilities
- Replace the planned `PromptApiAdapter` note with the actual `GoogleGenAIAdapter` and `BuiltInAIAdapter` entries in the skill
- Rewrite `adapters.md` skill reference: remove non-existent `WebSocketTransport`, add real adapter sections and built-in tool API docs
- Remove `AgentTool`/`localAgent`/`AcpAgent` sub-agents section from `core-api.md` (not implemented)

## Test plan

- [ ] Review README monorepo structure section matches the actual `apps/` and `packages/` directories
- [ ] Review `skills/mast-ai/references/adapters.md` examples compile against current package exports