### PR TITLE
feat: add prepare scripts to enable GitHub dependency installs

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
+    "prepare": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
     "dev": "tsup src/index.ts --format esm --out-dir dist --watch",
     "test": "vitest"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
+    "prepare": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
     "dev": "tsup src/index.ts --format esm --out-dir dist --watch"
   },
   "devDependencies": {

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
+    "prepare": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
     "dev": "tsup src/index.ts --format esm --out-dir dist --watch",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary

- Adds a `prepare` script to `packages/core`, `packages/google-genai`, and `packages/built-in-ai`
- `prepare` mirrors the `build` script so npm automatically builds `dist/` when installing from a GitHub URL (e.g. `"@mast-ai/core": "github:andreban/mast-ai#main&path:packages/core"`)
- `tsup` and `typescript` remain in `devDependencies` since npm installs devDeps when building from source

## Test plan

- [ ] Install a package via GitHub URL in a separate project and verify `dist/` is generated
- [ ] Confirm `npm run build` still works as before in each package