### PR TITLE
feat(react-ui): core types and useAgentStream streaming state machine

### DIFF
--- a/packages/react-ui/src/hooks/useAgentStream.test.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.test.ts
@@ -1,0 +1,572 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { AgentEvent, Conversation } from '@mast-ai/core';
+import { useAgentStream } from './useAgentStream';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+type OnToolEvent = (toolName: string, event: AgentEvent) => void;
+
+/**
+ * Creates a minimal Conversation mock whose `runStream` yields the given
+ * `mainEvents` in order.
+ *
+ * After yielding each `tool_call_started` event, any sub-events registered for
+ * that tool name in `subEventsByTool` are synchronously forwarded to the
+ * `onToolEvent` callback — simulating a sub-agent emitting events during tool
+ * execution.
+ */
+function mockConversation(
+  mainEvents: AgentEvent[],
+  subEventsByTool?: Map<string, AgentEvent[]>,
+): Conversation {
+  return {
+    history: [],
+    runStream(
+      _input: string,
+      _signal?: AbortSignal,
+      onToolEvent?: OnToolEvent,
+    ): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        for (const event of mainEvents) {
+          yield event;
+          if (event.type === 'tool_call_started' && onToolEvent && subEventsByTool) {
+            for (const sub of subEventsByTool.get(event.name) ?? []) {
+              onToolEvent(event.name, sub);
+            }
+          }
+        }
+      })();
+    },
+  } as unknown as Conversation;
+}
+
+/**
+ * Creates a Conversation mock whose stream yields `beforeEvents`, then blocks
+ * until the returned `resume` function is called, then yields `afterEvents`.
+ *
+ * Useful for asserting intermediate streaming state.
+ */
+function pausableConversation(
+  beforeEvents: AgentEvent[],
+  afterEvents: AgentEvent[],
+): { conversation: Conversation; resume: () => void } {
+  let resume!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    resume = resolve;
+  });
+
+  const conversation = {
+    history: [],
+    runStream(): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        for (const event of beforeEvents) yield event;
+        await gate;
+        for (const event of afterEvents) yield event;
+      })();
+    },
+  } as unknown as Conversation;
+
+  return { conversation, resume };
+}
+
+/**
+ * Creates a Conversation mock whose stream yields `beforeEvents` then throws
+ * an error, simulating a network failure or adapter error.
+ */
+function erroringConversation(beforeEvents: AgentEvent[]): Conversation {
+  return {
+    history: [],
+    runStream(): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        for (const event of beforeEvents) yield event;
+        throw new Error('Stream error');
+      })();
+    },
+  } as unknown as Conversation;
+}
+
+/**
+ * Creates a Conversation mock whose stream blocks until the returned abort
+ * signal fires, simulating a long-running run that is externally cancelled.
+ */
+function cancellableConversation(beforeEvents: AgentEvent[]): {
+  conversation: Conversation;
+} {
+  const conversation = {
+    history: [],
+    runStream(_input: string, signal?: AbortSignal): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        for (const event of beforeEvents) yield event;
+        await new Promise<never>((_, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('Aborted')));
+        });
+      })();
+    },
+  } as unknown as Conversation;
+  return { conversation };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAgentStream', () => {
+  it('starts with empty entries and isRunning false', () => {
+    const conv = mockConversation([]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    expect(result.current.entries).toHaveLength(0);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Text streaming
+  // -------------------------------------------------------------------------
+
+  it('appends a user entry and a streaming assistant entry immediately on sendMessage', () => {
+    const { conversation, resume } = pausableConversation([], []);
+    const { result } = renderHook(() => useAgentStream(conversation));
+
+    act(() => {
+      result.current.sendMessage('Hello');
+    });
+
+    expect(result.current.entries).toHaveLength(2);
+    expect(result.current.entries[0]).toMatchObject({ role: 'user', text: 'Hello', isStreaming: false });
+    expect(result.current.entries[1]).toMatchObject({ role: 'assistant', text: '', isStreaming: true });
+    expect(result.current.isRunning).toBe(true);
+
+    resume();
+  });
+
+  it('accumulates text_delta events into the assistant entry text', async () => {
+    const conv = mockConversation([
+      { type: 'text_delta', delta: 'Hello' },
+      { type: 'text_delta', delta: ', ' },
+      { type: 'text_delta', delta: 'world' },
+      { type: 'done', output: 'Hello, world', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('Hi');
+    });
+
+    expect(result.current.entries[1].text).toBe('Hello, world');
+    expect(result.current.entries[1].isStreaming).toBe(false);
+  });
+
+  it('sets isStreaming false on the assistant entry after the done event', async () => {
+    const conv = mockConversation([
+      { type: 'text_delta', delta: 'Hi' },
+      { type: 'done', output: 'Hi', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('Hey');
+    });
+
+    expect(result.current.entries[1].isStreaming).toBe(false);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('finalises text from done.output, not from accumulated deltas', async () => {
+    const conv = mockConversation([
+      { type: 'text_delta', delta: 'partial' },
+      { type: 'done', output: 'canonical output', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('go');
+    });
+
+    expect(result.current.entries[1].text).toBe('canonical output');
+  });
+
+  it('isStreaming is true during streaming and false after completion', async () => {
+    const { conversation, resume } = pausableConversation(
+      [{ type: 'text_delta', delta: 'So far...' }],
+      [{ type: 'done', output: 'So far...', history: [] }],
+    );
+    const { result } = renderHook(() => useAgentStream(conversation));
+
+    // Start the run but do not let it complete yet.
+    act(() => {
+      result.current.sendMessage('test');
+    });
+
+    expect(result.current.entries[1].isStreaming).toBe(true);
+    expect(result.current.isRunning).toBe(true);
+
+    // Let the stream complete.
+    resume();
+    await act(async () => {});
+
+    expect(result.current.entries[1].isStreaming).toBe(false);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Thinking streaming
+  // -------------------------------------------------------------------------
+
+  it('accumulates thinking deltas into the thinking field', async () => {
+    const conv = mockConversation([
+      { type: 'thinking', delta: 'Step 1. ' },
+      { type: 'thinking', delta: 'Step 2.' },
+      { type: 'text_delta', delta: 'Answer' },
+      { type: 'done', output: 'Answer', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('think');
+    });
+
+    expect(result.current.entries[1].thinking).toBe('Step 1. Step 2.');
+    expect(result.current.entries[1].text).toBe('Answer');
+  });
+
+  it('thinking field is undefined when no thinking deltas are emitted', async () => {
+    const conv = mockConversation([
+      { type: 'text_delta', delta: 'Answer' },
+      { type: 'done', output: 'Answer', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    expect(result.current.entries[1].thinking).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool call lifecycle
+  // -------------------------------------------------------------------------
+
+  it('appends a streaming ToolEventEntry on tool_call_started', async () => {
+    const { conversation, resume } = pausableConversation(
+      [{ type: 'tool_call_started', name: 'my_tool', args: { x: 1 } }],
+      [
+        { type: 'tool_call_completed', name: 'my_tool', result: 'done' },
+        { type: 'done', output: 'ok', history: [] },
+      ],
+    );
+    const { result } = renderHook(() => useAgentStream(conversation));
+
+    act(() => {
+      result.current.sendMessage('run');
+    });
+
+    // The tool_call_started state update is async; waitFor polls until it lands.
+    await waitFor(() => {
+      expect(result.current.entries[1].toolEvents).toHaveLength(1);
+    });
+    expect(result.current.entries[1].toolEvents[0]).toMatchObject({
+      type: 'tool_call_started',
+      name: 'my_tool',
+      args: { x: 1 },
+      isStreaming: true,
+    });
+
+    resume();
+    await act(async () => {});
+  });
+
+  it('marks ToolEventEntry completed with result on tool_call_completed', async () => {
+    const conv = mockConversation([
+      { type: 'tool_call_started', name: 'calc', args: { expr: '2+2' } },
+      { type: 'tool_call_completed', name: 'calc', result: 4 },
+      { type: 'done', output: 'The answer is 4.', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('calculate');
+    });
+
+    const toolEvent = result.current.entries[1].toolEvents[0];
+    expect(toolEvent.type).toBe('tool_call_completed');
+    expect(toolEvent.result).toBe(4);
+    expect(toolEvent.isStreaming).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Sub-agent thinking via onToolEvent
+  // -------------------------------------------------------------------------
+
+  it('appends sub-agent thinking deltas to ToolEventEntry.subThinking', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      [
+        'agent_tool',
+        [
+          { type: 'thinking', delta: 'Considering...' },
+          { type: 'thinking', delta: ' Done.' },
+        ],
+      ],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'agent_tool', args: {} },
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'ok' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run agent');
+    });
+
+    expect(result.current.entries[1].toolEvents[0].subThinking).toBe('Considering... Done.');
+  });
+
+  // -------------------------------------------------------------------------
+  // Sub-agent text via onToolEvent
+  // -------------------------------------------------------------------------
+
+  it('appends sub-agent text_delta events to ToolEventEntry.subText', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      [
+        'agent_tool',
+        [
+          { type: 'text_delta', delta: 'Sub ' },
+          { type: 'text_delta', delta: 'response.' },
+        ],
+      ],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'agent_tool', args: {} },
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'ok' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run agent');
+    });
+
+    expect(result.current.entries[1].toolEvents[0].subText).toBe('Sub response.');
+  });
+
+  // -------------------------------------------------------------------------
+  // Sub-agent done event ignored
+  // -------------------------------------------------------------------------
+
+  it('ignores sub-agent done events — parent isStreaming is unaffected', async () => {
+    const { conversation, resume } = pausableConversation(
+      [{ type: 'tool_call_started', name: 'agent_tool', args: {} }],
+      [
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'ok' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+    );
+
+    // Patch runStream to fire a sub-agent done event before releasing the gate.
+    const base = conversation.runStream.bind(conversation);
+    (conversation as unknown as { runStream: typeof base }).runStream = function (
+      input: string,
+      signal?: AbortSignal,
+      onToolEvent?: OnToolEvent,
+    ) {
+      const inner = base(input, signal, onToolEvent);
+      return (async function* () {
+        for await (const event of inner) {
+          yield event;
+          if (event.type === 'tool_call_started' && onToolEvent) {
+            // Fire a sub-agent done — should be ignored by the hook.
+            onToolEvent('agent_tool', { type: 'done', output: 'sub done', history: [] });
+          }
+        }
+      })();
+    };
+
+    const { result } = renderHook(() => useAgentStream(conversation));
+
+    act(() => {
+      result.current.sendMessage('run');
+    });
+
+    // Parent assistant entry should still be streaming.
+    expect(result.current.entries[1].isStreaming).toBe(true);
+
+    resume();
+    await act(async () => {});
+
+    // After the parent done, it should be false.
+    expect(result.current.entries[1].isStreaming).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Concurrent tool calls
+  // -------------------------------------------------------------------------
+
+  it('tracks concurrent tool calls independently and routes sub-agent events correctly', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      ['tool_a', [{ type: 'text_delta', delta: 'Sub text A' }]],
+      ['tool_b', [{ type: 'thinking', delta: 'Sub thinking B' }]],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'tool_a', args: { a: 1 } },
+        { type: 'tool_call_started', name: 'tool_b', args: { b: 2 } },
+        { type: 'tool_call_completed', name: 'tool_a', result: 'result_a' },
+        { type: 'tool_call_completed', name: 'tool_b', result: 'result_b' },
+        { type: 'done', output: 'Both done.', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run both');
+    });
+
+    const toolEvents = result.current.entries[1].toolEvents;
+    expect(toolEvents).toHaveLength(2);
+
+    const a = toolEvents.find((t) => t.name === 'tool_a')!;
+    expect(a.subText).toBe('Sub text A');
+    expect(a.result).toBe('result_a');
+    expect(a.isStreaming).toBe(false);
+
+    const b = toolEvents.find((t) => t.name === 'tool_b')!;
+    expect(b.subThinking).toBe('Sub thinking B');
+    expect(b.result).toBe('result_b');
+    expect(b.isStreaming).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error / cancel
+  // -------------------------------------------------------------------------
+
+  it('sets isStreaming false on the last entry when the stream errors', async () => {
+    const conv = erroringConversation([{ type: 'text_delta', delta: 'Partial...' }]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('go');
+    });
+
+    expect(result.current.entries[1].isStreaming).toBe(false);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('leaves prior entries unchanged when a later run errors', async () => {
+    // First turn completes successfully.
+    const conv1 = mockConversation([
+      { type: 'text_delta', delta: 'First response' },
+      { type: 'done', output: 'First response', history: [] },
+    ]);
+    const { result, rerender } = renderHook(
+      ({ conv }: { conv: Conversation }) => useAgentStream(conv),
+      { initialProps: { conv: conv1 } },
+    );
+
+    await act(async () => {
+      result.current.sendMessage('first');
+    });
+
+    const firstAssistantText = result.current.entries[1].text;
+    expect(firstAssistantText).toBe('First response');
+
+    // Second turn errors.
+    const conv2 = erroringConversation([]);
+    rerender({ conv: conv2 });
+
+    await act(async () => {
+      result.current.sendMessage('second');
+    });
+
+    // First entry text is unchanged.
+    expect(result.current.entries[1].text).toBe('First response');
+    // Last (errored) entry has isStreaming: false.
+    expect(result.current.entries[3].isStreaming).toBe(false);
+  });
+
+  it('sets isStreaming false when cancel() is called', async () => {
+    // No beforeEvents: the stream blocks immediately so the abort listener is
+    // registered during the first generator.next() call.
+    const { conversation } = cancellableConversation([]);
+    const { result } = renderHook(() => useAgentStream(conversation));
+
+    act(() => {
+      result.current.sendMessage('go');
+    });
+
+    // Flush the microtask that starts the stream and registers the abort listener.
+    await act(async () => {});
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    // Abort resolution is async; waitFor polls until state settles.
+    await waitFor(() => {
+      expect(result.current.entries[1].isStreaming).toBe(false);
+    });
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // New turn sequencing
+  // -------------------------------------------------------------------------
+
+  it('appends a new entry pair on a second sendMessage rather than mutating the first', async () => {
+    const makeConv = (output: string) =>
+      mockConversation([{ type: 'done', output, history: [] }]);
+
+    const { result, rerender } = renderHook(
+      ({ conv }: { conv: Conversation }) => useAgentStream(conv),
+      { initialProps: { conv: makeConv('First') } },
+    );
+
+    await act(async () => {
+      result.current.sendMessage('Turn 1');
+    });
+
+    expect(result.current.entries).toHaveLength(2);
+    expect(result.current.entries[0].text).toBe('Turn 1');
+    expect(result.current.entries[1].text).toBe('First');
+
+    rerender({ conv: makeConv('Second') });
+
+    await act(async () => {
+      result.current.sendMessage('Turn 2');
+    });
+
+    expect(result.current.entries).toHaveLength(4);
+    expect(result.current.entries[2].text).toBe('Turn 2');
+    expect(result.current.entries[3].text).toBe('Second');
+
+    // Original entries are unchanged.
+    expect(result.current.entries[0].text).toBe('Turn 1');
+    expect(result.current.entries[1].text).toBe('First');
+  });
+
+  it('assigns stable unique ids to every entry', async () => {
+    const conv = mockConversation([{ type: 'done', output: 'ok', history: [] }]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    const ids = result.current.entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach((id) => expect(id).toBeTruthy());
+  });
+});

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -1,0 +1,246 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useCallback, useRef } from 'react';
+import type { Conversation } from '@mast-ai/core';
+import type { AgentEvent } from '@mast-ai/core';
+import type { ConversationEntry, ToolEventEntry } from '../types';
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(role: 'user' | 'assistant', text: string, isStreaming: boolean): ConversationEntry {
+  return { id: crypto.randomUUID(), role, text, toolEvents: [], isStreaming };
+}
+
+/**
+ * Returns a new array with the entry identified by `id` replaced by the result
+ * of calling `updater` on it. All other entries are returned unchanged.
+ */
+function updateEntry(
+  entries: ConversationEntry[],
+  id: string,
+  updater: (e: ConversationEntry) => ConversationEntry,
+): ConversationEntry[] {
+  return entries.map((e) => (e.id === id ? updater(e) : e));
+}
+
+/**
+ * Returns a new array where the first `ToolEventEntry` in the entry identified
+ * by `entryId` that matches `toolName` and is still streaming is replaced by
+ * the result of `updater`. All other entries and tool events are unchanged.
+ */
+function updateToolEvent(
+  entries: ConversationEntry[],
+  entryId: string,
+  toolName: string,
+  updater: (t: ToolEventEntry) => ToolEventEntry,
+): ConversationEntry[] {
+  return updateEntry(entries, entryId, (entry) => {
+    let patched = false;
+    const toolEvents = entry.toolEvents.map((t) => {
+      if (!patched && t.name === toolName && t.isStreaming) {
+        patched = true;
+        return updater(t);
+      }
+      return t;
+    });
+    return { ...entry, toolEvents };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * The value returned by {@link useAgentStream}.
+ */
+export interface UseAgentStreamReturn {
+  /**
+   * Ordered list of conversation entries built from the `AgentEvent` stream.
+   * Each `sendMessage` call appends one user entry and one assistant entry.
+   * Entries are updated in-place as events stream in; their `id` values are
+   * stable across renders.
+   */
+  entries: ConversationEntry[];
+
+  /**
+   * `true` while the agent is generating a response; `false` otherwise.
+   * Reflects the overall run state rather than the individual entry's streaming
+   * flag, which may differ briefly at the boundaries of a run.
+   */
+  isRunning: boolean;
+
+  /**
+   * Sends a user message and starts a new agent run.
+   *
+   * Appends a user `ConversationEntry` and an empty streaming assistant
+   * `ConversationEntry`, then consumes the `AgentEvent` stream emitted by
+   * `conversation.runStream`. Calling `sendMessage` while a run is already in
+   * progress is a no-op (the caller should disable the input while `isRunning`
+   * is true).
+   *
+   * @param text - The user's message text.
+   */
+  sendMessage: (text: string) => void;
+
+  /**
+   * Aborts the current run.
+   *
+   * Signals the underlying `AbortController`, which causes the agent loop to
+   * stop and sets the last assistant entry's `isStreaming` flag to `false`.
+   * Has no effect when `isRunning` is false.
+   */
+  cancel: () => void;
+}
+
+/**
+ * Internal hook that drives the streaming state machine for a single
+ * `Conversation` instance.
+ *
+ * Subscribes to `AgentEvent`s emitted by `conversation.runStream` and
+ * maintains a `ConversationEntry[]` that reflects the current rendered state
+ * of the conversation. Sub-agent events are captured via `onToolEvent` and
+ * routed to the matching `ToolEventEntry` by tool name.
+ *
+ * This hook is consumed by `<AgentProvider>` and is not part of the public API.
+ * It is exported so that it can be used independently in advanced scenarios.
+ *
+ * ### State machine summary
+ *
+ * | Event | Action |
+ * |-------|--------|
+ * | `sendMessage(text)` | Append user entry; append assistant entry with `isStreaming: true` |
+ * | `text_delta` | Append delta to last assistant entry's `text` |
+ * | `thinking` | Append delta to last assistant entry's `thinking` |
+ * | `tool_call_started` | Push new `ToolEventEntry` with `isStreaming: true` |
+ * | `onToolEvent` → `thinking` | Append delta to matching `ToolEventEntry.subThinking` |
+ * | `onToolEvent` → `text_delta` | Append delta to matching `ToolEventEntry.subText` |
+ * | `onToolEvent` → `done` | Ignored |
+ * | `tool_call_completed` | Set `result` and `isStreaming: false` on matching entry |
+ * | `done` | Set `text = output` and `isStreaming: false` on assistant entry |
+ * | Error / cancel | Set `isStreaming: false` on last assistant entry |
+ *
+ * @param conversation - A `Conversation` instance obtained from
+ *   `AgentRunner.conversation(agentConfig)`.
+ *
+ * @example
+ * ```tsx
+ * const conversation = useMemo(() => runner.conversation(agentConfig), [runner, agentConfig]);
+ * const { entries, sendMessage, cancel, isRunning } = useAgentStream(conversation);
+ * ```
+ */
+export function useAgentStream(conversation: Conversation): UseAgentStreamReturn {
+  const [entries, setEntries] = useState<ConversationEntry[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const sendMessage = useCallback(
+    (text: string) => {
+      if (isRunning) return;
+
+      const userEntry = makeEntry('user', text, false);
+      const assistantEntry = makeEntry('assistant', '', true);
+      const assistantId = assistantEntry.id;
+
+      setEntries((prev) => [...prev, userEntry, assistantEntry]);
+      setIsRunning(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const run = async () => {
+        try {
+          const stream = conversation.runStream(
+            text,
+            controller.signal,
+            (toolName, event: AgentEvent) => {
+              if (event.type === 'thinking') {
+                setEntries((prev) =>
+                  updateToolEvent(prev, assistantId, toolName, (t) => ({
+                    ...t,
+                    subThinking: (t.subThinking ?? '') + event.delta,
+                  })),
+                );
+              } else if (event.type === 'text_delta') {
+                setEntries((prev) =>
+                  updateToolEvent(prev, assistantId, toolName, (t) => ({
+                    ...t,
+                    subText: (t.subText ?? '') + event.delta,
+                  })),
+                );
+              }
+              // done events from sub-agents are intentionally ignored —
+              // tool_call_completed is the authoritative signal that a tool finished.
+            },
+          );
+
+          for await (const event of stream) {
+            if (event.type === 'text_delta') {
+              setEntries((prev) =>
+                updateEntry(prev, assistantId, (e) => ({
+                  ...e,
+                  text: e.text + event.delta,
+                })),
+              );
+            } else if (event.type === 'thinking') {
+              setEntries((prev) =>
+                updateEntry(prev, assistantId, (e) => ({
+                  ...e,
+                  thinking: (e.thinking ?? '') + event.delta,
+                })),
+              );
+            } else if (event.type === 'tool_call_started') {
+              const toolEvent: ToolEventEntry = {
+                type: 'tool_call_started',
+                name: event.name,
+                args: event.args,
+                isStreaming: true,
+              };
+              setEntries((prev) =>
+                updateEntry(prev, assistantId, (e) => ({
+                  ...e,
+                  toolEvents: [...e.toolEvents, toolEvent],
+                })),
+              );
+            } else if (event.type === 'tool_call_completed') {
+              setEntries((prev) =>
+                updateToolEvent(prev, assistantId, event.name, (t) => ({
+                  ...t,
+                  type: 'tool_call_completed',
+                  result: event.result,
+                  isStreaming: false,
+                })),
+              );
+            } else if (event.type === 'done') {
+              setEntries((prev) =>
+                updateEntry(prev, assistantId, (e) => ({
+                  ...e,
+                  text: event.output,
+                  isStreaming: false,
+                })),
+              );
+            }
+          }
+        } catch {
+          setEntries((prev) =>
+            updateEntry(prev, assistantId, (e) => ({ ...e, isStreaming: false })),
+          );
+        } finally {
+          setIsRunning(false);
+        }
+      };
+
+      void run();
+    },
+    [conversation, isRunning],
+  );
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  return { entries, isRunning, sendMessage, cancel };
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -1,2 +1,6 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
+
+export type { ConversationEntry, ToolEventEntry, IconMap } from './types';
+export { useAgentStream } from './hooks/useAgentStream';
+export type { UseAgentStreamReturn } from './hooks/useAgentStream';

--- a/packages/react-ui/src/types.ts
+++ b/packages/react-ui/src/types.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+
+/**
+ * The rendered state of a single tool invocation within an assistant turn.
+ *
+ * Created when a `tool_call_started` event is received and updated as the tool
+ * executes. For tools that run sub-agents, `subThinking` and `subText` accumulate
+ * live output streamed via {@link AgentRunner}'s `onToolEvent` callback.
+ */
+export interface ToolEventEntry {
+  /** Discriminates between a pending and a completed tool call. */
+  type: 'tool_call_started' | 'tool_call_completed';
+
+  /** The registered name of the tool. */
+  name: string;
+
+  /** The arguments passed to the tool, as parsed JSON. Present once the call has started. */
+  args?: unknown;
+
+  /**
+   * The value returned by the tool.
+   * Only present when `type` is `'tool_call_completed'`.
+   */
+  result?: unknown;
+
+  /**
+   * Accumulated thinking text streamed from a sub-agent running inside this tool.
+   * Populated incrementally via `onToolEvent` → `thinking` deltas.
+   * `undefined` for tools that are not sub-agents.
+   */
+  subThinking?: string;
+
+  /**
+   * Accumulated text streamed from a sub-agent running inside this tool.
+   * Populated incrementally via `onToolEvent` → `text_delta` deltas.
+   * `undefined` for tools that are not sub-agents.
+   */
+  subText?: string;
+
+  /**
+   * `true` while the tool is executing; `false` once `tool_call_completed` is received.
+   * Drives the spinner → check-mark transition in `<ToolCallBlock>`.
+   */
+  isStreaming: boolean;
+}
+
+/**
+ * The rendered state of a single turn in the conversation.
+ *
+ * Each `sendMessage` call produces one user entry and one assistant entry.
+ * The assistant entry is updated in place as `AgentEvent`s stream in; it is
+ * never replaced — its `id` is stable for React reconciliation.
+ */
+export interface ConversationEntry {
+  /** Stable identifier used as the React `key` for this entry. */
+  id: string;
+
+  /** Whether this entry was produced by the user or the assistant. */
+  role: 'user' | 'assistant';
+
+  /**
+   * The accumulated text content of this entry.
+   *
+   * For user entries this is the original message text.
+   * For assistant entries it grows with each `text_delta` event and is
+   * finalised to `event.output` when `done` is received.
+   */
+  text: string;
+
+  /**
+   * Accumulated thinking/reasoning trace for this assistant turn.
+   * Only present when the model emits `thinking` deltas.
+   */
+  thinking?: string;
+
+  /**
+   * Ordered list of tool invocations made during this assistant turn.
+   * Each element corresponds to one `tool_call_started` event and is updated
+   * in-place as the tool executes.
+   */
+  toolEvents: ToolEventEntry[];
+
+  /**
+   * `true` while the assistant is generating this entry; `false` once `done`,
+   * an error, or a cancellation is received.
+   * Drives streaming indicators across all child components.
+   */
+  isStreaming: boolean;
+}
+
+/**
+ * Allows consumers to replace any or all of the six built-in SVG icons with
+ * their own React nodes (e.g. from `lucide-react` or a custom design system).
+ *
+ * Pass an `IconMap` to the `icons` prop of `<AgentProvider>`. Unspecified keys
+ * fall back to the bundled inline SVG defaults.
+ *
+ * @example
+ * ```tsx
+ * import { Brain, Wrench, CircleCheck, LoaderCircle, Send, Square } from 'lucide-react';
+ *
+ * <AgentProvider icons={{
+ *   brain:  <Brain size={16} />,
+ *   wrench: <Wrench size={16} />,
+ *   check:  <CircleCheck size={16} />,
+ *   loader: <LoaderCircle size={16} className="mast-spin" />,
+ *   send:   <Send size={16} />,
+ *   stop:   <Square size={16} />,
+ * }}>
+ * ```
+ */
+export interface IconMap {
+  /** Shown in the `<ThinkingBlock>` header. */
+  brain?: ReactNode;
+  /** Shown in the `<ToolCallBlock>` header while the tool is pending. */
+  wrench?: ReactNode;
+  /** Shown in the `<ToolCallBlock>` header once the tool has completed. */
+  check?: ReactNode;
+  /** Animated spinner shown during streaming and pending tool calls. */
+  loader?: ReactNode;
+  /** Shown on the send button in `<ChatInput>`. */
+  send?: ReactNode;
+  /** Shown on the cancel button in `<ChatInput>` while `isRunning` is true. */
+  stop?: ReactNode;
+}


### PR DESCRIPTION
## Summary

- Adds `packages/react-ui/src/types.ts` — `ConversationEntry`, `ToolEventEntry`, `IconMap` with full TSDoc
- Adds `packages/react-ui/src/hooks/useAgentStream.ts` — internal streaming state machine hook that subscribes to `AgentEvent`s from a `Conversation`, routes sub-agent events via `onToolEvent`, and maintains `ConversationEntry[]`
- Adds `packages/react-ui/src/hooks/useAgentStream.test.ts` — 19 tests covering all scenarios from SPEC §11.2
- Exports all new types and the hook from `src/index.ts`

## Implementation notes

- All `setEntries` calls use functional updaters so concurrent state updates from the main stream and `onToolEvent` callbacks compose correctly when batched by React 18
- `updateToolEvent` matches the first *still-streaming* `ToolEventEntry` with the given tool name, which correctly handles concurrent tool calls with distinct names
- `done` events from sub-agents (via `onToolEvent`) are intentionally ignored — `tool_call_completed` is the authoritative completion signal
- `sendMessage` guards against overlapping runs via the `isRunning` flag
- Two tests use `waitFor` for async state assertions: checking intermediate `tool_call_started` state (stream paused at a gate) and verifying cancel (requires flushing the microtask that registers the abort listener before firing `cancel()`)

## Test plan

- [x] `npm test` passes in `packages/react-ui` (19/19)
- [x] `npm run build && npm run lint` pass from the repo root

Closes #29