### PR TITLE
feat: add ToolProvider interface, ToolRegistryView, and scope to ToolDefinition

### DIFF
--- a/apps/demo-basic-chat/src/main.ts
+++ b/apps/demo-basic-chat/src/main.ts
@@ -26,7 +26,7 @@ const agentConfig = createAgent({
 
 document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
 const toolsList = document.querySelector<HTMLUListElement>('#tools-list')!;
-for (const { name } of registry.definitions()) {
+for (const { name } of registry.getTools()) {
   const li = document.createElement('li');
   const code = document.createElement('code');
   code.textContent = name;

--- a/apps/demo-basic-chat/src/tools/calculate.ts
+++ b/apps/demo-basic-chat/src/tools/calculate.ts
@@ -14,7 +14,8 @@ export class CalculatorTool implements Tool {
           expression: { type: 'string' }
         },
         required: ['expression']
-      }
+      },
+      scope: 'read' as const
     };
   }
 

--- a/apps/demo-basic-chat/src/tools/getCurrentTime.ts
+++ b/apps/demo-basic-chat/src/tools/getCurrentTime.ts
@@ -12,7 +12,8 @@ export class GetCurrentTimeTool implements Tool {
         type: 'object',
         properties: {},
         required: []
-      }
+      },
+      scope: 'read' as const
     };
   }
 

--- a/apps/demo-proofread/src/main.ts
+++ b/apps/demo-proofread/src/main.ts
@@ -40,7 +40,7 @@ async function init() {
         statusBadge.textContent = `Downloading… ${pct}%`;
       },
     });
-    proofreadTool = registry.get('proofread')!;
+    proofreadTool = registry.getTool('proofread')!;
     console.log('[proofread-demo] Ready.');
     statusBadge.textContent = 'Available';
     statusBadge.className = 'status-badge available';

--- a/apps/demo-summarizer/src/main.ts
+++ b/apps/demo-summarizer/src/main.ts
@@ -78,7 +78,7 @@ async function startRegistration() {
 function waitForTool(): Promise<void> {
   return new Promise((resolve) => {
     function check() {
-      if (registry.get('summarize')) {
+      if (registry.getTool('summarize')) {
         resolve();
       } else {
         setTimeout(check, 50);
@@ -105,7 +105,7 @@ async function handleSummarize() {
   const text = inputText.value.trim();
   if (!text) return;
 
-  const tool = registry.get('summarize');
+  const tool = registry.getTool('summarize');
   if (!tool) return;
 
   const args: SummarizeArgs = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -947,6 +947,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1021,6 +1031,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/demo-basic-chat": {
@@ -1690,6 +1710,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -1755,6 +1782,13 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1904,6 +1938,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2172,6 +2216,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -2247,10 +2304,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2484,6 +2561,36 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vitest": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
@@ -2650,7 +2757,230 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.0.0",
-        "typescript": "~6.0.2"
+        "typescript": "~6.0.2",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/core/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/core/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/core/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/core/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "packages/google-ai": {

--- a/packages/built-in-ai/src/BuiltInAIAdapter.test.ts
+++ b/packages/built-in-ai/src/BuiltInAIAdapter.test.ts
@@ -56,7 +56,7 @@ describe("BuiltInAIAdapter", () => {
     it("always returns empty toolCalls", async () => {
       const response = await adapter.generate({
         messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
-        tools: [{ name: "myTool", description: "does stuff", parameters: {} }],
+        tools: [{ name: "myTool", description: "does stuff", parameters: {}, scope: "read" as const }],
       });
 
       expect(response.toolCalls).toEqual([]);
@@ -66,7 +66,7 @@ describe("BuiltInAIAdapter", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       await adapter.generate({
         messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
-        tools: [{ name: "t", description: "d", parameters: {} }],
+        tools: [{ name: "t", description: "d", parameters: {}, scope: "read" as const }],
       });
       expect(warn).toHaveBeenCalledWith(expect.stringContaining("tool calling is not supported"));
     });
@@ -262,7 +262,7 @@ describe("BuiltInAIAdapter", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       await collect({
         messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
-        tools: [{ name: "t", description: "d", parameters: {} }],
+        tools: [{ name: "t", description: "d", parameters: {}, scope: "read" as const }],
       });
       expect(warn).toHaveBeenCalledWith(expect.stringContaining("tool calling is not supported"));
     });

--- a/packages/built-in-ai/src/tools/detectLanguage.test.ts
+++ b/packages/built-in-ai/src/tools/detectLanguage.test.ts
@@ -42,7 +42,7 @@ describe("DetectLanguageTool", () => {
       await expect(DetectLanguageTool.addToRegistry(registry)).rejects.toThrow(
         "not supported in this browser",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
 
       vi.stubGlobal("LanguageDetector", { create: mockCreate, availability: mockAvailability });
     });
@@ -52,8 +52,8 @@ describe("DetectLanguageTool", () => {
       await flush();
 
       expect(mockCreate).toHaveBeenCalled();
-      expect(registry.definitions()).toHaveLength(1);
-      expect(registry.definitions()[0].name).toBe("detectLanguage");
+      expect(registry.getTools()).toHaveLength(1);
+      expect(registry.getTools()[0].name).toBe("detectLanguage");
     });
 
     it("resolves and registers tool in background when after-download", async () => {
@@ -65,7 +65,7 @@ describe("DetectLanguageTool", () => {
 
       const createOpts = mockCreate.mock.calls[0][0];
       expect(typeof createOpts.monitor).toBe("function");
-      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.getTools()).toHaveLength(1);
     });
 
     it("resolves and registers tool in background when downloading", async () => {
@@ -75,7 +75,7 @@ describe("DetectLanguageTool", () => {
       await flush();
 
       expect(mockCreate).toHaveBeenCalled();
-      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.getTools()).toHaveLength(1);
     });
 
     it("rejects with AdapterError when unavailable", async () => {
@@ -84,7 +84,7 @@ describe("DetectLanguageTool", () => {
       await expect(DetectLanguageTool.addToRegistry(registry)).rejects.toThrow(
         "unavailable on this device",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
     });
 
     it("fires onDownloadProgress callback when downloadprogress event fires", async () => {
@@ -115,7 +115,7 @@ describe("DetectLanguageTool", () => {
       await DetectLanguageTool.addToRegistry(registry);
       await flush();
 
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
     });
   });
 
@@ -134,7 +134,7 @@ describe("DetectLanguageTool", () => {
     it("resolves with the top detection result", async () => {
       await DetectLanguageTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("detectLanguage")!;
+      const tool = registry.getTool("detectLanguage")!;
 
       const result = await tool.call({ text: "Hello world" }, {});
       expect(result).toEqual({ detectedLanguage: "en", confidence: 0.97 });
@@ -143,7 +143,7 @@ describe("DetectLanguageTool", () => {
     it("reuses the cached session across calls", async () => {
       await DetectLanguageTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("detectLanguage")!;
+      const tool = registry.getTool("detectLanguage")!;
 
       await tool.call({ text: "first" }, {});
       await tool.call({ text: "second" }, {});
@@ -157,7 +157,7 @@ describe("DetectLanguageTool", () => {
 
       await DetectLanguageTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("detectLanguage")!;
+      const tool = registry.getTool("detectLanguage")!;
 
       const controller = new AbortController();
       await tool.call({ text: "text" }, { signal: controller.signal });
@@ -174,7 +174,7 @@ describe("DetectLanguageTool", () => {
 
       await DetectLanguageTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("detectLanguage")!;
+      const tool = registry.getTool("detectLanguage")!;
 
       const result = await tool.call({ text: "???" }, {});
       expect(result).toEqual({ detectedLanguage: null, confidence: 0 });
@@ -188,7 +188,7 @@ describe("DetectLanguageTool", () => {
 
       await DetectLanguageTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("detectLanguage")!;
+      const tool = registry.getTool("detectLanguage")!;
 
       await expect(tool.call({ text: "text" }, {})).rejects.toThrow("detect failed");
     });

--- a/packages/built-in-ai/src/tools/detectLanguage.ts
+++ b/packages/built-in-ai/src/tools/detectLanguage.ts
@@ -88,6 +88,7 @@ export class DetectLanguageTool implements Tool<DetectLanguageArgs, LanguageDete
         },
         required: ["text"],
       },
+      scope: 'read',
     };
   }
 

--- a/packages/built-in-ai/src/tools/proofread.test.ts
+++ b/packages/built-in-ai/src/tools/proofread.test.ts
@@ -44,7 +44,7 @@ describe("ProofreadTool", () => {
       await expect(ProofreadTool.addToRegistry(registry)).rejects.toThrow(
         "not supported in this browser",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
 
       vi.stubGlobal("Proofreader", { create: mockCreate, availability: mockAvailability });
     });
@@ -55,7 +55,7 @@ describe("ProofreadTool", () => {
       await expect(ProofreadTool.addToRegistry(registry)).rejects.toThrow(
         "not available on this device",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
       expect(mockCreate).not.toHaveBeenCalled();
     });
 
@@ -63,8 +63,8 @@ describe("ProofreadTool", () => {
       await ProofreadTool.addToRegistry(registry);
 
       expect(mockCreate).toHaveBeenCalledTimes(1);
-      expect(registry.definitions()).toHaveLength(1);
-      expect(registry.definitions()[0].name).toBe("proofread");
+      expect(registry.getTools()).toHaveLength(1);
+      expect(registry.getTools()[0].name).toBe("proofread");
     });
 
     it("registers without creating a session when availability is downloadable", async () => {
@@ -73,7 +73,7 @@ describe("ProofreadTool", () => {
       await ProofreadTool.addToRegistry(registry);
 
       expect(mockCreate).not.toHaveBeenCalled();
-      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.getTools()).toHaveLength(1);
     });
 
     it("registers without creating a session when availability is downloading", async () => {
@@ -82,14 +82,14 @@ describe("ProofreadTool", () => {
       await ProofreadTool.addToRegistry(registry);
 
       expect(mockCreate).not.toHaveBeenCalled();
-      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.getTools()).toHaveLength(1);
     });
   });
 
   describe("call() — session created eagerly (available)", () => {
     it("rejects with AdapterError when Proofreader global is absent", async () => {
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       vi.stubGlobal("Proofreader", undefined);
       await expect(tool.call({ text: "teh cat" }, {})).rejects.toThrow(
@@ -101,7 +101,7 @@ describe("ProofreadTool", () => {
 
     it("returns ProofreadResult from session.proofread", async () => {
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       const result = await tool.call({ text: "teh cat" }, {});
       expect(result).toEqual(RESULT);
@@ -112,7 +112,7 @@ describe("ProofreadTool", () => {
       mockCreate.mockResolvedValue(makeSession({ proofread: vi.fn().mockResolvedValue(emptyResult) }));
 
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       const result = await tool.call({ text: "the cat" }, {});
       expect(result).toEqual(emptyResult);
@@ -123,7 +123,7 @@ describe("ProofreadTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       const controller = new AbortController();
       await tool.call({ text: "teh cat" }, { signal: controller.signal });
@@ -141,7 +141,7 @@ describe("ProofreadTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       await expect(tool.call({ text: "teh cat" }, {})).rejects.toThrow("proofread failed");
     });
@@ -151,7 +151,7 @@ describe("ProofreadTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       await tool.call({ text: "teh cat" }, {});
       await tool.call({ text: "speling eror" }, {});
@@ -169,7 +169,7 @@ describe("ProofreadTool", () => {
       await ProofreadTool.addToRegistry(registry, { onDownloadProgress });
       expect(mockCreate).not.toHaveBeenCalled();
 
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
       await tool.call({ text: "teh cat" }, {});
 
       expect(mockCreate).toHaveBeenCalledTimes(1);
@@ -193,7 +193,7 @@ describe("ProofreadTool", () => {
       const onDownloadProgress = vi.fn();
       await ProofreadTool.addToRegistry(registry, { onDownloadProgress });
 
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
       await tool.call({ text: "teh cat" }, {});
 
       const evt = Object.assign(new Event("downloadprogress"), { loaded: 50, total: 100 });
@@ -208,7 +208,7 @@ describe("ProofreadTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await ProofreadTool.addToRegistry(registry);
-      const tool = registry.get("proofread")!;
+      const tool = registry.getTool("proofread")!;
 
       await tool.call({ text: "teh cat" }, {});
       await tool.call({ text: "speling eror" }, {});

--- a/packages/built-in-ai/src/tools/proofread.ts
+++ b/packages/built-in-ai/src/tools/proofread.ts
@@ -84,6 +84,7 @@ export class ProofreadTool implements Tool<ProofreadArgs, ProofreadResult> {
         },
         required: ["text"],
       },
+      scope: 'read',
     };
   }
 

--- a/packages/built-in-ai/src/tools/summarize.test.ts
+++ b/packages/built-in-ai/src/tools/summarize.test.ts
@@ -43,7 +43,7 @@ describe("SummarizeTool", () => {
       await expect(SummarizeTool.addToRegistry(registry)).rejects.toThrow(
         "not supported in this browser",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
 
       vi.stubGlobal("Summarizer", { create: mockCreate, availability: mockAvailability });
     });
@@ -53,8 +53,8 @@ describe("SummarizeTool", () => {
       await flush();
 
       expect(mockCreate).toHaveBeenCalled();
-      expect(registry.definitions()).toHaveLength(1);
-      expect(registry.definitions()[0].name).toBe("summarize");
+      expect(registry.getTools()).toHaveLength(1);
+      expect(registry.getTools()[0].name).toBe("summarize");
     });
 
     it("resolves and registers tool in background when after-download", async () => {
@@ -66,7 +66,7 @@ describe("SummarizeTool", () => {
 
       const createOpts = mockCreate.mock.calls[0][0];
       expect(typeof createOpts.monitor).toBe("function");
-      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.getTools()).toHaveLength(1);
     });
 
     it("resolves and registers tool in background when downloading", async () => {
@@ -76,7 +76,7 @@ describe("SummarizeTool", () => {
       await flush();
 
       expect(mockCreate).toHaveBeenCalled();
-      expect(registry.definitions()).toHaveLength(1);
+      expect(registry.getTools()).toHaveLength(1);
     });
 
     it("rejects with AdapterError when unavailable", async () => {
@@ -85,7 +85,7 @@ describe("SummarizeTool", () => {
       await expect(SummarizeTool.addToRegistry(registry)).rejects.toThrow(
         "unavailable on this device",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
     });
 
     it("fires onDownloadProgress callback when downloadprogress event fires", async () => {
@@ -128,7 +128,7 @@ describe("SummarizeTool", () => {
     it("resolves with the summary string", async () => {
       await SummarizeTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("summarize")!;
+      const tool = registry.getTool("summarize")!;
 
       const result = await tool.call({ text: "long text" }, {});
       expect(result).toBe("summary text");
@@ -137,7 +137,7 @@ describe("SummarizeTool", () => {
     it("reuses the cached instance when options match", async () => {
       await SummarizeTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("summarize")!;
+      const tool = registry.getTool("summarize")!;
 
       await tool.call({ text: "first" }, {});
       await tool.call({ text: "second" }, {});
@@ -152,7 +152,7 @@ describe("SummarizeTool", () => {
 
       await SummarizeTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("summarize")!;
+      const tool = registry.getTool("summarize")!;
 
       await tool.call({ text: "first" }, {});
       await tool.call({ text: "second", type: "tldr" }, {});
@@ -167,7 +167,7 @@ describe("SummarizeTool", () => {
 
       await SummarizeTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("summarize")!;
+      const tool = registry.getTool("summarize")!;
 
       const controller = new AbortController();
       await tool.call({ text: "text" }, { signal: controller.signal });
@@ -186,7 +186,7 @@ describe("SummarizeTool", () => {
 
       await SummarizeTool.addToRegistry(registry);
       await flush();
-      const tool = registry.get("summarize")!;
+      const tool = registry.getTool("summarize")!;
 
       await expect(tool.call({ text: "text" }, {})).rejects.toThrow("summarize failed");
     });

--- a/packages/built-in-ai/src/tools/summarize.ts
+++ b/packages/built-in-ai/src/tools/summarize.ts
@@ -133,6 +133,7 @@ export class SummarizeTool implements Tool<SummarizeArgs, string> {
         },
         required: ["text"],
       },
+      scope: 'read',
     };
   }
 

--- a/packages/built-in-ai/src/tools/translate.test.ts
+++ b/packages/built-in-ai/src/tools/translate.test.ts
@@ -39,7 +39,7 @@ describe("TranslateTool", () => {
       await expect(TranslateTool.addToRegistry(registry)).rejects.toThrow(
         "not supported in this browser",
       );
-      expect(registry.definitions()).toHaveLength(0);
+      expect(registry.getTools()).toHaveLength(0);
 
       vi.stubGlobal("Translator", { create: mockCreate, availability: mockAvailability });
     });
@@ -47,8 +47,8 @@ describe("TranslateTool", () => {
     it("registers the tool immediately without creating a session", async () => {
       await TranslateTool.addToRegistry(registry);
 
-      expect(registry.definitions()).toHaveLength(1);
-      expect(registry.definitions()[0].name).toBe("translate");
+      expect(registry.getTools()).toHaveLength(1);
+      expect(registry.getTools()[0].name).toBe("translate");
       expect(mockCreate).not.toHaveBeenCalled();
     });
   });
@@ -56,7 +56,7 @@ describe("TranslateTool", () => {
   describe("call()", () => {
     it("rejects with AdapterError when Translator global is absent", async () => {
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       vi.stubGlobal("Translator", undefined);
       await expect(
@@ -70,7 +70,7 @@ describe("TranslateTool", () => {
       mockAvailability.mockResolvedValue("unavailable");
 
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await expect(
         tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "xx" }, {}),
@@ -83,7 +83,7 @@ describe("TranslateTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       const result = await tool.call(
         { text: "hello", sourceLanguage: "en", targetLanguage: "fr" },
@@ -97,7 +97,7 @@ describe("TranslateTool", () => {
       const onDownloadProgress = vi.fn();
 
       await TranslateTool.addToRegistry(registry, { onDownloadProgress });
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
 
@@ -122,7 +122,7 @@ describe("TranslateTool", () => {
 
       const onDownloadProgress = vi.fn();
       await TranslateTool.addToRegistry(registry, { onDownloadProgress });
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
 
@@ -139,7 +139,7 @@ describe("TranslateTool", () => {
 
     it("reuses a cached session for the same language pair", async () => {
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
       await tool.call({ text: "world", sourceLanguage: "en", targetLanguage: "fr" }, {});
@@ -149,7 +149,7 @@ describe("TranslateTool", () => {
 
     it("creates separate sessions for different language pairs", async () => {
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {});
       await tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "ja" }, {});
@@ -170,7 +170,7 @@ describe("TranslateTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       const controller = new AbortController();
       await tool.call(
@@ -192,7 +192,7 @@ describe("TranslateTool", () => {
       mockCreate.mockRejectedValue(new DOMException("Aborted", "AbortError"));
 
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await expect(
         tool.call(
@@ -214,7 +214,7 @@ describe("TranslateTool", () => {
       mockCreate.mockResolvedValue(session);
 
       await TranslateTool.addToRegistry(registry);
-      const tool = registry.get("translate")!;
+      const tool = registry.getTool("translate")!;
 
       await expect(
         tool.call({ text: "hello", sourceLanguage: "en", targetLanguage: "fr" }, {}),

--- a/packages/built-in-ai/src/tools/translate.ts
+++ b/packages/built-in-ai/src/tools/translate.ts
@@ -81,6 +81,7 @@ export class TranslateTool implements Tool<TranslateArgs, string> {
         },
         required: ["text", "sourceLanguage", "targetLanguage"],
       },
+      scope: 'read',
     };
   }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,10 +8,12 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
     "prepare": "tsup src/index.ts --format esm --minify --out-dir dist && tsc --emitDeclarationOnly --rootDir src --outDir dist",
-    "dev": "tsup src/index.ts --format esm --out-dir dist --watch"
+    "dev": "tsup src/index.ts --format esm --out-dir dist --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
     "tsup": "^8.0.0",
-    "typescript": "~6.0.2"
+    "typescript": "~6.0.2",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -3,7 +3,7 @@
 
 import type { AgentConfig, AgentEvent, AgentResult, Message, ToolCall } from './types';
 import type { LlmAdapter, AdapterRequest } from './adapter/index';
-import { ToolRegistry } from './tool';
+import { type ToolProvider, ToolRegistry } from './tool';
 import { AgentError } from './error';
 import { Conversation } from './conversation';
 
@@ -95,8 +95,8 @@ export class AgentRunner {
   constructor(
     /** The LLM adapter used to generate responses. */
     public readonly adapter: LlmAdapter,
-    /** Registry of tools the runner may invoke on behalf of agents. */
-    public readonly registry: ToolRegistry = new ToolRegistry()
+    /** Provider of tools the runner may invoke on behalf of agents. */
+    public readonly registry: ToolProvider = new ToolRegistry()
   ) {}
 
   /** Creates a Conversation that automatically tracks history across turns. */
@@ -140,7 +140,7 @@ export class AgentRunner {
     // Use the explicit tool list when provided; otherwise expose all registered tools.
     const toolDefinitions = agent.tools
       ? agent.tools.map((toolName) => {
-          const tool = this.registry.get(toolName);
+          const tool = this.registry.getTool(toolName);
           if (!tool) {
             throw new AgentError(
               `Tool '${toolName}' requested by agent '${agent.name}' is not registered.`,
@@ -148,7 +148,7 @@ export class AgentRunner {
           }
           return tool.definition();
         })
-      : this.registry.definitions();
+      : this.registry.getTools();
 
     // Clone history and add new user message
     const currentHistory: Message[] = [
@@ -205,7 +205,7 @@ export class AgentRunner {
 
         const toolResults = await Promise.all(
           toolCalls.map(async (call) => {
-            const tool = this.registry.get(call.name);
+            const tool = this.registry.getTool(call.name);
             if (!tool) {
               return { call, result: `Error: Tool '${call.name}' not found.` };
             }

--- a/packages/core/src/tool.test.ts
+++ b/packages/core/src/tool.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { ToolRegistry, ToolRegistryView, type ToolProvider } from './tool';
+import type { Tool, ToolDefinition, ToolContext } from './tool';
+
+function makeTool(name: string, scope: 'read' | 'write'): Tool {
+  return {
+    definition: (): ToolDefinition => ({
+      name,
+      description: `${name} tool`,
+      parameters: {},
+      scope,
+    }),
+    call: vi.fn().mockResolvedValue({}),
+  };
+}
+
+describe('ToolDefinition', () => {
+  it('has a scope field', () => {
+    const def: ToolDefinition = {
+      name: 'test',
+      description: 'test',
+      parameters: {},
+      scope: 'read',
+    };
+    expect(def.scope).toBe('read');
+  });
+});
+
+describe('ToolRegistry', () => {
+  it('implements ToolProvider', () => {
+    const registry: ToolProvider = new ToolRegistry();
+    expect(typeof registry.getTools).toBe('function');
+    expect(typeof registry.getTool).toBe('function');
+  });
+
+  it('registers and retrieves tools', () => {
+    const registry = new ToolRegistry();
+    const tool = makeTool('myTool', 'read');
+    registry.register(tool);
+    expect(registry.getTool('myTool')).toBe(tool);
+  });
+
+  it('throws when registering a duplicate tool name', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('dup', 'read'));
+    expect(() => registry.register(makeTool('dup', 'write'))).toThrow("Tool 'dup' is already registered.");
+  });
+
+  it('getTools returns definitions of all registered tools', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('a', 'read'));
+    registry.register(makeTool('b', 'write'));
+    const defs = registry.getTools();
+    expect(defs).toHaveLength(2);
+    expect(defs.map(d => d.name)).toContain('a');
+    expect(defs.map(d => d.name)).toContain('b');
+  });
+
+  it('getTool returns undefined for unknown names', () => {
+    const registry = new ToolRegistry();
+    expect(registry.getTool('missing')).toBeUndefined();
+  });
+
+  it('unregister removes a tool', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('gone', 'write'));
+    registry.unregister('gone');
+    expect(registry.getTool('gone')).toBeUndefined();
+    expect(registry.getTools()).toHaveLength(0);
+  });
+
+  it('unregister is a no-op for unknown names', () => {
+    const registry = new ToolRegistry();
+    expect(() => registry.unregister('nope')).not.toThrow();
+  });
+
+  it('readOnly returns a ToolRegistryView', () => {
+    const registry = new ToolRegistry();
+    expect(registry.readOnly()).toBeInstanceOf(ToolRegistryView);
+  });
+});
+
+describe('ToolRegistryView', () => {
+  it('implements ToolProvider', () => {
+    const view: ToolProvider = new ToolRegistry().readOnly();
+    expect(typeof view.getTools).toBe('function');
+    expect(typeof view.getTool).toBe('function');
+  });
+
+  it('getTools filters to matching scope only', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('reader', 'read'));
+    registry.register(makeTool('writer', 'write'));
+
+    const view = registry.readOnly();
+    const defs = view.getTools();
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('reader');
+  });
+
+  it('getTool returns tool when scope matches', () => {
+    const registry = new ToolRegistry();
+    const tool = makeTool('reader', 'read');
+    registry.register(tool);
+
+    const view = registry.readOnly();
+    expect(view.getTool('reader')).toBe(tool);
+  });
+
+  it('getTool returns undefined when scope does not match', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('writer', 'write'));
+
+    const view = registry.readOnly();
+    expect(view.getTool('writer')).toBeUndefined();
+  });
+
+  it('getTool returns undefined for unknown names', () => {
+    const view = new ToolRegistry().readOnly();
+    expect(view.getTool('missing')).toBeUndefined();
+  });
+
+  it('reflects additions to the parent registry live', () => {
+    const registry = new ToolRegistry();
+    const view = registry.readOnly();
+
+    expect(view.getTools()).toHaveLength(0);
+
+    registry.register(makeTool('lateRead', 'read'));
+    expect(view.getTools()).toHaveLength(1);
+    expect(view.getTool('lateRead')).toBeDefined();
+  });
+
+  it('reflects removals from the parent registry live', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('removable', 'read'));
+    const view = registry.readOnly();
+
+    expect(view.getTools()).toHaveLength(1);
+    registry.unregister('removable');
+    expect(view.getTools()).toHaveLength(0);
+  });
+});

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -9,6 +9,8 @@ export interface ToolDefinition {
   description: string;
   /** JSON Schema object describing the tool's arguments. */
   parameters: Record<string, unknown>;
+  /** Whether the tool reads or modifies state. Used for scope-based filtering. */
+  scope: 'read' | 'write';
 }
 
 /** Runtime context passed to every {@link Tool.call} invocation. */
@@ -37,8 +39,20 @@ export interface Tool<TArgs = unknown, TResult = unknown> {
   call(args: TArgs, context: ToolContext): Promise<TResult>;
 }
 
+/**
+ * Read-only interface for accessing tool definitions and resolving tools by name.
+ * Passed to {@link AgentRunner} so that scope-based filtering is handled by the
+ * provider rather than the runner.
+ */
+export interface ToolProvider {
+  /** Returns the definitions of all accessible tools. */
+  getTools(): ToolDefinition[];
+  /** Returns the tool registered under `name`, or `undefined` if not found or out of scope. */
+  getTool(name: string): Tool | undefined;
+}
+
 /** Holds all tools available to an {@link AgentRunner} and resolves them by name during execution. */
-export class ToolRegistry {
+export class ToolRegistry implements ToolProvider {
   private _tools = new Map<string, Tool>();
 
   /**
@@ -54,13 +68,46 @@ export class ToolRegistry {
     return this;
   }
 
+  /** Removes the tool registered under `name`. No-op if not found. */
+  unregister(name: string): void {
+    this._tools.delete(name);
+  }
+
   /** Returns the tool registered under `name`, or `undefined` if not found. */
-  get(name: string): Tool | undefined {
+  getTool(name: string): Tool | undefined {
     return this._tools.get(name);
   }
 
   /** Returns the definitions of all registered tools for inclusion in an adapter request. */
-  definitions(): ToolDefinition[] {
+  getTools(): ToolDefinition[] {
     return Array.from(this._tools.values()).map(t => t.definition());
+  }
+
+  /** Returns a live read-only view filtered to tools with `scope: 'read'`. */
+  readOnly(): ToolRegistryView {
+    return new ToolRegistryView(this, 'read');
+  }
+}
+
+/**
+ * A live filtered projection of a {@link ToolRegistry}.
+ *
+ * Changes to the parent registry are automatically reflected — no copy is made.
+ * Only tools whose `scope` matches the view's scope are visible.
+ */
+export class ToolRegistryView implements ToolProvider {
+  constructor(
+    private readonly parent: ToolRegistry,
+    private readonly scope: 'read' | 'write',
+  ) {}
+
+  getTools(): ToolDefinition[] {
+    return this.parent.getTools().filter(def => def.scope === this.scope);
+  }
+
+  getTool(name: string): Tool | undefined {
+    const tool = this.parent.getTool(name);
+    if (!tool) return undefined;
+    return tool.definition().scope === this.scope ? tool : undefined;
   }
 }

--- a/packages/google-genai/src/GoogleGenAIAdapter.test.ts
+++ b/packages/google-genai/src/GoogleGenAIAdapter.test.ts
@@ -88,7 +88,7 @@ describe("GoogleGenAIAdapter", () => {
       messages: [
         { role: "user", content: { type: "text", text: "Call tool" } },
       ],
-      tools: [{ name: "testTool", description: "desc", parameters: {} }],
+      tools: [{ name: "testTool", description: "desc", parameters: {}, scope: "read" as const }],
     });
 
     expect(response.toolCalls).toHaveLength(1);
@@ -242,7 +242,7 @@ describe("GoogleGenAIAdapter", () => {
 
       const chunks = await collectChunks({
         messages: [{ role: "user", content: { type: "text", text: "Hi" } }],
-        tools: [{ name: "read", description: "reads", parameters: {} }],
+        tools: [{ name: "read", description: "reads", parameters: {}, scope: "read" as const }],
       });
 
       expect(chunks).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Adds `scope: 'read' | 'write'` to `ToolDefinition`
- Introduces `ToolProvider` interface (`getTools()`, `getTool()`) and updates `AgentRunner` to accept it instead of the concrete `ToolRegistry`
- `ToolRegistry` now implements `ToolProvider`, gains `unregister()` and `readOnly()`, and renames `get()` → `getTool()` / `definitions()` → `getTools()`
- Adds `ToolRegistryView`: a live, scope-filtered projection of a parent `ToolRegistry` — no copy, changes reflected automatically
- Updates all callsites across built-in-ai, google-genai, and demo apps
- Adds 16 Vitest unit tests covering all acceptance criteria

Closes #24

## Test plan

- [x] `npm test` in `packages/core` — 16 tests pass
- [x] `npm run build` in repo root — all packages build cleanly
- [x] Verify `ToolRegistryView` filters correctly for 'read' vs 'write' scope
- [x] Verify live reflection: adding/removing tools from `ToolRegistry` is immediately visible in derived views