### PR TITLE
feat(react-ui): AgentProvider and useAgent hook

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -1,10 +1,84 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-export default function App() {
+import { useState, type KeyboardEvent } from 'react';
+import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+import { AgentProvider, useAgent } from '@mast-ai/react-ui';
+
+import { GetCurrentTimeTool } from './tools';
+
+const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+if (!apiKey) {
+  console.warn('VITE_GEMINI_API_KEY is not set. Copy .env.example to .env and set your key.');
+}
+
+const registry = new ToolRegistry().register(new GetCurrentTimeTool());
+const runner = new AgentRunner(new GoogleGenAIAdapter(apiKey ?? ''), registry);
+
+const agentConfig = createAgent({
+  name: 'DemoAssistant',
+  instructions:
+    'You are a helpful assistant for a demo of the @mast-ai/react-ui package. ' +
+    'Use the get_current_time tool when the user asks about the current time.',
+  tools: ['get_current_time'],
+});
+
+function ChatUI() {
+  const { messages, sendMessage, cancel, isRunning } = useAgent();
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text || isRunning) return;
+    setInput('');
+    sendMessage(text);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleSend();
+    }
+  };
+
   return (
     <div>
-      <h1>MAST React UI — coming soon</h1>
+      <ul>
+        {messages.map((entry) => (
+          <li key={entry.id}>
+            <strong>{entry.role}:</strong> {entry.text}
+            {entry.isStreaming && entry.text === '' ? <em> (thinking...)</em> : null}
+          </li>
+        ))}
+      </ul>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        rows={3}
+        placeholder="Type a message and press Enter."
+        disabled={isRunning}
+      />
+      <div>
+        <button type="button" onClick={handleSend} disabled={isRunning || !input.trim()}>
+          Send
+        </button>
+        {isRunning ? (
+          <button type="button" onClick={cancel}>
+            Cancel
+          </button>
+        ) : null}
+      </div>
     </div>
+  );
+}
+
+export default function App() {
+  return (
+    <AgentProvider runner={runner} agent={agentConfig}>
+      <h1>MAST React UI Demo</h1>
+      <ChatUI />
+    </AgentProvider>
   );
 }

--- a/apps/demo-react-ui/src/tools.ts
+++ b/apps/demo-react-ui/src/tools.ts
@@ -1,0 +1,24 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolContext } from '@mast-ai/core';
+
+/** Returns the current time as an ISO 8601 string. */
+export class GetCurrentTimeTool implements Tool {
+  definition() {
+    return {
+      name: 'get_current_time',
+      description: 'Returns the current time as an ISO 8601 string.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+      scope: 'read' as const,
+    };
+  }
+
+  async call(_args: unknown, _context: ToolContext): Promise<string> {
+    return new Date().toISOString();
+  }
+}

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -1,0 +1,120 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ReactNode } from 'react';
+import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
+
+import { AgentProvider, useAgent } from './context';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a fake `AgentRunner` whose `conversation()` returns a fresh fake
+ * `Conversation` that yields the supplied scripted events on `runStream`.
+ *
+ * The `vi.fn` wrapping `conversation` lets tests assert how many times a fresh
+ * `Conversation` was created.
+ */
+function makeMockRunner(events: AgentEvent[] = []): AgentRunner {
+  const make = (): Conversation =>
+    ({
+      history: [],
+      runStream(): AsyncIterable<AgentEvent> {
+        return (async function* () {
+          for (const event of events) yield event;
+        })();
+      },
+    }) as unknown as Conversation;
+
+  return {
+    conversation: vi.fn(make),
+  } as unknown as AgentRunner;
+}
+
+const agentConfig: AgentConfig = {
+  name: 'TestAgent',
+  instructions: 'A test agent.',
+};
+
+function makeWrapper(runner: AgentRunner) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <AgentProvider runner={runner} agent={agentConfig}>
+        {children}
+      </AgentProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAgent', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // React logs caught render errors to console.error. Suppress to keep
+    // the throws-outside-provider test output clean.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('throws a descriptive error when called outside <AgentProvider>', () => {
+    expect(() => renderHook(() => useAgent())).toThrow(/AgentProvider/);
+  });
+
+  it('returns { messages, sendMessage, cancel, isRunning, reset }', () => {
+    const runner = makeMockRunner();
+    const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
+
+    expect(result.current.messages).toEqual([]);
+    expect(typeof result.current.sendMessage).toBe('function');
+    expect(typeof result.current.cancel).toBe('function');
+    expect(typeof result.current.reset).toBe('function');
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('sendMessage appends entries that are exposed via messages', async () => {
+    const runner = makeMockRunner([
+      { type: 'text_delta', delta: 'Hi' },
+      { type: 'done', output: 'Hi', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]).toMatchObject({ role: 'user', text: 'hello' });
+    expect(result.current.messages[1]).toMatchObject({ role: 'assistant', text: 'Hi' });
+  });
+
+  it('reset() clears messages and creates a fresh Conversation', async () => {
+    const runner = makeMockRunner([{ type: 'done', output: 'ok', history: [] }]);
+    const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
+
+    expect(runner.conversation).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(runner.conversation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -1,0 +1,93 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { AgentConfig, AgentRunner, Conversation } from '@mast-ai/core';
+
+import { useAgentStream } from './hooks/useAgentStream';
+import type { ConversationEntry, IconMap } from './types';
+
+/**
+ * Props accepted by {@link AgentProvider}.
+ */
+export interface AgentProviderProps {
+  /** The {@link AgentRunner} that will execute agent runs. */
+  runner: AgentRunner;
+  /** The agent configuration used for every turn. */
+  agent: AgentConfig;
+  /** The subtree that should have access to {@link useAgent}. */
+  children: ReactNode;
+  /**
+   * Optional override for the bundled inline SVG icons. Wired up in a follow-up
+   * issue; accepted here so the prop is part of the stable provider API.
+   */
+  icons?: IconMap;
+}
+
+/**
+ * The value exposed by {@link useAgent}.
+ */
+export interface UseAgentReturn {
+  /** Ordered conversation entries, suitable for rendering. */
+  messages: ConversationEntry[];
+  /** Sends a user message and starts a new agent run. */
+  sendMessage: (text: string) => void;
+  /** Aborts the current run, if any. */
+  cancel: () => void;
+  /** `true` while a run is in progress. */
+  isRunning: boolean;
+  /**
+   * Aborts any in-flight run, clears the rendered conversation, and replaces
+   * the underlying {@link Conversation} with a fresh instance so the next
+   * `sendMessage` call starts with empty core history.
+   */
+  reset: () => void;
+}
+
+const AgentContext = createContext<UseAgentReturn | null>(null);
+
+/**
+ * Wraps a subtree with agent context.
+ *
+ * Internally creates a {@link Conversation} via `runner.conversation(agent)`
+ * and drives it with {@link useAgentStream}. Children access the resulting
+ * state through {@link useAgent}.
+ */
+export function AgentProvider({ runner, agent, children }: AgentProviderProps) {
+  const [conversation, setConversation] = useState<Conversation>(() => runner.conversation(agent));
+
+  const {
+    entries,
+    sendMessage,
+    cancel,
+    isRunning,
+    reset: resetStream,
+  } = useAgentStream(conversation);
+
+  const reset = useCallback(() => {
+    resetStream();
+    setConversation(runner.conversation(agent));
+  }, [resetStream, runner, agent]);
+
+  const value = useMemo<UseAgentReturn>(
+    () => ({ messages: entries, sendMessage, cancel, isRunning, reset }),
+    [entries, sendMessage, cancel, isRunning, reset],
+  );
+
+  return <AgentContext.Provider value={value}>{children}</AgentContext.Provider>;
+}
+
+/**
+ * Reads the current agent state from {@link AgentProvider}.
+ *
+ * Throws when called outside an `<AgentProvider>` so misuse is caught at the
+ * call site rather than producing silent runtime bugs.
+ */
+export function useAgent(): UseAgentReturn {
+  const ctx = useContext(AgentContext);
+  if (!ctx) {
+    throw new Error('useAgent() must be called from a component rendered inside <AgentProvider>.');
+  }
+  return ctx;
+}

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -10,7 +10,11 @@ import type { ConversationEntry, ToolEventEntry } from '../types';
 // Private helpers
 // ---------------------------------------------------------------------------
 
-function makeEntry(role: 'user' | 'assistant', text: string, isStreaming: boolean): ConversationEntry {
+function makeEntry(
+  role: 'user' | 'assistant',
+  text: string,
+  isStreaming: boolean,
+): ConversationEntry {
   return { id: crypto.randomUUID(), role, text, toolEvents: [], isStreaming };
 }
 
@@ -94,6 +98,15 @@ export interface UseAgentStreamReturn {
    * Has no effect when `isRunning` is false.
    */
   cancel: () => void;
+
+  /**
+   * Aborts any in-flight run and clears all conversation entries.
+   *
+   * Note that this only resets the UI rendering state owned by this hook. It
+   * does not clear the underlying `Conversation.history`; callers wanting to
+   * start a fresh conversation should also replace the `Conversation` instance.
+   */
+  reset: () => void;
 }
 
 /**
@@ -242,5 +255,12 @@ export function useAgentStream(conversation: Conversation): UseAgentStreamReturn
     abortRef.current?.abort();
   }, []);
 
-  return { entries, isRunning, sendMessage, cancel };
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setEntries([]);
+    setIsRunning(false);
+  }, []);
+
+  return { entries, isRunning, sendMessage, cancel, reset };
 }

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -4,3 +4,5 @@
 export type { ConversationEntry, ToolEventEntry, IconMap } from './types';
 export { useAgentStream } from './hooks/useAgentStream';
 export type { UseAgentStreamReturn } from './hooks/useAgentStream';
+export { AgentProvider, useAgent } from './context';
+export type { AgentProviderProps, UseAgentReturn } from './context';


### PR DESCRIPTION
## Summary

- Adds `packages/react-ui/src/context.tsx` — `AgentProvider` (creates a `Conversation` from `runner.conversation(agent)`, drives it with `useAgentStream`, exposes state via `AgentContext`) and the `useAgent()` hook (throws when called outside the provider).
- Extends `useAgentStream` with a `reset()` function that aborts any in-flight run and clears entries; `AgentProvider.reset()` calls it and replaces the underlying `Conversation` so the next turn starts from empty core history.
- Wires `apps/demo-react-ui` end-to-end: `GoogleGenAIAdapter`, a `get_current_time` tool, and a minimal `useAgent()`-driven UI (raw `<ul>` of entries + `<textarea>` + send/cancel `<button>`s).
- Exports `AgentProvider`, `useAgent`, `AgentProviderProps`, `UseAgentReturn` from `src/index.ts`.

## Implementation notes

- `AgentProvider` keeps the `Conversation` in `useState` so `reset()` can swap it out and force the next turn to start with empty core history. `useAgentStream` owns the `entries` state and exposes its own `reset()` so the provider can clear UI state without depending on remount/key tricks.
- `AgentProviderProps.icons?` is accepted now per the issue but not yet wired through; the icon system lands in #31.
- `useAgent()` throws a descriptive error referencing `<AgentProvider>` so misuse surfaces at the call site.
- The 4 new tests in `context.test.tsx` cover: throws outside provider, returns the documented shape, `sendMessage` populates `messages`, and `reset()` clears entries plus calls `runner.conversation()` a second time. The 19 existing `useAgentStream` tests still pass.

## Test plan

- [x] `npm test` passes in `packages/react-ui` (23/23: 4 context + 19 useAgentStream)
- [x] `npm run lint` and `npm run build` pass from the repo root
- [x] Manually verified `npm run dev` in `apps/demo-react-ui` produces a working chat with a tool call

Closes #30