### PR TITLE
feat(core): createAgentTool helper to wrap an agent as a tool

### DIFF
--- a/apps/demo-agent-tool/index.html
+++ b/apps/demo-agent-tool/index.html
@@ -12,13 +12,14 @@
         <h2>createAgentTool Demo <small id="version"></small></h2>
 
         <div class="config-panel">
-          <label>Parent endpoint URL (URP)</label>
-          <input type="text" id="endpoint-url" value="http://127.0.0.1:3000/api/chat" />
+          <label>Google AI API key</label>
+          <input type="password" id="api-key" placeholder="AIza…" autocomplete="off" />
+          <p class="config-hint">Stored in localStorage on this device only.</p>
         </div>
 
         <div class="info-panel">
           <h3>Architecture</h3>
-          <p><strong>Parent agent</strong> &middot; <code>UrpAdapter</code> (remote)</p>
+          <p><strong>Parent agent</strong> &middot; <code>GoogleGenAIAdapter</code> (Gemini)</p>
           <p>
             <strong>Child agent</strong> &middot; <code>BuiltInAIAdapter</code> (on-device, via
             Chrome Prompt API)

--- a/apps/demo-agent-tool/index.html
+++ b/apps/demo-agent-tool/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAST — createAgentTool Demo</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <div class="sidebar">
+        <h2>createAgentTool Demo <small id="version"></small></h2>
+
+        <div class="config-panel">
+          <label>Parent endpoint URL (URP)</label>
+          <input type="text" id="endpoint-url" value="http://127.0.0.1:3000/api/chat" />
+        </div>
+
+        <div class="info-panel">
+          <h3>Architecture</h3>
+          <p><strong>Parent agent</strong> &middot; <code>UrpAdapter</code> (remote)</p>
+          <p>
+            <strong>Child agent</strong> &middot; <code>BuiltInAIAdapter</code> (on-device, via
+            Chrome Prompt API)
+          </p>
+          <p>
+            The parent has one tool, <code>rewrite_text</code>, wired up with
+            <code>createAgentTool</code>. When the parent calls it, the child agent runs locally and
+            its <code>thinking</code> / <code>text_delta</code> events stream into the
+            <code>onToolEvent</code> handler &mdash; you'll see them appear inline below the tool
+            call.
+          </p>
+        </div>
+
+        <div class="info-panel">
+          <h3>Try this</h3>
+          <ul>
+            <li>Make this formal: "hey what's up?"</li>
+            <li>Rewrite as a haiku: "I went to the store and bought some bread."</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="chat-container">
+        <div class="message-list" id="message-list">
+          <div class="message assistant">
+            <div class="bubble">
+              Hi! Ask me to rewrite a piece of text in some style and I'll delegate to my on-device
+              child agent.
+            </div>
+          </div>
+        </div>
+
+        <div class="input-area">
+          <div class="status-indicator" id="status-indicator">Idle</div>
+          <div class="input-group">
+            <textarea
+              id="prompt-input"
+              placeholder="e.g. Rewrite as a haiku: I went to the store and bought some bread."
+            ></textarea>
+            <button id="send-button">Send</button>
+            <button id="stop-button" class="stop-button" hidden>Stop</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/demo-agent-tool/index.html
+++ b/apps/demo-agent-tool/index.html
@@ -19,17 +19,20 @@
 
         <div class="info-panel">
           <h3>Architecture</h3>
-          <p><strong>Parent agent</strong> &middot; <code>GoogleGenAIAdapter</code> (Gemini)</p>
           <p>
-            <strong>Child agent</strong> &middot; <code>BuiltInAIAdapter</code> (on-device, via
-            Chrome Prompt API)
+            <strong>Parent agent</strong>: an orchestrator that picks tools. It runs through its
+            own <code>AgentRunner</code> + <code>GoogleGenAIAdapter</code>.
           </p>
           <p>
-            The parent has one tool, <code>rewrite_text</code>, wired up with
-            <code>createAgentTool</code>. When the parent calls it, the child agent runs locally and
-            its <code>thinking</code> / <code>text_delta</code> events stream into the
-            <code>onToolEvent</code> handler &mdash; you'll see them appear inline below the tool
-            call.
+            <strong>Child agent</strong>: a specialised rewriter. It runs through a separate
+            <code>AgentRunner</code> + <code>GoogleGenAIAdapter</code> with its own
+            <code>AgentConfig</code>.
+          </p>
+          <p>
+            <code>createAgentTool</code> wires the child as the parent's only tool,
+            <code>rewrite_text</code>. The child's <code>text_delta</code> events stream into the
+            parent's <code>onToolEvent</code> handler &mdash; you'll see them appear inline below
+            the tool call.
           </p>
         </div>
 

--- a/apps/demo-agent-tool/package.json
+++ b/apps/demo-agent-tool/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demo-agent-tool",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/built-in-ai": "*",
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/demo-agent-tool/package.json
+++ b/apps/demo-agent-tool/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@mast-ai/built-in-ai": "*",
-    "@mast-ai/core": "*"
+    "@mast-ai/core": "*",
+    "@mast-ai/google-genai": "*"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/apps/demo-agent-tool/package.json
+++ b/apps/demo-agent-tool/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@mast-ai/built-in-ai": "*",
     "@mast-ai/core": "*",
     "@mast-ai/google-genai": "*"
   },

--- a/apps/demo-agent-tool/src/main.ts
+++ b/apps/demo-agent-tool/src/main.ts
@@ -1,0 +1,208 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  VERSION,
+  ToolRegistry,
+  HttpTransport,
+  AgentRunner,
+  UrpAdapter,
+  createAgent,
+  createAgentTool,
+  Conversation,
+} from '@mast-ai/core';
+import { BuiltInAIAdapter, checkAvailability } from '@mast-ai/built-in-ai';
+
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
+
+// --- Child agent: runs on-device via the Prompt API. -------------------------
+const childAgent = createAgent({
+  name: 'Rewriter',
+  instructions:
+    'You are a text rewriter. The input you receive is JSON of the form {"text": string, "style": string}. ' +
+    'Return only the rewritten text in the requested style — no preamble, no explanation, no quotes around the result.',
+});
+
+const childRunner = new AgentRunner(new BuiltInAIAdapter());
+
+const rewriteTool = createAgentTool(childRunner, childAgent, {
+  name: 'rewrite_text',
+  description:
+    'Rewrites a piece of text in the requested style. Use this whenever the user asks to rephrase, reword, or transform text.',
+  parameters: {
+    type: 'object',
+    properties: {
+      text: { type: 'string', description: 'The text to rewrite.' },
+      style: {
+        type: 'string',
+        description: 'The target style (e.g. "formal", "haiku", "shakespearean").',
+      },
+    },
+    required: ['text', 'style'],
+  },
+  buildInput: (args) => JSON.stringify(args),
+});
+
+// --- Parent agent: hits a remote URP backend with one tool. ------------------
+const registry = new ToolRegistry().register(rewriteTool);
+
+const parentAgent = createAgent({
+  name: 'RewriteOrchestrator',
+  instructions:
+    'You help the user rewrite text in different styles. When the user provides text and a target style, ' +
+    'always call the rewrite_text tool — never attempt to rewrite text yourself. Return the tool result verbatim.',
+  tools: ['rewrite_text'],
+});
+
+const endpointInput = document.querySelector<HTMLInputElement>('#endpoint-url')!;
+
+function buildConversation(): Conversation {
+  const runner = new AgentRunner(
+    new UrpAdapter(new HttpTransport({ url: endpointInput.value })),
+    registry,
+  );
+  return runner.conversation(parentAgent);
+}
+
+let conversation = buildConversation();
+endpointInput.addEventListener('change', () => {
+  conversation = buildConversation();
+});
+
+// --- Availability check for the child adapter. -------------------------------
+checkAvailability()
+  .then((status) => {
+    if (status !== 'readily') {
+      appendSystemMessage(
+        `On-device model status: ${status}. The rewrite_text tool will fail until the model is "readily" available.`,
+        'error',
+      );
+    }
+  })
+  .catch(() => {
+    appendSystemMessage(
+      'The Prompt API (LanguageModel) is not supported in this browser — the child agent cannot run.',
+      'error',
+    );
+  });
+
+// --- Chat UI. ----------------------------------------------------------------
+const messageList = document.querySelector('#message-list')!;
+const promptInput = document.querySelector<HTMLTextAreaElement>('#prompt-input')!;
+const sendButton = document.querySelector<HTMLButtonElement>('#send-button')!;
+const stopButton = document.querySelector<HTMLButtonElement>('#stop-button')!;
+const statusIndicator = document.querySelector('#status-indicator')!;
+
+let currentController: AbortController | null = null;
+
+function appendMessage(role: 'user' | 'assistant', content: string): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message ${role}`;
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  bubble.textContent = content;
+  msgEl.appendChild(bubble);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return bubble;
+}
+
+function appendSystemMessage(content: string, type: 'tool' | 'error' = 'tool'): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message system ${type}`;
+  const small = document.createElement('small');
+  small.textContent = content;
+  msgEl.appendChild(small);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return msgEl;
+}
+
+function appendChildBlock(toolName: string): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = 'message system child';
+  const header = document.createElement('strong');
+  header.textContent = `↳ child events from ${toolName}`;
+  const body = document.createElement('pre');
+  body.className = 'child-body';
+  msgEl.appendChild(header);
+  msgEl.appendChild(body);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return body;
+}
+
+async function handleSend() {
+  if (currentController) return;
+
+  const text = promptInput.value.trim();
+  if (!text) return;
+
+  promptInput.value = '';
+  promptInput.disabled = true;
+  sendButton.disabled = true;
+  stopButton.hidden = false;
+
+  appendMessage('user', text);
+
+  const controller = new AbortController();
+  currentController = controller;
+
+  statusIndicator.textContent = 'Running...';
+  statusIndicator.className = 'status-indicator running';
+
+  let parentBubble: HTMLElement | null = null;
+  // Tracks one child-events block per tool invocation so concurrent calls don't interleave.
+  const childBlocks = new Map<string, HTMLElement>();
+
+  try {
+    const stream = conversation.runStream(text, controller.signal, (toolName, event) => {
+      if (event.type === 'text_delta' || event.type === 'thinking') {
+        let body = childBlocks.get(toolName);
+        if (!body) {
+          body = appendChildBlock(toolName);
+          childBlocks.set(toolName, body);
+        }
+        body.textContent += event.delta;
+      }
+    });
+
+    for await (const event of stream) {
+      if (event.type === 'text_delta') {
+        if (!parentBubble) parentBubble = appendMessage('assistant', '');
+        parentBubble.textContent += event.delta;
+      } else if (event.type === 'tool_call_started') {
+        appendSystemMessage(`Calling ${event.name}(${JSON.stringify(event.args)})`, 'tool');
+      } else if (event.type === 'tool_call_completed') {
+        appendSystemMessage(`Result: ${JSON.stringify(event.result)}`, 'tool');
+        // Reset so the next tool invocation gets a fresh block.
+        childBlocks.delete(event.name);
+      }
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      console.error(error);
+      appendSystemMessage(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        'error',
+      );
+    }
+  } finally {
+    currentController = null;
+    promptInput.disabled = false;
+    sendButton.disabled = false;
+    stopButton.hidden = true;
+    promptInput.focus();
+    statusIndicator.textContent = 'Idle';
+    statusIndicator.className = 'status-indicator';
+  }
+}
+
+sendButton.addEventListener('click', handleSend);
+stopButton.addEventListener('click', () => currentController?.abort());
+promptInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    handleSend();
+  }
+});

--- a/apps/demo-agent-tool/src/main.ts
+++ b/apps/demo-agent-tool/src/main.ts
@@ -4,14 +4,13 @@
 import {
   VERSION,
   ToolRegistry,
-  HttpTransport,
   AgentRunner,
-  UrpAdapter,
   createAgent,
   createAgentTool,
   Conversation,
 } from '@mast-ai/core';
 import { BuiltInAIAdapter, checkAvailability } from '@mast-ai/built-in-ai';
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
 
 document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
 
@@ -54,18 +53,19 @@ const parentAgent = createAgent({
   tools: ['rewrite_text'],
 });
 
-const endpointInput = document.querySelector<HTMLInputElement>('#endpoint-url')!;
+const apiKeyInput = document.querySelector<HTMLInputElement>('#api-key')!;
+const API_KEY_STORAGE = 'mast-demo-agent-tool.gemini-api-key';
+apiKeyInput.value = localStorage.getItem(API_KEY_STORAGE) ?? '';
 
 function buildConversation(): Conversation {
-  const runner = new AgentRunner(
-    new UrpAdapter(new HttpTransport({ url: endpointInput.value })),
-    registry,
-  );
+  const runner = new AgentRunner(new GoogleGenAIAdapter(apiKeyInput.value), registry);
   return runner.conversation(parentAgent);
 }
 
 let conversation = buildConversation();
-endpointInput.addEventListener('change', () => {
+
+apiKeyInput.addEventListener('change', () => {
+  localStorage.setItem(API_KEY_STORAGE, apiKeyInput.value);
   conversation = buildConversation();
 });
 
@@ -137,6 +137,14 @@ async function handleSend() {
 
   const text = promptInput.value.trim();
   if (!text) return;
+
+  if (!apiKeyInput.value.trim()) {
+    appendSystemMessage(
+      'Set a Google AI API key in the sidebar before sending — the parent agent uses Gemini.',
+      'error',
+    );
+    return;
+  }
 
   promptInput.value = '';
   promptInput.disabled = true;

--- a/apps/demo-agent-tool/src/main.ts
+++ b/apps/demo-agent-tool/src/main.ts
@@ -9,12 +9,11 @@ import {
   createAgentTool,
   Conversation,
 } from '@mast-ai/core';
-import { BuiltInAIAdapter, checkAvailability } from '@mast-ai/built-in-ai';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
 
 document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
 
-// --- Child agent: runs on-device via the Prompt API. -------------------------
+// --- Child agent: a specialised rewriter with its own runner and config. -----
 const childAgent = createAgent({
   name: 'Rewriter',
   instructions:
@@ -22,44 +21,46 @@ const childAgent = createAgent({
     'Return only the rewritten text in the requested style — no preamble, no explanation, no quotes around the result.',
 });
 
-const childRunner = new AgentRunner(new BuiltInAIAdapter());
-
-const rewriteTool = createAgentTool(childRunner, childAgent, {
-  name: 'rewrite_text',
-  description:
-    'Rewrites a piece of text in the requested style. Use this whenever the user asks to rephrase, reword, or transform text.',
-  parameters: {
-    type: 'object',
-    properties: {
-      text: { type: 'string', description: 'The text to rewrite.' },
-      style: {
-        type: 'string',
-        description: 'The target style (e.g. "formal", "haiku", "shakespearean").',
-      },
-    },
-    required: ['text', 'style'],
-  },
-  buildInput: (args) => JSON.stringify(args),
-});
-
-// --- Parent agent: hits a remote URP backend with one tool. ------------------
-const registry = new ToolRegistry().register(rewriteTool);
-
-const parentAgent = createAgent({
-  name: 'RewriteOrchestrator',
-  instructions:
-    'You help the user rewrite text in different styles. When the user provides text and a target style, ' +
-    'always call the rewrite_text tool — never attempt to rewrite text yourself. Return the tool result verbatim.',
-  tools: ['rewrite_text'],
-});
-
 const apiKeyInput = document.querySelector<HTMLInputElement>('#api-key')!;
 const API_KEY_STORAGE = 'mast-demo-agent-tool.gemini-api-key';
 apiKeyInput.value = localStorage.getItem(API_KEY_STORAGE) ?? '';
 
+// Both parent and child agents are built fresh whenever the API key changes,
+// so each owns its own AgentRunner / adapter — that's what createAgentTool
+// makes easy.
 function buildConversation(): Conversation {
-  const runner = new AgentRunner(new GoogleGenAIAdapter(apiKeyInput.value), registry);
-  return runner.conversation(parentAgent);
+  const apiKey = apiKeyInput.value;
+  const childRunner = new AgentRunner(new GoogleGenAIAdapter(apiKey));
+
+  const rewriteTool = createAgentTool(childRunner, childAgent, {
+    name: 'rewrite_text',
+    description:
+      'Rewrites a piece of text in the requested style. Use this whenever the user asks to rephrase, reword, or transform text.',
+    parameters: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'The text to rewrite.' },
+        style: {
+          type: 'string',
+          description: 'The target style (e.g. "formal", "haiku", "shakespearean").',
+        },
+      },
+      required: ['text', 'style'],
+    },
+    buildInput: (args) => JSON.stringify(args),
+  });
+
+  const parentAgent = createAgent({
+    name: 'RewriteOrchestrator',
+    instructions:
+      'You help the user rewrite text in different styles. When the user provides text and a target style, ' +
+      'always call the rewrite_text tool — never attempt to rewrite text yourself. Return the tool result verbatim.',
+    tools: ['rewrite_text'],
+  });
+
+  const registry = new ToolRegistry().register(rewriteTool);
+  const parentRunner = new AgentRunner(new GoogleGenAIAdapter(apiKey), registry);
+  return parentRunner.conversation(parentAgent);
 }
 
 let conversation = buildConversation();
@@ -68,23 +69,6 @@ apiKeyInput.addEventListener('change', () => {
   localStorage.setItem(API_KEY_STORAGE, apiKeyInput.value);
   conversation = buildConversation();
 });
-
-// --- Availability check for the child adapter. -------------------------------
-checkAvailability()
-  .then((status) => {
-    if (status !== 'readily') {
-      appendSystemMessage(
-        `On-device model status: ${status}. The rewrite_text tool will fail until the model is "readily" available.`,
-        'error',
-      );
-    }
-  })
-  .catch(() => {
-    appendSystemMessage(
-      'The Prompt API (LanguageModel) is not supported in this browser — the child agent cannot run.',
-      'error',
-    );
-  });
 
 // --- Chat UI. ----------------------------------------------------------------
 const messageList = document.querySelector('#message-list')!;

--- a/apps/demo-agent-tool/src/style.css
+++ b/apps/demo-agent-tool/src/style.css
@@ -1,0 +1,273 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  --primary-color: #3b82f6;
+  --bg-color: #f4f4f5;
+  --border-color: #e4e4e7;
+  --child-bg: #eff6ff;
+  --child-border: #bfdbfe;
+}
+
+body,
+html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+.app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar {
+  width: 320px;
+  background-color: var(--bg-color);
+  border-right: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sidebar h2 small {
+  font-size: 0.75rem;
+  color: #71717a;
+  font-weight: normal;
+}
+
+.config-panel label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #52525b;
+  margin-bottom: 0.4rem;
+}
+
+.config-panel input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.info-panel {
+  font-size: 0.85rem;
+  color: #52525b;
+  line-height: 1.5;
+}
+
+.info-panel h3 {
+  font-size: 0.95rem;
+  color: #1a1a1a;
+  margin: 0 0 0.5rem;
+}
+
+.info-panel p {
+  margin: 0.4rem 0;
+}
+
+.info-panel ul {
+  margin: 0.4rem 0;
+  padding-left: 1.2rem;
+}
+
+.info-panel li {
+  margin: 0.25rem 0;
+}
+
+.info-panel code {
+  font-size: 0.8rem;
+  background: #ffffff;
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 0.05em 0.3em;
+}
+
+.chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+}
+
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+}
+
+.message.assistant {
+  align-self: flex-start;
+}
+
+.message.system {
+  align-self: center;
+  max-width: 90%;
+}
+
+.bubble {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.user .bubble {
+  background-color: var(--primary-color);
+  color: white;
+  border-bottom-right-radius: 0;
+}
+
+.assistant .bubble {
+  background-color: var(--bg-color);
+  color: #1a1a1a;
+  border-bottom-left-radius: 0;
+}
+
+.system small {
+  color: #71717a;
+  font-family: monospace;
+  font-size: 0.8rem;
+  background: #f8f8f8;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+}
+
+.system.error small {
+  color: #ef4444;
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.system.child {
+  align-self: stretch;
+  max-width: 100%;
+  background: var(--child-bg);
+  border: 1px solid var(--child-border);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  margin: 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.system.child strong {
+  font-size: 0.75rem;
+  color: #1d4ed8;
+  font-family: monospace;
+  letter-spacing: 0.02em;
+}
+
+.system.child .child-body {
+  margin: 0;
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #1e3a8a;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+
+.input-area {
+  padding: 1rem 2rem 2rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  color: #71717a;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-indicator.running {
+  color: var(--primary-color);
+  font-weight: bold;
+}
+
+.input-group {
+  display: flex;
+  gap: 1rem;
+}
+
+textarea {
+  flex: 1;
+  resize: none;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 1rem;
+  height: 60px;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+button {
+  padding: 0 1.5rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #2563eb;
+}
+
+button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.stop-button {
+  background-color: #ef4444;
+}
+
+.stop-button:hover {
+  background-color: #dc2626;
+}

--- a/apps/demo-agent-tool/src/style.css
+++ b/apps/demo-agent-tool/src/style.css
@@ -71,6 +71,13 @@ html {
   border-radius: 4px;
 }
 
+.config-hint {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+  color: #71717a;
+  line-height: 1.4;
+}
+
 .info-panel {
   font-size: 0.85rem;
   color: #52525b;

--- a/apps/demo-agent-tool/tsconfig.json
+++ b/apps/demo-agent-tool/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -315,112 +315,65 @@ for await (const event of conv2.runStream('Hello!', abortController.signal)) {
 }
 ```
 
-### `AgentExecutor` / `AgentTool` (`src/agent-tool.ts`)
+### `createAgentTool` (`src/agentTool.ts`)
 
-Because a sub-agent is exposed to its parent as a plain `Tool`, the sub-agent's execution mode is entirely independent of the parent's. The unifying abstraction is `AgentExecutor` — anything that can run an agent given a string input:
+A sub-agent is exposed to its parent as a plain `Tool`. `createAgentTool` is the helper that wraps an `AgentConfig` + `AgentRunner` pair as a `Tool`, encoding the sub-agent contract documented in [Tool Event Streaming](./tool-event-streaming/PLAN.md) so individual tool authors do not have to reimplement it (and get it wrong).
 
 ```typescript
-export interface AgentExecutor {
-  run(input: string, context: ToolContext): Promise<{ output: string }>;
+export interface AgentToolOptions {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>; // JSON Schema
+  scope?: 'read' | 'write'; // defaults to 'read'
+  requiresApproval?: boolean;
+  /** Build the input string passed to the child agent from the tool args. */
+  buildInput: (args: unknown) => string;
 }
+
+export function createAgentTool(
+  runner: AgentRunner,
+  agent: AgentConfig,
+  options: AgentToolOptions,
+): Tool;
 ```
 
-`AgentTool` wraps any `AgentExecutor` as a `Tool`, making the sub-agent's location invisible to the parent:
+The returned tool's `call(args, context)`:
+
+1. Builds the child input via `options.buildInput(args)`.
+2. Calls `runner.runBuilder(agent).signal(context.signal).runStream(input)`.
+3. For every event whose type is not `done`, calls `context.onEvent?.(event)`.
+4. Returns the `done.output` string as the tool result.
+5. Throws `AgentError` if the stream ends without a `done` event.
+
+`done` events are filtered because they carry the child's full conversation `history`, which must not leak to parent UI consumers registered via `RunBuilder.onToolEvent` (see [Tool Event Streaming](./tool-event-streaming/PLAN.md#consumer-integration)).
+
+Because `runner` and `agent` are passed in separately, the child can use a different adapter, registry, instructions, or tool allowlist than the parent — true decoupling between parent and child execution modes.
+
+**Usage pattern (hybrid parent → on-device child):**
 
 ```typescript
-export class AgentTool implements Tool {
-  constructor(
-    definition: ToolDefinition, // name, description, parameters exposed to the parent adapter
-    executor: AgentExecutor,
-  );
-
-  definition(): ToolDefinition;
-  call(args: unknown, context: ToolContext): Promise<{ output: string }>;
-}
-```
-
-**How `call` works:**
-
-1. Serialises `args` to a JSON string and passes it to `executor.run(input, context)`.
-2. `ToolContext` (including `signal`) is forwarded to the executor so cancellation propagates.
-3. Returns `{ output }` so the parent adapter receives a structured, readable result.
-
-The three sub-agent execution modes each have a corresponding `AgentExecutor` implementation:
-
-| Sub-agent mode  | `AgentExecutor` implementation                                     |
-| --------------- | ------------------------------------------------------------------ |
-| **Client-side** | `localAgent(config, runner)` — binds `AgentConfig` + `AgentRunner` |
-| **Hybrid**      | `localAgent(config, runner)` with `runner` using `UrpAdapter`      |
-| **Server-side** | `AcpAgent` — calls a remote ACP-compliant endpoint                 |
-
-#### `localAgent` helper
-
-Binds an `AgentConfig` and `AgentRunner` into an `AgentExecutor`. The sub-agent loop runs in the browser; the `LlmAdapter` on the runner determines whether inference is local (`PromptApiAdapter`) or remote (`UrpAdapter`).
-
-```typescript
-export function localAgent(agent: AgentConfig, runner: AgentRunner): AgentExecutor;
-```
-
-**Usage pattern (hybrid parent → client-side child):**
-
-```typescript
-const childRunner = new AgentRunner(new PromptApiAdapter());
+const childRunner = new AgentRunner(await BuiltInAIAdapter.create());
 const childAgent: AgentConfig = {
   name: 'Classifier',
-  instructions: 'Classify the intent in the "text" field of the JSON input.',
+  instructions: 'Classify the intent in the input text.',
 };
 
-const classifyTool = new AgentTool(
-  {
-    name: 'classify_intent',
-    description: 'Classifies the user intent in a piece of text.',
-    parameters: {
-      type: 'object',
-      properties: { text: { type: 'string' } },
-      required: ['text'],
-    },
+const classifyTool = createAgentTool(childRunner, childAgent, {
+  name: 'classify_intent',
+  description: 'Classifies the user intent in a piece of text.',
+  parameters: {
+    type: 'object',
+    properties: { text: { type: 'string' } },
+    required: ['text'],
   },
-  localAgent(childAgent, childRunner),
-);
+  buildInput: (args) => (args as { text: string }).text,
+});
 
 const registry = new ToolRegistry().register(classifyTool);
 const parentRunner = new AgentRunner(parentAdapter, registry);
 ```
 
-#### `AcpAgent` — server-side sub-agents
-
-`AcpAgent` implements `AgentExecutor` against the Agent Call Protocol (ACP), a minimal HTTP convention for server-side agent endpoints (see [Agent Call Protocol](#agent-call-protocol-acp) below).
-
-```typescript
-export interface AcpAgentOptions {
-  url: string;
-  headers?: Record<string, string>;
-}
-
-export class AcpAgent implements AgentExecutor {
-  constructor(options: AcpAgentOptions);
-  run(input: string, context: ToolContext): Promise<{ output: string }>;
-}
-```
-
-**Usage pattern (hybrid parent → server-side child):**
-
-```typescript
-const summariseTool = new AgentTool(
-  {
-    name: 'summarise',
-    description: 'Summarises a long piece of text using a server-side agent.',
-    parameters: {
-      type: 'object',
-      properties: { text: { type: 'string' } },
-      required: ['text'],
-    },
-  },
-  new AcpAgent({ url: '/api/agents/summariser' }),
-);
-```
-
-Custom `AgentExecutor` implementations can wrap third-party agent APIs (e.g. OpenAI Assistants, LangChain agents) without modifying `AgentTool`.
+Server-side sub-agents (an HTTP-backed agent endpoint) can be modelled as a custom `Tool` that calls the endpoint directly; they do not need `createAgentTool`.
 
 ### `AgentError` (`src/error.ts`)
 
@@ -583,7 +536,7 @@ On failure, the server returns a non-2xx status code. An optional JSON body may 
 
 - ACP is intentionally minimal. It carries no conversation history, no tool definitions, and no configuration — those are internal concerns of the server-side agent.
 - A backend built with `rust-agent-kit` can expose any `AgentRunner` as an ACP endpoint with a thin HTTP handler (~10 lines).
-- Third-party agent APIs that do not speak ACP natively can be wrapped in a custom `AgentExecutor` implementation without modifying `AgentTool`.
+- Third-party agent APIs that do not speak ACP natively can be wrapped in a custom `Tool` implementation that posts to the third-party endpoint and returns the response as the tool result.
 
 ---
 
@@ -824,7 +777,7 @@ src/
   agent.ts                — createAgent helper, AgentConfig validation
   runner.ts               — AgentRunner, RunBuilder
   conversation.ts         — Conversation (automatic history management)
-  agent-tool.ts           — AgentExecutor, AgentTool, localAgent, AcpAgent, AcpAgentOptions
+  agentTool.ts            — createAgentTool, AgentToolOptions
   adapter/
     index.ts              — LlmAdapter, AdapterRequest, AdapterResponse,
                             AdapterStreamChunk, ModelConfig
@@ -846,7 +799,7 @@ tests/
     tool-registry.test.ts
     urp-adapter.test.ts         — URP ↔ AdapterRequest translation
     prompt-api-adapter.test.ts  — tool injection, responseConstraint schema, session lifecycle
-    agent-tool.test.ts          — AgentTool, localAgent, AcpAgent with stub executor
+    agentTool.test.ts           — createAgentTool with stub adapter
   integration/
     http-transport.test.ts      — hits a local URP echo server
     acp-agent.test.ts           — hits a local ACP echo server

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@mast-ai/built-in-ai": "*",
-        "@mast-ai/core": "*"
+        "@mast-ai/core": "*",
+        "@mast-ai/google-genai": "*"
       },
       "devDependencies": {
         "typescript": "~6.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,17 @@
         "typescript-eslint": "^8.59.1"
       }
     },
+    "apps/demo-agent-tool": {
+      "version": "0.0.0",
+      "dependencies": {
+        "@mast-ai/built-in-ai": "*",
+        "@mast-ai/core": "*"
+      },
+      "devDependencies": {
+        "typescript": "~6.0.2",
+        "vite": "^6.0.0"
+      }
+    },
     "apps/demo-basic-chat": {
       "version": "0.0.0",
       "dependencies": {
@@ -2030,6 +2041,10 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/demo-agent-tool": {
+      "resolved": "apps/demo-agent-tool",
+      "link": true
     },
     "node_modules/demo-basic-chat": {
       "resolved": "apps/demo-basic-chat",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
     "apps/demo-agent-tool": {
       "version": "0.0.0",
       "dependencies": {
-        "@mast-ai/built-in-ai": "*",
         "@mast-ai/core": "*",
         "@mast-ai/google-genai": "*"
       },

--- a/packages/core/src/agentTool.test.ts
+++ b/packages/core/src/agentTool.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { createAgentTool } from './agentTool';
+import { AgentRunner } from './runner';
+import { AgentError } from './error';
+import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index';
+import type { AgentConfig, AgentEvent } from './types';
+import type { ToolContext } from './tool';
+
+function streamingAdapter(chunks: AdapterStreamChunk[]): LlmAdapter {
+  return {
+    generate: vi.fn(),
+    generateStream: (_request: AdapterRequest) =>
+      (async function* () {
+        for (const chunk of chunks) yield chunk;
+      })(),
+  };
+}
+
+const childAgent: AgentConfig = {
+  name: 'Child',
+  instructions: 'Be a child agent.',
+};
+
+describe('createAgentTool', () => {
+  it('exposes the configured definition', () => {
+    const runner = new AgentRunner(streamingAdapter([]));
+    const tool = createAgentTool(runner, childAgent, {
+      name: 'classify',
+      description: 'Classifies intent.',
+      parameters: { type: 'object' },
+      scope: 'write',
+      requiresApproval: true,
+      buildInput: () => '',
+    });
+
+    expect(tool.definition()).toEqual({
+      name: 'classify',
+      description: 'Classifies intent.',
+      parameters: { type: 'object' },
+      scope: 'write',
+      requiresApproval: true,
+    });
+  });
+
+  it("defaults scope to 'read' when omitted", () => {
+    const runner = new AgentRunner(streamingAdapter([]));
+    const tool = createAgentTool(runner, childAgent, {
+      name: 't',
+      description: 'd',
+      parameters: {},
+      buildInput: () => '',
+    });
+    expect(tool.definition().scope).toBe('read');
+  });
+
+  it('forwards non-done child events via context.onEvent and returns done.output', async () => {
+    const runner = new AgentRunner(
+      streamingAdapter([
+        { type: 'thinking', delta: 'pondering' },
+        { type: 'text_delta', delta: 'Hello ' },
+        { type: 'text_delta', delta: 'world' },
+      ]),
+    );
+
+    const tool = createAgentTool(runner, childAgent, {
+      name: 'sub',
+      description: 'sub',
+      parameters: {},
+      buildInput: (args) => (args as { q: string }).q,
+    });
+
+    const events: AgentEvent[] = [];
+    const context: ToolContext = { onEvent: (e) => events.push(e) };
+
+    const result = await tool.call({ q: 'hi' }, context);
+
+    expect(result).toBe('Hello world');
+    // No 'done' event should be forwarded.
+    expect(events.some((e) => e.type === 'done')).toBe(false);
+    expect(events.map((e) => e.type)).toEqual(['thinking', 'text_delta', 'text_delta']);
+  });
+
+  it('threads context.signal into the child runner', async () => {
+    const controller = new AbortController();
+    controller.abort('test reason');
+
+    const runner = new AgentRunner(streamingAdapter([{ type: 'text_delta', delta: 'x' }]));
+    const tool = createAgentTool(runner, childAgent, {
+      name: 'sub',
+      description: 'sub',
+      parameters: {},
+      buildInput: () => 'input',
+    });
+
+    await expect(tool.call({}, { signal: controller.signal })).rejects.toBeInstanceOf(AgentError);
+  });
+
+  it('throws AgentError when the child stream ends without a done event', async () => {
+    const runner = new AgentRunner(streamingAdapter([]));
+    // Replace runBuilder to return a stream that ends with no events at all,
+    // bypassing the runner's normal 'done' emission.
+    const originalRunBuilder = runner.runBuilder.bind(runner);
+    runner.runBuilder = (agent: AgentConfig) => {
+      const builder = originalRunBuilder(agent);
+      builder.runStream = () =>
+        (async function* () {
+          // intentionally yields nothing
+        })();
+      return builder;
+    };
+
+    const tool = createAgentTool(runner, childAgent, {
+      name: 'sub',
+      description: 'sub',
+      parameters: {},
+      buildInput: () => 'input',
+    });
+
+    await expect(tool.call({}, {})).rejects.toBeInstanceOf(AgentError);
+  });
+
+  it('passes the result of buildInput as the child input', async () => {
+    let capturedUserMessage: unknown;
+    const generateStream = vi.fn((request: AdapterRequest) => {
+      // Capture immediately — the runner mutates the messages array in place
+      // by appending the assistant turn after the stream completes.
+      capturedUserMessage = request.messages[request.messages.length - 1];
+      return (async function* () {
+        yield { type: 'text_delta', delta: 'ok' } as AdapterStreamChunk;
+      })();
+    });
+    const runner = new AgentRunner({ generate: vi.fn(), generateStream });
+
+    const tool = createAgentTool(runner, childAgent, {
+      name: 'sub',
+      description: 'sub',
+      parameters: {},
+      buildInput: (args) => `built:${(args as { q: string }).q}`,
+    });
+
+    await tool.call({ q: 'hi' }, {});
+
+    expect(capturedUserMessage).toEqual({
+      role: 'user',
+      content: { type: 'text', text: 'built:hi' },
+    });
+  });
+});

--- a/packages/core/src/agentTool.ts
+++ b/packages/core/src/agentTool.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AgentConfig } from './types';
+import type { AgentRunner } from './runner';
+import type { Tool, ToolContext, ToolDefinition } from './tool';
+import { AgentError } from './error';
+
+/** Configuration for {@link createAgentTool}. */
+export interface AgentToolOptions {
+  name: string;
+  description: string;
+  /** JSON Schema object describing the tool's arguments. */
+  parameters: Record<string, unknown>;
+  /** Whether the tool reads or modifies state. Defaults to `'read'`. */
+  scope?: 'read' | 'write';
+  /** When true, the tool is sensitive and requires human confirmation before executing. */
+  requiresApproval?: boolean;
+  /** Build the input string passed to the child agent from the tool args. */
+  buildInput: (args: unknown) => string;
+}
+
+/**
+ * Wraps an {@link AgentConfig} as a {@link Tool} so it can be registered as a
+ * sub-agent of another agent. The returned tool, when called, runs `agent` on
+ * the given `runner`, forwards every non-`done` child event to
+ * `context.onEvent`, and returns the child's final output as the tool result.
+ *
+ * `runner` and `agent` are independent of the parent: the child can use a
+ * different adapter, registry, instructions, or tool allowlist.
+ */
+export function createAgentTool(
+  runner: AgentRunner,
+  agent: AgentConfig,
+  options: AgentToolOptions,
+): Tool {
+  const definition: ToolDefinition = {
+    name: options.name,
+    description: options.description,
+    parameters: options.parameters,
+    scope: options.scope ?? 'read',
+    requiresApproval: options.requiresApproval,
+  };
+
+  return {
+    definition: () => definition,
+    async call(args: unknown, context: ToolContext): Promise<string> {
+      const input = options.buildInput(args);
+      const builder = runner.runBuilder(agent);
+      if (context.signal) builder.signal(context.signal);
+
+      for await (const event of builder.runStream(input)) {
+        if (event.type === 'done') {
+          return event.output;
+        }
+        context.onEvent?.(event);
+      }
+
+      throw new AgentError(`Sub-agent '${agent.name}' stream ended without a 'done' event.`);
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from './types';
 export * from './error';
 export * from './tool';
 export * from './agent';
+export * from './agentTool';
 export * from './runner';
 export * from './conversation';
 


### PR DESCRIPTION
## Summary

- Adds `createAgentTool(runner, agent, options)` to `@mast-ai/core` — a small helper that wraps an `AgentConfig` + `AgentRunner` pair as a `Tool`, encoding the sub-agent contract from `docs/tool-event-streaming/PLAN.md` so individual tool authors do not have to reimplement it.
- `runner` and `agent` are passed in separately so the child can use a different adapter, registry, instructions, or tool allowlist than the parent — true decoupling between parent and child execution modes.
- Updates `docs/SPEC.md` to replace the unimplemented `AgentExecutor` / `AgentTool` / `localAgent` / `AcpAgent` design with the simpler `createAgentTool` API that's actually shipping.

The returned tool's `call(args, context)`:
1. Builds the child input via `options.buildInput(args)`.
2. Runs `runner.runBuilder(agent).signal(context.signal).runStream(input)`.
3. Forwards every non-`done` event to `context.onEvent` (filtering `done` is critical — it carries the child's full `history`, which must not leak to parent UI consumers).
4. Returns `done.output` as the tool result.
5. Throws `AgentError` if the stream ends without a `done` event.

Closes #50

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format` — clean
- [x] `npm run build` — all packages build
- [x] `npm test` — 123 tests pass across the workspace (6 new in `agentTool.test.ts` covering the four acceptance criteria + scope default + `buildInput` plumbing)
- [ ] Manually wire a sub-agent via `createAgentTool` in a demo app and confirm child events flow through `onToolEvent`