### PR TITLE
feat(react-ui): icon system with bundled SVG defaults and override prop

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -4,7 +4,8 @@
 import { useState, type KeyboardEvent } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
-import { AgentProvider, useAgent } from '@mast-ai/react-ui';
+import { AgentProvider, useAgent, type IconMap } from '@mast-ai/react-ui';
+import { Brain, CircleCheck, LoaderCircle, Send, Square, Wrench } from 'lucide-react';
 
 import { GetCurrentTimeTool } from './tools';
 
@@ -23,6 +24,15 @@ const agentConfig = createAgent({
     'Use the get_current_time tool when the user asks about the current time.',
   tools: ['get_current_time'],
 });
+
+const icons: IconMap = {
+  brain: <Brain size={16} />,
+  wrench: <Wrench size={16} />,
+  check: <CircleCheck size={16} />,
+  loader: <LoaderCircle size={16} className="mast-spin" />,
+  send: <Send size={16} />,
+  stop: <Square size={16} />,
+};
 
 function ChatUI() {
   const { messages, sendMessage, cancel, isRunning } = useAgent();
@@ -76,7 +86,7 @@ function ChatUI() {
 
 export default function App() {
   return (
-    <AgentProvider runner={runner} agent={agentConfig}>
+    <AgentProvider runner={runner} agent={agentConfig} icons={icons}>
       <h1>MAST React UI Demo</h1>
       <ChatUI />
     </AgentProvider>

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -1,12 +1,14 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, render } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ReactNode } from 'react';
 import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
 
 import { AgentProvider, useAgent } from './context';
+import { defaultIcons, useIcons } from './icons';
+import type { IconMap } from './types';
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -96,6 +98,42 @@ describe('useAgent', () => {
     expect(result.current.messages).toHaveLength(2);
     expect(result.current.messages[0]).toMatchObject({ role: 'user', text: 'hello' });
     expect(result.current.messages[1]).toMatchObject({ role: 'assistant', text: 'Hi' });
+  });
+
+  it('exposes the bundled icon defaults when no `icons` prop is provided', () => {
+    const runner = makeMockRunner();
+    const { result } = renderHook(() => useIcons(), { wrapper: makeWrapper(runner) });
+
+    expect(result.current).toBe(defaultIcons);
+  });
+
+  it('overrides individual icon slots from the `icons` prop, leaving the rest as defaults', () => {
+    const runner = makeMockRunner();
+    const customSend = <span data-testid="custom-send">SEND</span>;
+    const customStop = <span data-testid="custom-stop">STOP</span>;
+    const icons: IconMap = { send: customSend, stop: customStop };
+
+    function ProbeIcons() {
+      const map = useIcons();
+      return (
+        <div>
+          <div data-testid="brain-slot">{map.brain}</div>
+          <div data-testid="send-slot">{map.send}</div>
+          <div data-testid="stop-slot">{map.stop}</div>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(
+      <AgentProvider runner={runner} agent={agentConfig} icons={icons}>
+        <ProbeIcons />
+      </AgentProvider>,
+    );
+
+    expect(getByTestId('custom-send').textContent).toBe('SEND');
+    expect(getByTestId('custom-stop').textContent).toBe('STOP');
+    // The unspecified `brain` slot still renders the bundled SVG default.
+    expect(getByTestId('brain-slot').querySelector('svg')).not.toBeNull();
   });
 
   it('reset() clears messages and creates a fresh Conversation', async () => {

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import type { AgentConfig, AgentRunner, Conversation } from '@mast-ai/core';
 
 import { useAgentStream } from './hooks/useAgentStream';
+import { IconProvider } from './icons';
 import type { ConversationEntry, IconMap } from './types';
 
 /**
@@ -19,8 +20,10 @@ export interface AgentProviderProps {
   /** The subtree that should have access to {@link useAgent}. */
   children: ReactNode;
   /**
-   * Optional override for the bundled inline SVG icons. Wired up in a follow-up
-   * issue; accepted here so the prop is part of the stable provider API.
+   * Optional overrides for the bundled inline SVG icons. Any keys left
+   * unspecified fall back to the defaults exported from `./icons`. Distributed
+   * to descendants through a dedicated icon context so updates do not flow
+   * through the agent state context.
    */
   icons?: IconMap;
 }
@@ -54,7 +57,7 @@ const AgentContext = createContext<UseAgentReturn | null>(null);
  * and drives it with {@link useAgentStream}. Children access the resulting
  * state through {@link useAgent}.
  */
-export function AgentProvider({ runner, agent, children }: AgentProviderProps) {
+export function AgentProvider({ runner, agent, children, icons }: AgentProviderProps) {
   const [conversation, setConversation] = useState<Conversation>(() => runner.conversation(agent));
 
   const {
@@ -75,7 +78,11 @@ export function AgentProvider({ runner, agent, children }: AgentProviderProps) {
     [entries, sendMessage, cancel, isRunning, reset],
   );
 
-  return <AgentContext.Provider value={value}>{children}</AgentContext.Provider>;
+  return (
+    <AgentContext.Provider value={value}>
+      <IconProvider icons={icons}>{children}</IconProvider>
+    </AgentContext.Provider>
+  );
 }
 
 /**

--- a/packages/react-ui/src/hooks/useAgentStream.test.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.test.ts
@@ -138,8 +138,16 @@ describe('useAgentStream', () => {
     });
 
     expect(result.current.entries).toHaveLength(2);
-    expect(result.current.entries[0]).toMatchObject({ role: 'user', text: 'Hello', isStreaming: false });
-    expect(result.current.entries[1]).toMatchObject({ role: 'assistant', text: '', isStreaming: true });
+    expect(result.current.entries[0]).toMatchObject({
+      role: 'user',
+      text: 'Hello',
+      isStreaming: false,
+    });
+    expect(result.current.entries[1]).toMatchObject({
+      role: 'assistant',
+      text: '',
+      isStreaming: true,
+    });
     expect(result.current.isRunning).toBe(true);
 
     resume();
@@ -526,8 +534,7 @@ describe('useAgentStream', () => {
   // -------------------------------------------------------------------------
 
   it('appends a new entry pair on a second sendMessage rather than mutating the first', async () => {
-    const makeConv = (output: string) =>
-      mockConversation([{ type: 'done', output, history: [] }]);
+    const makeConv = (output: string) => mockConversation([{ type: 'done', output, history: [] }]);
 
     const { result, rerender } = renderHook(
       ({ conv }: { conv: Conversation }) => useAgentStream(conv),

--- a/packages/react-ui/src/icons.tsx
+++ b/packages/react-ui/src/icons.tsx
@@ -1,0 +1,123 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+import type { IconMap } from './types';
+
+/**
+ * Shared SVG attributes for the bundled defaults. Each icon is a 16x16
+ * `currentColor`-stroked outline so it inherits text colour from its slot.
+ */
+const baseSvgProps = {
+  width: 16,
+  height: 16,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+  focusable: false,
+};
+
+function BrainIcon() {
+  return (
+    <svg {...baseSvgProps}>
+      <path d="M9 3a3 3 0 0 0-3 3v.5a3 3 0 0 0-2 5.2A3 3 0 0 0 6 17v.5a3 3 0 0 0 6 0V3a3 3 0 0 0-3 0Z" />
+      <path d="M15 3a3 3 0 0 1 3 3v.5a3 3 0 0 1 2 5.2A3 3 0 0 1 18 17v.5a3 3 0 0 1-6 0V3a3 3 0 0 1 3 0Z" />
+    </svg>
+  );
+}
+
+function WrenchIcon() {
+  return (
+    <svg {...baseSvgProps}>
+      <path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.6 2.6-2.4-2.4 2.6-2.6Z" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg {...baseSvgProps}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="m8 12 3 3 5-6" />
+    </svg>
+  );
+}
+
+function LoaderIcon() {
+  return (
+    <svg {...baseSvgProps} className="mast-spin">
+      <path d="M12 3a9 9 0 1 0 9 9" />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg {...baseSvgProps} fill="currentColor" stroke="none">
+      <path d="M3 3 21 12 3 21l3-9-3-9Z" />
+    </svg>
+  );
+}
+
+function StopIcon() {
+  return (
+    <svg {...baseSvgProps} fill="currentColor" stroke="none">
+      <rect x="5" y="5" width="14" height="14" rx="1" />
+    </svg>
+  );
+}
+
+/**
+ * Bundled defaults for every icon slot. Every key is populated, so callers
+ * receive a `Required<IconMap>` from {@link useIcons}.
+ */
+export const defaultIcons: Required<IconMap> = {
+  brain: <BrainIcon />,
+  wrench: <WrenchIcon />,
+  check: <CheckIcon />,
+  loader: <LoaderIcon />,
+  send: <SendIcon />,
+  stop: <StopIcon />,
+};
+
+/**
+ * Internal context that distributes the icon set to every component below
+ * `<AgentProvider>`. Kept separate from `AgentContext` so re-renders driven
+ * by streaming state do not invalidate consumers that only read icons.
+ */
+const IconContext = createContext<Required<IconMap>>(defaultIcons);
+
+/**
+ * Internal provider used by `<AgentProvider>` to merge consumer overrides on
+ * top of the bundled defaults before publishing the resulting map.
+ */
+export function IconProvider({ icons, children }: { icons?: IconMap; children: ReactNode }) {
+  const value = useMemo<Required<IconMap>>(() => {
+    if (!icons) return defaultIcons;
+    return {
+      brain: icons.brain ?? defaultIcons.brain,
+      wrench: icons.wrench ?? defaultIcons.wrench,
+      check: icons.check ?? defaultIcons.check,
+      loader: icons.loader ?? defaultIcons.loader,
+      send: icons.send ?? defaultIcons.send,
+      stop: icons.stop ?? defaultIcons.stop,
+    };
+  }, [icons]);
+
+  return <IconContext.Provider value={value}>{children}</IconContext.Provider>;
+}
+
+/**
+ * Internal hook used by components that render an icon slot. Always returns
+ * a fully populated map, falling back to the bundled defaults for any slot
+ * the consumer did not override.
+ */
+export function useIcons(): Required<IconMap> {
+  return useContext(IconContext);
+}


### PR DESCRIPTION
## Summary

- Adds `packages/react-ui/src/icons.tsx`: six hand-authored inline SVG icons (`brain`, `wrench`, `check`, `loader`, `send`, `stop`), an internal `IconContext` kept separate from the agent state context (so streaming re-renders don't invalidate icon consumers), and an internal `useIcons()` hook that always returns a fully populated `Required<IconMap>`.
- `AgentProvider` now consumes the `icons` prop and wraps children in an `IconProvider` that merges consumer overrides on top of the bundled defaults.
- `apps/demo-react-ui` passes all six `lucide-react` equivalents (`Brain`, `Wrench`, `CircleCheck`, `LoaderCircle` with `mast-spin`, `Send`, `Square`) via the `icons` prop on `AgentProvider`.

`IconMap` was already exported from `src/index.ts` (added in #30), so no change there.

## Notes

The icons are not yet visible in the demo's UI: the components that consume `useIcons()` (`ThinkingBlock`, `ToolCallBlock`, `ChatInput`) come in later issues per `docs/react-ui/PLAN.md`. This PR plumbs the context end-to-end and verifies the override behaviour at the unit level.

## Test plan

- [x] `npm run lint` passes from the repo root
- [x] `npm run build` passes from the repo root
- [x] `npm test --workspaces --if-present` — react-ui has 25 tests (was 23); two new tests cover the bundled defaults and per-slot override behaviour
- [x] `apps/demo-react-ui` boots via `npm run dev` and the basic chat still works

Closes #31