### PR TITLE
docs: add PRD and SPEC for @mast-ai/react-ui

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ apps/demo-rust-server/src/
 
 Before starting work on a feature, check its subdirectory in `docs/` for context. When creating docs for a new feature, create a subdirectory under `docs/` and write a `PRD.md` and `SPEC.md` there.
 
-**PRD.md and SPEC.md must be kept up to date throughout implementation.** Any change to requirements, technical decisions, or architecture must be reflected in the relevant doc before or alongside the code change. Both files must be current before opening a pull request.
+**All PRD.md and SPEC.md files — both the library-level ones and every feature subdirectory — must be kept up to date throughout implementation.** Any change to requirements, technical decisions, or architecture must be reflected in the relevant doc before or alongside the code change. Both files must be current before opening a pull request.
 
 ## GitHub Issues
 

--- a/docs/react-ui/PRD.md
+++ b/docs/react-ui/PRD.md
@@ -86,7 +86,31 @@ function MyAgentPanel() {
 />
 ```
 
-### 4.5 Approval callback
+### 4.5 Conversation persistence
+> As a developer building a multi-session app, I want to save the conversation after
+> each turn and restore it on the next page load so users can continue where they left off.
+
+```tsx
+// Save
+<AgentProvider
+  runner={runner}
+  agent={agentConfig}
+  onConversationChange={(history, entries) => {
+    localStorage.setItem('history', JSON.stringify(history));
+    localStorage.setItem('entries', JSON.stringify(entries));
+  }}
+>
+
+// Restore
+<AgentProvider
+  runner={runner}
+  agent={agentConfig}
+  initialHistory={JSON.parse(localStorage.getItem('history') ?? '[]')}
+  initialEntries={JSON.parse(localStorage.getItem('entries') ?? '[]')}
+>
+```
+
+### 4.6 Approval callback
 > As a developer whose agent uses tools that require human confirmation, I want to
 > hook into the approval flow so I can render my own confirmation UI before the tool
 > executes.
@@ -116,8 +140,8 @@ function MyAgentPanel() {
    `ToolCallBlock`, `ChatInput`) is importable individually for compositional use.
 6. All interactive elements (send button, collapsible blocks) meet WCAG 2.1 AA
    keyboard-navigation and ARIA requirements.
-7. The streaming state machine (`useAgentStream`), approval flow, and all interactive
-   components have unit tests that pass in CI.
+7. The streaming state machine (`useAgentStream`), approval flow, conversation
+   persistence, and all interactive components have unit tests that pass in CI.
 8. A working demo app (`apps/demo-react-ui`) ships alongside the library demonstrating
    the default setup with `@mast-ai/google-genai`, custom icons via `lucide-react`, and
    at least two registered tools.

--- a/docs/react-ui/PRD.md
+++ b/docs/react-ui/PRD.md
@@ -1,0 +1,134 @@
+# Product Requirements Document: @mast-ai/react-ui
+
+## 1. Problem Statement
+
+Every MAST-powered React application independently rebuilds the same agent chat UI:
+a streaming message list, collapsible thinking blocks, tool call displays, and a text
+input wired to `AgentRunner`. This has happened in at least two existing apps
+([agent-text-editor](https://github.com/andreban/agent-text-editor) and
+[bandarrame_rs/admin-ui](https://github.com/andreban/bandarrame_rs)). Each
+reimplementation duplicates rendering logic, streaming state management, and accessibility
+concerns while diverging on styling details.
+
+The gap between "I have an AgentRunner" and "I have a working chat UI" is currently filled
+by hundreds of lines of app-specific boilerplate that cannot be shared.
+
+## 2. Goals
+
+- **Eliminate the UI boilerplate** for any developer who has an `AgentRunner` from `@mast-ai/core`.
+- **Cover non-chat use cases** — the agent panel should be embeddable as a sidebar, modal,
+  or inline pane in text editors, image editors, CAD tools, and any other application type.
+  It must not assume it is the primary UI.
+- **Maximise React app compatibility** — work in any React app regardless of its existing
+  styling setup (Tailwind, MUI, Ant Design, CSS Modules, plain CSS, etc.).
+- **Minimise mandatory dependencies** — do not impose Radix UI, shadcn, or any headless
+  component library on consumers. Do not require Tailwind to be installed or configured.
+- **Export all building blocks** — every sub-component must be independently importable so
+  developers can compose bespoke UIs without forking the library.
+
+## 3. Non-Goals
+
+- **Editor integrations** — Monaco decorations, diff overlays, and canvas annotations are
+  domain-specific. They stay in the consuming application.
+- **Domain-specific approval flows** — suggestion diffs, plan confirmations, and field-update
+  prompts are too app-specific. The library provides a callback hook; the app renders the
+  approval UI.
+- **Server-side rendering** — the library targets browser-rendered React applications. SSR
+  compatibility is a nice-to-have but not a requirement.
+- **Non-React frameworks** — Vue, Svelte, and Web Components are out of scope.
+
+## 4. User Stories
+
+### 4.1 Zero-config chat panel
+> As a developer who has an `AgentRunner` and a tool registry, I want to render a full
+> chat panel by adding a single component, without configuring any styling system.
+
+```tsx
+<AgentProvider runner={runner} agent={agentConfig}>
+  <ConversationPanel />
+</AgentProvider>
+```
+
+### 4.2 Custom layout with library primitives
+> As a developer building a text editor, I want a floating chat sidebar that shares
+> the same message rendering logic as the default panel, but with my own layout and
+> header chrome.
+
+```tsx
+<AgentProvider runner={runner} agent={agentConfig}>
+  <MySidebar>
+    <MessageList />
+    <ChatInput />
+  </MySidebar>
+</AgentProvider>
+```
+
+### 4.3 Fully headless custom UI
+> As a developer whose app already uses a design system, I want access to the streaming
+> state and message data via a hook so I can render everything myself without any library
+> styles conflicting with mine.
+
+```tsx
+function MyAgentPanel() {
+  const { messages, sendMessage, isRunning, cancel } = useAgent();
+  return <MyDesignSystemChatPanel ... />;
+}
+```
+
+### 4.4 Custom tool call rendering
+> As a developer whose tools have rich results (images, charts, code diffs), I want to
+> replace the default tool call block with my own renderer while keeping everything else
+> from the library.
+
+```tsx
+<ConversationPanel
+  renderToolCall={(toolCall) => <MyRichToolCallRenderer toolCall={toolCall} />}
+/>
+```
+
+### 4.5 Approval callback
+> As a developer whose agent uses tools that require human confirmation, I want to
+> hook into the approval flow so I can render my own confirmation UI before the tool
+> executes.
+
+```tsx
+<AgentProvider
+  runner={runner}
+  agent={agentConfig}
+  onApprovalRequired={(toolCall) => myConfirmationDialog(toolCall)}
+>
+  <ConversationPanel />
+</AgentProvider>
+```
+
+## 5. Success Criteria
+
+1. A developer can render a working agent chat UI with three lines of JSX and no style
+   configuration.
+2. The library ships with zero peer dependencies beyond `react`, `react-dom`,
+   `@mast-ai/core`, and `@tanstack/react-virtual`. Markdown rendering and icon sets are
+   optional.
+3. The default stylesheet imports with a single CSS import and requires no build-tool
+   configuration (no Tailwind, no PostCSS plugins).
+4. Every component accepts a `className` prop and the default styles are expressed as
+   overridable CSS custom properties, so consuming apps can restyle without `!important`.
+5. The full component surface (`MessageList`, `MessageItem`, `ThinkingBlock`,
+   `ToolCallBlock`, `ChatInput`) is importable individually for compositional use.
+6. All interactive elements (send button, collapsible blocks) meet WCAG 2.1 AA
+   keyboard-navigation and ARIA requirements.
+7. The streaming state machine (`useAgentStream`), approval flow, and all interactive
+   components have unit tests that pass in CI.
+8. A working demo app (`apps/demo-react-ui`) ships alongside the library demonstrating
+   the default setup with `@mast-ai/google-genai`, custom icons via `lucide-react`, and
+   at least two registered tools.
+9. Developer documentation (`docs/react-ui/USAGE.md`) and the `skills/mast-ai` skill
+   are updated to cover the new package before the feature is considered complete.
+
+## 6. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| CSS conflicts with consuming app | Namespace all default classes with `mast-` prefix; use CSS custom properties scoped to `[data-mast]` so they don't bleed |
+| `react-markdown` adds weight | Make it optional; `renderMessage` prop lets apps supply their own renderer |
+| Streaming state logic diverges from core | Keep all streaming wiring in one `useAgentStream` internal hook derived directly from `AgentEvent` types |
+| API surface locks in early design | Keep `ConversationPanel` as a thin compositor over exported primitives; breaking the top-level API is tolerable if primitives remain stable |

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -1,0 +1,771 @@
+# Technical Specification: @mast-ai/react-ui
+
+## 1. Package
+
+| Field | Value |
+|-------|-------|
+| Name | `@mast-ai/react-ui` |
+| Location | `packages/react-ui` |
+| Build tool | Vite (library mode) |
+| Language | TypeScript (strict) |
+
+### Peer Dependencies
+
+```json
+{
+  "react": ">=19.0.0",
+  "react-dom": ">=19.0.0",
+  "@mast-ai/core": "workspace:*",
+  "@tanstack/react-virtual": ">=3.0.0"
+}
+```
+
+`@tanstack/react-virtual` is a required peer dependency. `<MessageList>` uses virtual
+scrolling by default because agent conversations grow unboundedly during long sessions.
+
+### Optional Dependencies
+
+| Package | Used for | How to activate |
+|---------|----------|-----------------|
+| `react-markdown` + `remark-gfm` + `rehype-sanitize` | Markdown rendering in `MessageItem` | Installed automatically when present; falls back to plain text |
+
+When `react-markdown` is detected, `rehype-sanitize` is **always applied** — the library
+does not expose a way to disable sanitisation. Apps that need unrestricted HTML rendering
+should supply a `renderMessage` prop instead.
+
+Icons are **bundled inline** — see [Section 6: Icons](#6-icons).
+
+---
+
+## 2. Styling Architecture
+
+### 2.1 Two-tier approach
+
+**Tier 1 — Headless (behaviour only)**
+Every component renders semantic HTML with `data-mast-*` attributes and no inline styles.
+Components accept `className` and `style` props for consumer control.
+
+**Tier 2 — Default stylesheet**
+An optional CSS file provides a complete default theme. Consumers opt in with:
+
+```ts
+import '@mast-ai/react-ui/styles.css';
+```
+
+This file is plain CSS with no build-tool dependencies. It uses CSS custom properties
+scoped under `[data-mast-root]` so it does not pollute the global namespace.
+
+### 2.2 CSS Custom Properties
+
+The default stylesheet defines a light theme and an automatic dark theme. Both are
+expressed as CSS custom property blocks so consuming apps can override individual tokens
+at any scope without `!important`.
+
+```css
+/* Light theme (default) */
+[data-mast-root] {
+  /* Color */
+  --mast-bg: #ffffff;
+  --mast-bg-subtle: #f9fafb;
+  --mast-fg: #111827;
+  --mast-fg-muted: #6b7280;
+  --mast-border: #e5e7eb;
+  --mast-accent: #2563eb;
+  --mast-accent-fg: #ffffff;
+  --mast-thinking-bg: #fefce8;
+  --mast-thinking-fg: #854d0e;
+  --mast-tool-bg: #f0fdf4;
+  --mast-tool-fg: #166534;
+  --mast-tool-pending: #f59e0b;
+  --mast-user-bubble: #dbeafe;
+  --mast-user-fg: #1e3a8a;
+
+  /* Typography */
+  --mast-font: system-ui, sans-serif;
+  --mast-font-mono: ui-monospace, monospace;
+  --mast-text-sm: 0.875rem;
+  --mast-text-base: 1rem;
+
+  /* Spacing */
+  --mast-gap: 0.75rem;
+  --mast-radius: 0.5rem;
+}
+
+/* Dark theme — activated by OS preference OR explicit attribute */
+@media (prefers-color-scheme: dark) {
+  [data-mast-root]:not([data-mast-theme="light"]) {
+    --mast-bg: #111827;
+    --mast-bg-subtle: #1f2937;
+    --mast-fg: #f9fafb;
+    --mast-fg-muted: #9ca3af;
+    --mast-border: #374151;
+    --mast-accent: #3b82f6;
+    --mast-accent-fg: #ffffff;
+    --mast-thinking-bg: #1c1917;
+    --mast-thinking-fg: #fcd34d;
+    --mast-tool-bg: #052e16;
+    --mast-tool-fg: #86efac;
+    --mast-tool-pending: #fbbf24;
+    --mast-user-bubble: #1e3a8a;
+    --mast-user-fg: #bfdbfe;
+  }
+}
+
+/* Explicit dark override (for apps using next-themes or similar) */
+[data-mast-root][data-mast-theme="dark"] {
+  /* same tokens as above */
+}
+```
+
+**Manual theme control:** Apps that manage their own theme switching (e.g. via
+`next-themes`) pass `data-mast-theme="light"` or `data-mast-theme="dark"` to the
+root element. `ConversationPanel` accepts a `theme` prop that sets this attribute:
+
+```tsx
+<ConversationPanel theme="dark" />        // force dark
+<ConversationPanel theme="light" />       // force light
+<ConversationPanel />                     // follow OS (default)
+```
+
+### 2.3 CSS class naming
+
+All default classes use the `mast-` prefix (e.g. `mast-message`, `mast-thinking-block`).
+This avoids collisions with Tailwind utility classes and other CSS frameworks.
+
+---
+
+## 3. Data Types
+
+These types live in `@mast-ai/react-ui` and are separate from the `@mast-ai/core` types
+they are derived from. The UI types represent the *rendered state* of a conversation, not
+the raw protocol messages.
+
+```typescript
+export interface ToolEventEntry {
+  type: 'tool_call_started' | 'tool_call_completed';
+  name: string;
+  args?: unknown;
+  result?: unknown;
+}
+
+export interface ConversationEntry {
+  id: string;               // stable key for React reconciliation
+  role: 'user' | 'assistant';
+  text: string;             // accumulated text (empty while streaming)
+  thinking?: string;        // accumulated thinking (empty while streaming)
+  toolEvents: ToolEventEntry[];
+  isStreaming: boolean;
+}
+```
+
+The `useAgentStream` internal hook builds and maintains a `ConversationEntry[]` from
+the `AgentEvent` stream emitted by `AgentRunner`.
+
+---
+
+## 4. Components
+
+### 4.1 `<AgentProvider>`
+
+Wraps a subtree with agent context. Manages a `Conversation` instance from
+`@mast-ai/core` and exposes it via the `useAgent()` hook.
+
+```tsx
+interface AgentProviderProps {
+  runner: AgentRunner;
+  agent: AgentConfig;
+  children: React.ReactNode;
+  icons?: IconMap;
+
+  /**
+   * Called before executing any tool call that has requiresApproval: true in
+   * its ToolDefinition. Return true to proceed, false to cancel, or a string
+   * to short-circuit execution with a synthetic result.
+   *
+   * Also called for any tool whose name appears in approvalOverride, regardless
+   * of the tool's own requiresApproval flag — allowing context-specific policy
+   * (e.g. a sandbox environment that auto-approves everything, or a production
+   * deployment that adds approval to a third-party tool it did not define).
+   */
+  onApprovalRequired?: (toolCall: ToolEventEntry) => Promise<boolean | string>;
+
+  /**
+   * Runtime override of per-tool approval policy. Names in this set trigger
+   * onApprovalRequired even if requiresApproval is false on the tool definition;
+   * names prefixed with '!' suppress approval even if requiresApproval is true.
+   * Example: approvalOverride={['extra_tool', '!safe_tool']}
+   */
+  approvalOverride?: string[];
+}
+```
+
+**Internal state managed by `AgentProvider`:**
+- `conversation` — `Conversation` instance (from `@mast-ai/core`)
+- `entries` — `ConversationEntry[]` built by processing `AgentEvent` stream
+- `isRunning` — boolean
+- `abortController` — ref, replaced on each new run
+
+### 4.2 `<ConversationPanel>`
+
+Renders a complete chat UI as a single composable unit. Internally renders
+`<MessageList>` and `<ChatInput>`. Requires `<AgentProvider>` as an ancestor.
+
+```tsx
+interface ConversationPanelProps {
+  className?: string;
+
+  /** Replace the default tool call renderer. Receives the ToolEventEntry. */
+  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+
+  /** Replace the default markdown renderer. Receives the raw text string. */
+  renderMessage?: (text: string) => React.ReactNode;
+
+  /** Placeholder text for the input field. */
+  inputPlaceholder?: string;
+}
+```
+
+Renders:
+
+```html
+<div data-mast-root class="mast-conversation-panel {className}">
+  <MessageList renderToolCall={...} renderMessage={...} />
+  <ChatInput placeholder={...} />
+</div>
+```
+
+### 4.3 `<MessageList>`
+
+Scrollable list of `ConversationEntry` items. Reads `entries` from context.
+Uses `@tanstack/react-virtual` (`useVirtualizer`) to render only the visible window of
+messages. Automatically scrolls to the bottom when a new entry is appended or the last
+entry (currently streaming) changes size.
+
+```tsx
+interface MessageListProps {
+  className?: string;
+  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+  renderMessage?: (text: string) => React.ReactNode;
+}
+```
+
+The virtualizer uses dynamic item measurement (`measureElement`) so variable-height
+messages (those with long tool call results or large markdown blocks) are handled
+correctly. A `useEffect` that watches `entries.length` and the last entry's `text`
+length drives the auto-scroll-to-bottom behaviour.
+
+Renders:
+
+```html
+<div data-mast-message-list class="mast-message-list {className}" role="log" aria-live="polite">
+  <div style="height: {totalSize}px; position: relative;">
+    {virtualItems.map(item => (
+      <div data-index={item.index} style="position: absolute; top: {item.start}px; width: 100%">
+        <MessageItem entry={entries[item.index]} ... />
+      </div>
+    ))}
+  </div>
+</div>
+```
+
+### 4.4 `<MessageItem>`
+
+Renders a single `ConversationEntry`. Delegates to `<UserMessage>` or
+`<AssistantMessage>` based on `entry.role`.
+
+```tsx
+interface MessageItemProps {
+  entry: ConversationEntry;
+  className?: string;
+  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+  renderMessage?: (text: string) => React.ReactNode;
+}
+```
+
+### 4.5 `<AssistantMessage>`
+
+Renders an assistant turn: optional `<ThinkingBlock>`, zero or more
+`<ToolCallBlock>` entries, then the final text. Text is rendered via the optional
+`react-markdown` renderer or the `renderMessage` override.
+
+```tsx
+interface AssistantMessageProps {
+  entry: ConversationEntry;
+  className?: string;
+  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+  renderMessage?: (text: string) => React.ReactNode;
+}
+```
+
+### 4.6 `<UserMessage>`
+
+Renders a user turn as a simple text bubble.
+
+```tsx
+interface UserMessageProps {
+  entry: ConversationEntry;
+  className?: string;
+}
+```
+
+### 4.7 `<ThinkingBlock>`
+
+Collapsible section for the agent's thinking/reasoning trace.
+
+```tsx
+interface ThinkingBlockProps {
+  content: string;
+  isStreaming?: boolean;
+  className?: string;
+  /** Default: 'Thinking Process' */
+  label?: string;
+}
+```
+
+- When `isStreaming` is true, shows a pulsing indicator next to the label.
+- Collapsed by default; expands on click.
+- Uses a native `<details>/<summary>` element so it works without JavaScript and is
+  keyboard-accessible by default.
+
+### 4.8 `<ToolCallBlock>`
+
+Displays a single tool invocation: name, collapsible args, and result once available.
+
+```tsx
+interface ToolCallBlockProps {
+  entry: ToolEventEntry;
+  className?: string;
+}
+```
+
+- Pending state (no `result` yet): shows a spinner indicator and `args` collapsed.
+- Completed state (`result` present): shows a check mark; `result` available in
+  expanded view.
+- Args and result are rendered as formatted JSON in a `<pre>` block.
+- Uses `<details>/<summary>` for expand/collapse.
+
+### 4.9 `<ChatInput>`
+
+Text input wired to `sendMessage` from context. Handles Enter-to-send and
+disabled state during streaming.
+
+```tsx
+interface ChatInputProps {
+  className?: string;
+  placeholder?: string;
+  /** Overrides default send button content */
+  sendLabel?: React.ReactNode;
+  /** Overrides default cancel button content (shown while isRunning) */
+  cancelLabel?: React.ReactNode;
+}
+```
+
+- Pressing Enter (without Shift) submits.
+- While `isRunning`, the send button becomes a cancel button that calls `cancel()`.
+- Auto-grows vertically (using `rows` attribute, not fixed height).
+
+---
+
+## 5. Hooks
+
+### `useAgent()`
+
+Access agent state from any component inside `<AgentProvider>`.
+
+```typescript
+interface UseAgentReturn {
+  messages: ConversationEntry[];
+  sendMessage: (text: string) => void;
+  cancel: () => void;
+  isRunning: boolean;
+  reset: () => void;   // clears entries and starts a new Conversation
+}
+
+function useAgent(): UseAgentReturn;
+```
+
+Throws if called outside `<AgentProvider>`.
+
+---
+
+## 6. Icons
+
+### 6.1 Strategy
+
+Icons are **bundled inline** as small SVG React components. The library has no dependency
+on `lucide-react` or any icon library. Consuming apps that prefer a different icon set
+pass replacements via the `icons` prop on `<AgentProvider>`.
+
+### 6.2 Default icon set
+
+The following icons ship inside the package as hand-authored SVGs (~50–80 bytes each,
+~500 bytes total gzipped):
+
+| Key | Used in | Default appearance |
+|-----|---------|--------------------|
+| `brain` | `<ThinkingBlock>` header | Simple brain outline |
+| `wrench` | `<ToolCallBlock>` header (pending) | Simple wrench outline |
+| `check` | `<ToolCallBlock>` header (completed) | Checkmark circle |
+| `loader` | Streaming / pending spinner | Animated spinning circle |
+| `send` | `<ChatInput>` send button | Filled arrow |
+| `stop` | `<ChatInput>` cancel button | Filled square |
+
+### 6.3 `IconMap` type
+
+```typescript
+export interface IconMap {
+  brain?: React.ReactNode;
+  wrench?: React.ReactNode;
+  check?: React.ReactNode;
+  loader?: React.ReactNode;
+  send?: React.ReactNode;
+  stop?: React.ReactNode;
+}
+```
+
+All keys are optional. Unspecified keys fall back to the bundled defaults.
+
+### 6.4 `icons` prop on `<AgentProvider>`
+
+```tsx
+interface AgentProviderProps {
+  // ... existing props
+  icons?: IconMap;
+}
+```
+
+Icons are distributed to child components via a dedicated `IconContext` (separate from
+agent state to avoid re-renders on state changes).
+
+### 6.5 Lucide usage example
+
+```tsx
+import { Brain, Wrench, CircleCheck, LoaderCircle, Send, Square } from 'lucide-react';
+
+<AgentProvider
+  runner={runner}
+  agent={agentConfig}
+  icons={{
+    brain: <Brain size={16} />,
+    wrench: <Wrench size={16} />,
+    check: <CircleCheck size={16} />,
+    loader: <LoaderCircle size={16} className="mast-spin" />,
+    send: <Send size={16} />,
+    stop: <Square size={16} />,
+  }}
+>
+  <ConversationPanel />
+</AgentProvider>
+```
+
+### 6.6 `useIcons()` hook (internal)
+
+Components read icons via an internal `useIcons()` hook rather than accepting individual
+icon props. This keeps the per-component API clean while still allowing app-wide
+overrides.
+
+```typescript
+// internal — not exported
+function useIcons(): Required<IconMap>;
+```
+
+---
+
+## 7. Module Layout
+
+```
+packages/react-ui/
+├── src/
+│   ├── index.ts               — public exports
+│   ├── context.tsx            — AgentProvider, AgentContext, useAgent
+│   ├── icons.tsx              — IconMap type, IconContext, useIcons, bundled SVG defaults
+│   ├── types.ts               — ConversationEntry, ToolEventEntry
+│   ├── hooks/
+│   │   └── useAgentStream.ts  — internal: builds ConversationEntry[] from AgentEvent
+│   └── components/
+│       ├── ConversationPanel.tsx
+│       ├── MessageList.tsx
+│       ├── MessageItem.tsx
+│       ├── AssistantMessage.tsx
+│       ├── UserMessage.tsx
+│       ├── ThinkingBlock.tsx
+│       ├── ToolCallBlock.tsx
+│       └── ChatInput.tsx
+├── styles/
+│   └── default.css            — emitted as dist/styles.css
+├── package.json
+├── tsconfig.json
+└── vite.config.ts             — library mode; externalises react, @mast-ai/core
+```
+
+### Public exports (`src/index.ts`)
+
+```typescript
+// Provider + hook
+export { AgentProvider } from './context';
+export { useAgent } from './context';
+
+// Components
+export { ConversationPanel } from './components/ConversationPanel';
+export { MessageList } from './components/MessageList';
+export { MessageItem } from './components/MessageItem';
+export { AssistantMessage } from './components/AssistantMessage';
+export { UserMessage } from './components/UserMessage';
+export { ThinkingBlock } from './components/ThinkingBlock';
+export { ToolCallBlock } from './components/ToolCallBlock';
+export { ChatInput } from './components/ChatInput';
+
+// Types
+export type { ConversationEntry, ToolEventEntry, AgentProviderProps, IconMap } from './types';
+```
+
+CSS is a separate export path (`@mast-ai/react-ui/styles.css`) handled by the build
+output, not imported from `index.ts`.
+
+---
+
+## 8. Streaming State Machine
+
+`useAgentStream` subscribes to the `AgentEvent` stream from `AgentRunner` and
+maintains `ConversationEntry[]` as follows:
+
+| Event | Action |
+|-------|--------|
+| User sends message | Append `{ role: 'user', text, isStreaming: false }` |
+| Run starts | Append `{ role: 'assistant', text: '', isStreaming: true }` |
+| `text_delta` | Mutate last entry: append `delta` to `text` |
+| `thinking` | Mutate last entry: append `delta` to `thinking` |
+| `tool_call_started` | Mutate last entry: push `{ type: 'tool_call_started', name, args }` to `toolEvents` |
+| `tool_call_completed` | Mutate last entry: update matching `toolEvents` entry with `result` |
+| `done` | Mutate last entry: set `text = output`, `isStreaming = false` |
+| Error / cancel | Mutate last entry: set `isStreaming = false`; optionally append error text |
+
+State updates use `React.useState` with structural copies to trigger re-renders. The
+last entry's `isStreaming` flag drives the pulsing indicator in `<ThinkingBlock>` and
+the spinner in `<ToolCallBlock>`.
+
+---
+
+## 9. Tool Approval Flow (Optional)
+
+### 9.1 Policy: `requiresApproval` on `ToolDefinition` (core change)
+
+Approval intent is declared by the tool author on the tool definition:
+
+```typescript
+// @mast-ai/core — ToolDefinition extended
+interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  requiresApproval?: boolean;  // tool author declares this tool is sensitive
+}
+```
+
+This is the canonical signal. `requiresApproval: true` means "pause and ask a human
+before executing this." The declaration lives next to the tool's name and description,
+where it is discoverable, portable across all MAST runners, and set once rather than
+per-app.
+
+### 9.2 Mechanism: `onApprovalRequired` callback
+
+`AgentProvider` pauses the run before executing any tool whose effective approval flag
+is `true` and calls `onApprovalRequired`. The consuming app renders its own confirmation
+UI and returns:
+- `true` — proceed with the tool call as normal
+- `false` — cancel the tool call; the runner receives a synthetic "user cancelled" result
+- `string` — skip execution and inject this string as the tool result directly
+
+```tsx
+<AgentProvider
+  runner={runner}
+  agent={agentConfig}
+  onApprovalRequired={async (toolCall) => {
+    return await myConfirmationDialog(toolCall);
+  }}
+>
+```
+
+### 9.3 Runtime override: `approvalOverride`
+
+The `approvalOverride` prop allows context-specific policy adjustments without touching
+tool definitions:
+
+```tsx
+// A sandbox that suppresses approval for normally-sensitive tools:
+<AgentProvider approvalOverride={['!delete_file']} ... />
+
+// A high-trust workflow that adds approval to a third-party tool it didn't define:
+<AgentProvider approvalOverride={['third_party_tool']} ... />
+```
+
+Names prefixed with `!` suppress approval even when the tool has `requiresApproval: true`.
+Unprefixed names add approval even when the tool does not.
+
+The effective approval decision for a tool named `name` is:
+
+```
+overrideSet = new Set(approvalOverride.filter(s => !s.startsWith('!')))
+suppressSet = new Set(approvalOverride.filter(s => s.startsWith('!')).map(s => s.slice(1)))
+
+needsApproval = (toolDef.requiresApproval || overrideSet.has(name)) && !suppressSet.has(name)
+```
+
+`onApprovalRequired` is not called when `needsApproval` is false, or when
+`onApprovalRequired` is not provided (in which case tools with `requiresApproval: true`
+execute without pausing — the callback is the opt-in).
+
+---
+
+## 10. Accessibility
+
+- `<MessageList>` uses `role="log"` and `aria-live="polite"` so screen readers
+  announce new messages.
+- `<ThinkingBlock>` and `<ToolCallBlock>` use native `<details>/<summary>` elements,
+  which are keyboard-accessible without JavaScript.
+- `<ChatInput>` has an associated `<label>` (visually hidden) for screen readers.
+- Send and cancel buttons have descriptive `aria-label` attributes.
+- Streaming indicators (pulsing dots) are wrapped in `aria-hidden="true"` since they
+  convey purely visual state already communicated via `aria-live`.
+
+---
+
+## 11. Testing Strategy
+
+### 11.1 Stack
+
+| Tool | Role |
+|------|------|
+| Vitest | Test runner (consistent with other packages in the monorepo) |
+| `@testing-library/react` | Component rendering and user-event simulation |
+| `jsdom` | DOM environment for Vitest |
+| `@testing-library/user-event` | Realistic keyboard/click interactions |
+
+### 11.2 Unit tests
+
+**`useAgentStream` (highest priority)**
+
+The streaming state machine is the most complex logic in the library and the hardest
+to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequence of
+`AgentEvent`s.
+
+| Scenario | What is verified |
+|----------|-----------------|
+| Text streaming | `text_delta` events accumulate into the last entry's `text`; `isStreaming` is true during and false after |
+| Thinking streaming | `thinking` deltas accumulate into `thinking`; co-exists with text deltas |
+| Tool call lifecycle | `tool_call_started` appends a pending `ToolEventEntry`; `tool_call_completed` updates it with `result` |
+| Multiple concurrent tool calls | Each call tracked independently by name |
+| `done` event | Sets `isStreaming: false`, finalises `text` from `output` |
+| Error / cancel | Sets `isStreaming: false` on the last entry; prior entries unchanged |
+| New turn while previous is complete | Appends a new entry rather than mutating the last |
+
+**Approval flow**
+
+| Scenario | What is verified |
+|----------|-----------------|
+| Tool with `requiresApproval: true` | `onApprovalRequired` is called before tool executes |
+| Callback returns `false` | Tool call is cancelled; runner receives synthetic "user cancelled" result |
+| Callback returns a string | Injected as the tool result; tool does not execute |
+| `approvalOverride` adds a name | Unlisted tool triggers approval |
+| `approvalOverride` suppresses with `!` | Tool with `requiresApproval: true` executes without prompting |
+| No `onApprovalRequired` provided | Tools with `requiresApproval: true` execute silently |
+
+**Components**
+
+| Component | Scenarios tested |
+|-----------|-----------------|
+| `<ThinkingBlock>` | Renders collapsed by default; expands on click; shows pulse indicator when `isStreaming` |
+| `<ToolCallBlock>` | Pending state (spinner, no result); completed state (check, result visible when expanded) |
+| `<ChatInput>` | Enter submits; Shift+Enter does not; button switches to cancel while `isRunning`; disabled while `isRunning` |
+| `<MessageList>` | Renders user and assistant entries; scrolls to bottom on new entry |
+| `<AgentProvider>` | `useAgent()` throws when called outside provider |
+| Icon override | Components render the custom node from `icons` prop instead of default SVG |
+
+### 11.3 File layout
+
+```
+packages/react-ui/
+└── src/
+    └── __tests__/
+        ├── useAgentStream.test.ts
+        ├── approval.test.tsx
+        ├── ThinkingBlock.test.tsx
+        ├── ToolCallBlock.test.tsx
+        ├── ChatInput.test.tsx
+        ├── MessageList.test.tsx
+        └── AgentProvider.test.tsx
+```
+
+---
+
+## 12. Demo App (`apps/demo-react-ui`)
+
+A Vite + React + TypeScript app in the monorepo that serves as both a manual test
+surface and a reference implementation.
+
+### Stack
+
+| Concern | Choice |
+|---------|--------|
+| Bundler | Vite |
+| LLM adapter | `@mast-ai/google-genai` (API key via `VITE_GEMINI_API_KEY` in `.env`) |
+| Icons | `lucide-react` (demonstrates icon override) |
+| Markdown | `react-markdown` + `remark-gfm` + `rehype-sanitize` |
+
+### What it demonstrates
+
+1. **Minimal setup** — `<AgentProvider>` + `<ConversationPanel>` with a single CSS import
+   and a `GoogleGenAIAdapter`.
+2. **Custom icons** — all six icon slots overridden with `lucide-react` equivalents.
+3. **Tool call rendering** — two registered tools (`get_current_time`,
+   `get_page_title`) so tool call blocks appear in the conversation.
+4. **Dark mode** — a toggle button that sets `theme="dark"` / `"light"` on
+   `<ConversationPanel>`, demonstrating manual theme control alongside the OS default.
+5. **Approval flow** — `get_page_title` has `requiresApproval: true`; the demo shows a
+   simple browser `confirm()` dialog wired to `onApprovalRequired`.
+
+### File structure
+
+```
+apps/demo-react-ui/
+├── src/
+│   ├── main.tsx        — mounts App
+│   ├── App.tsx         — AgentProvider setup, tool registration, theme toggle
+│   └── tools.ts        — get_current_time and get_page_title tool definitions
+├── index.html
+├── vite.config.ts
+├── tsconfig.json
+├── package.json
+└── .env.example        — VITE_GEMINI_API_KEY=your_key_here
+```
+
+---
+
+## 13. Post-Implementation Deliverables
+
+The following are required before the feature is considered complete. They are deferred
+until the package and demo are implemented and manually verified.
+
+### 12.1 Developer documentation (`docs/react-ui/USAGE.md`)
+
+A usage guide covering:
+
+- Installation (peer deps, optional deps, CSS import)
+- Basic setup with `GoogleGenAIAdapter`
+- Registering tools
+- Custom icons (lucide-react example)
+- Dark mode and theming (CSS variable overrides)
+- Custom tool call rendering (`renderToolCall` prop)
+- Custom message rendering (`renderMessage` prop)
+- Composing a custom layout with primitives (`MessageList` + `ChatInput`)
+- Fully headless usage via `useAgent()`
+- Approval flow (`requiresApproval` on `ToolDefinition` + `onApprovalRequired` callback)
+
+### 12.2 Skill update (`skills/mast-ai/`)
+
+- Add `@mast-ai/react-ui` to the Core Concepts list in `SKILL.md`
+- Add a reference link to `references/react-ui.md` in `SKILL.md`
+- Create `skills/mast-ai/references/react-ui.md` mirroring the USAGE.md content in
+  reference format
+- Add `skills/mast-ai/assets/react-ui-basic.tsx` — a minimal working example showing
+  `AgentProvider` + `ConversationPanel` with `GoogleGenAIAdapter`

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -146,6 +146,9 @@ export interface ToolEventEntry {
   name: string;
   args?: unknown;
   result?: unknown;
+  subThinking?: string;  // accumulated thinking streamed from inside the tool/sub-agent
+  subText?: string;      // accumulated text streamed from inside the tool/sub-agent
+  isStreaming: boolean;  // true while the tool is executing
 }
 
 export interface ConversationEntry {
@@ -196,6 +199,27 @@ interface AgentProviderProps {
    * Example: approvalOverride={['extra_tool', '!safe_tool']}
    */
   approvalOverride?: string[];
+
+  /**
+   * Seed the conversation with a previously saved Message[] history.
+   * The history is set on the underlying Conversation instance before the
+   * first turn, allowing the LLM to continue from where it left off.
+   */
+  initialHistory?: Message[];
+
+  /**
+   * Seed the UI rendering state with a previously saved ConversationEntry[].
+   * Use alongside initialHistory to fully restore a prior session.
+   */
+  initialEntries?: ConversationEntry[];
+
+  /**
+   * Called after each completed turn (not during streaming) with the latest
+   * core message history and UI entry list. Use this to persist the conversation
+   * to localStorage, IndexedDB, a server, or any other storage.
+   * Not called when a run is cancelled or errors before completion.
+   */
+  onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
 }
 ```
 
@@ -329,7 +353,7 @@ interface ThinkingBlockProps {
 
 ### 4.8 `<ToolCallBlock>`
 
-Displays a single tool invocation: name, collapsible args, and result once available.
+Displays a single tool invocation with live streaming of sub-agent output.
 
 ```tsx
 interface ToolCallBlockProps {
@@ -338,11 +362,15 @@ interface ToolCallBlockProps {
 }
 ```
 
-- Pending state (no `result` yet): shows a spinner indicator and `args` collapsed.
-- Completed state (`result` present): shows a check mark; `result` available in
-  expanded view.
-- Args and result are rendered as formatted JSON in a `<pre>` block.
-- Uses `<details>/<summary>` for expand/collapse.
+- **Streaming state** (`isStreaming: true`): spinner icon; `subThinking` rendered in a
+  collapsible `<ThinkingBlock>` that auto-expands while streaming; `subText` rendered
+  as live markdown below the thinking block.
+- **Completed state** (`isStreaming: false`): check mark icon; `subThinking` and
+  `subText` remain visible (collapsed by default); `result` available in expanded view
+  as formatted JSON.
+- Tools that are not sub-agents will have no `subThinking` or `subText`; they show
+  only the spinner → check transition and args/result.
+- Uses `<details>/<summary>` for args and result expand/collapse.
 
 ### 4.9 `<ChatInput>`
 
@@ -375,10 +403,11 @@ Access agent state from any component inside `<AgentProvider>`.
 ```typescript
 interface UseAgentReturn {
   messages: ConversationEntry[];
+  history: Message[];        // raw core Message[] — read this to imperatively save state
   sendMessage: (text: string) => void;
   cancel: () => void;
   isRunning: boolean;
-  reset: () => void;   // clears entries and starts a new Conversation
+  reset: () => void;         // clears entries and history; starts a new Conversation
 }
 
 function useAgent(): UseAgentReturn;
@@ -535,10 +564,14 @@ maintains `ConversationEntry[]` as follows:
 | Run starts | Append `{ role: 'assistant', text: '', isStreaming: true }` |
 | `text_delta` | Mutate last entry: append `delta` to `text` |
 | `thinking` | Mutate last entry: append `delta` to `thinking` |
-| `tool_call_started` | Mutate last entry: push `{ type: 'tool_call_started', name, args }` to `toolEvents` |
-| `tool_call_completed` | Mutate last entry: update matching `toolEvents` entry with `result` |
+| `tool_call_started` | Mutate last entry: push `{ type: 'tool_call_started', name, args, isStreaming: true }` to `toolEvents` |
+| `onToolEvent` → `thinking` | Mutate matching `ToolEventEntry`: append `delta` to `subThinking` |
+| `onToolEvent` → `text_delta` | Mutate matching `ToolEventEntry`: append `delta` to `subText` |
+| `tool_call_completed` | Mutate matching `ToolEventEntry`: set `result`, `isStreaming: false` |
 | `done` | Mutate last entry: set `text = output`, `isStreaming = false` |
 | Error / cancel | Mutate last entry: set `isStreaming = false`; optionally append error text |
+
+`onToolEvent` events are wired by passing an `onToolEvent` handler to `RunBuilder` inside `useAgentStream`. Events are matched to the correct `ToolEventEntry` by `toolName`. The `done` event from a sub-agent is ignored — the parent's `tool_call_completed` is the authoritative signal that a tool finished.
 
 State updates use `React.useState` with structural copies to trigger re-renders. The
 last entry's `isStreaming` flag drives the pulsing indicator in `<ThinkingBlock>` and
@@ -653,8 +686,11 @@ to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequen
 |----------|-----------------|
 | Text streaming | `text_delta` events accumulate into the last entry's `text`; `isStreaming` is true during and false after |
 | Thinking streaming | `thinking` deltas accumulate into `thinking`; co-exists with text deltas |
-| Tool call lifecycle | `tool_call_started` appends a pending `ToolEventEntry`; `tool_call_completed` updates it with `result` |
-| Multiple concurrent tool calls | Each call tracked independently by name |
+| Tool call lifecycle | `tool_call_started` appends a pending `ToolEventEntry` with `isStreaming: true`; `tool_call_completed` sets `result` and `isStreaming: false` |
+| Sub-agent thinking | `onToolEvent` → `thinking` appends to matching `ToolEventEntry.subThinking` |
+| Sub-agent text | `onToolEvent` → `text_delta` appends to matching `ToolEventEntry.subText` |
+| Sub-agent `done` ignored | `onToolEvent` → `done` does not affect parent entry's `isStreaming` |
+| Multiple concurrent tool calls | Each call tracked independently by name; sub-agent events routed to correct entry |
 | `done` event | Sets `isStreaming: false`, finalises `text` from `output` |
 | Error / cancel | Sets `isStreaming: false` on the last entry; prior entries unchanged |
 | New turn while previous is complete | Appends a new entry rather than mutating the last |
@@ -670,6 +706,17 @@ to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequen
 | `approvalOverride` suppresses with `!` | Tool with `requiresApproval: true` executes without prompting |
 | No `onApprovalRequired` provided | Tools with `requiresApproval: true` execute silently |
 
+**Conversation persistence**
+
+| Scenario | What is verified |
+|----------|-----------------|
+| `onConversationChange` fires | Called with current `history` and `entries` after `done` event |
+| Not called on cancel/error | Callback not invoked when run ends without `done` |
+| `initialHistory` seeds core history | First turn sent to runner includes the provided prior messages |
+| `initialEntries` seeds UI | Pre-existing entries render immediately on mount |
+| `reset()` clears both | After reset, `messages` is empty and `history` is empty |
+| `useAgent().history` reflects state | Returns the live `Conversation.history` after each turn |
+
 **Components**
 
 | Component | Scenarios tested |
@@ -683,17 +730,20 @@ to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequen
 
 ### 11.3 File layout
 
+Test files live alongside their source, following the convention of the other packages
+in the monorepo.
+
 ```
-packages/react-ui/
-└── src/
-    └── __tests__/
-        ├── useAgentStream.test.ts
-        ├── approval.test.tsx
-        ├── ThinkingBlock.test.tsx
-        ├── ToolCallBlock.test.tsx
-        ├── ChatInput.test.tsx
-        ├── MessageList.test.tsx
-        └── AgentProvider.test.tsx
+packages/react-ui/src/
+├── context.test.tsx
+├── approval.test.tsx
+├── hooks/
+│   └── useAgentStream.test.ts
+└── components/
+    ├── ThinkingBlock.test.tsx
+    ├── ToolCallBlock.test.tsx
+    ├── ChatInput.test.tsx
+    └── MessageList.test.tsx
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds `docs/react-ui/PRD.md` and `docs/react-ui/SPEC.md` defining the design for `@mast-ai/react-ui`, a React component library that wires up a MAST `AgentRunner` to a chat UI with no Tailwind or Radix dependency
- Updates `CLAUDE.md` to clarify that all feature-level PRD/SPEC files (not just library-level ones) must be kept current throughout implementation

## Key design decisions

- **Styling**: plain CSS with `--mast-*` custom properties; light + dark themes out of the box; single `import '@mast-ai/react-ui/styles.css'` to opt in
- **Icons**: bundled inline SVGs as defaults; `icons` prop on `AgentProvider` accepts any `React.ReactNode` for each slot (lucide, heroicons, etc.)
- **Virtual scrolling**: `@tanstack/react-virtual` as a required peer dep; default in `MessageList`
- **Markdown**: optional `react-markdown` + `rehype-sanitize` (always applied when present); `renderMessage` prop for custom renderers
- **Approval flow**: `requiresApproval` on `@mast-ai/core` `ToolDefinition` declares intent; `onApprovalRequired` callback handles the mechanism; `approvalOverride` for runtime policy adjustments
- **Conversation persistence**: `initialHistory`/`initialEntries` props to restore sessions; `onConversationChange` callback for saving; `useAgent().history` for imperative access
- **Sub-agent streaming**: `ToolEventEntry` captures `subThinking`/`subText` streamed live from inside sub-agent tool calls via `RunBuilder.onToolEvent`

## Tracking issue

Closes part of #43 (docs milestone — implementation tracked separately via #28–#44)