### PR TITLE
feat(core): add requiresApproval to ToolDefinition

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -11,6 +11,8 @@ export interface ToolDefinition {
   parameters: Record<string, unknown>;
   /** Whether the tool reads or modifies state. Used for scope-based filtering. */
   scope: 'read' | 'write';
+  /** When true, the tool author declares this tool is sensitive and requires human confirmation before executing. */
+  requiresApproval?: boolean;
 }
 
 /** Runtime context passed to every {@link Tool.call} invocation. */


### PR DESCRIPTION
## Summary
- Adds optional `requiresApproval?: boolean` field to `ToolDefinition` in `packages/core/src/tool.ts`
- Metadata-only change — no behaviour change in core
- Used by `AgentProvider` in `@mast-ai/react-ui` to identify tools requiring human confirmation before executing

## References
- SPEC: `docs/react-ui/SPEC.md` §9.1

Closes #38