### PR TITLE
fix: re-enable TranslateTool

### DIFF
--- a/packages/built-in-ai/src/tools/index.ts
+++ b/packages/built-in-ai/src/tools/index.ts
@@ -3,6 +3,7 @@
 
 import { SummarizeTool } from "./summarize.js";
 import { DetectLanguageTool } from "./detectLanguage.js";
+import { TranslateTool } from "./translate.js";
 import { ProofreadTool } from "./proofread.js";
 import type { ToolRegistry } from "@mast-ai/core";
 
@@ -33,12 +34,11 @@ export async function addAllBuiltInAITools(
         ? (p) => options.onDownloadProgress!("detectLanguage", p)
         : undefined,
     }),
-    // TranslateTool disabled: Translator API crashes in Chrome as of 2026-04-22.
-    // TranslateTool.addToRegistry(registry, {
-    //   onDownloadProgress: options?.onDownloadProgress
-    //     ? (p) => options.onDownloadProgress!("translate", p)
-    //     : undefined,
-    // }),
+    TranslateTool.addToRegistry(registry, {
+      onDownloadProgress: options?.onDownloadProgress
+        ? (p) => options.onDownloadProgress!("translate", p)
+        : undefined,
+    }),
     ProofreadTool.addToRegistry(registry, {
       onDownloadProgress: options?.onDownloadProgress
         ? (p) => options.onDownloadProgress!("proofread", p)


### PR DESCRIPTION
## Summary

- Re-enables `TranslateTool` in `addAllBuiltInAITools` after it was disabled on 2026-04-22
- The Translator API crash in Chrome appears to be device-specific, not a general issue

## Test plan

- [ ] All existing tests pass (67/67)
- [ ] Verify `TranslateTool` works in Chrome on multiple devices