### PR TITLE
feat(react-ui): ThinkingBlock component

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -4,7 +4,7 @@
 import { useState, type KeyboardEvent } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
-import { AgentProvider, useAgent, type IconMap } from '@mast-ai/react-ui';
+import { AgentProvider, ThinkingBlock, useAgent, type IconMap } from '@mast-ai/react-ui';
 import { Brain, CircleCheck, LoaderCircle, Send, Square, Wrench } from 'lucide-react';
 
 import { GetCurrentTimeTool } from './tools';
@@ -57,7 +57,11 @@ function ChatUI() {
       <ul>
         {messages.map((entry) => (
           <li key={entry.id}>
-            <strong>{entry.role}:</strong> {entry.text}
+            <strong>{entry.role}:</strong>{' '}
+            {entry.role === 'assistant' && entry.thinking ? (
+              <ThinkingBlock content={entry.thinking} isStreaming={entry.isStreaming} />
+            ) : null}
+            {entry.text}
             {entry.isStreaming && entry.text === '' ? <em> (thinking...)</em> : null}
           </li>
         ))}

--- a/packages/react-ui/src/components/ThinkingBlock.test.tsx
+++ b/packages/react-ui/src/components/ThinkingBlock.test.tsx
@@ -1,0 +1,75 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ThinkingBlock } from './ThinkingBlock';
+
+describe('<ThinkingBlock>', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders collapsed by default', () => {
+    render(<ThinkingBlock content="Some reasoning trace" />);
+    const details = screen.getByText('Thinking Process').closest('details');
+    expect(details).not.toBeNull();
+    expect(details!.open).toBe(false);
+  });
+
+  it('uses the default "Thinking Process" label when none is supplied', () => {
+    render(<ThinkingBlock content="x" />);
+    expect(screen.getByText('Thinking Process')).toBeDefined();
+  });
+
+  it('honours a custom label', () => {
+    render(<ThinkingBlock content="x" label="Reasoning" />);
+    expect(screen.getByText('Reasoning')).toBeDefined();
+  });
+
+  it('expands when the summary is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ThinkingBlock content="hidden until expanded" />);
+
+    const summary = screen.getByText('Thinking Process');
+    const details = summary.closest('details');
+    expect(details!.open).toBe(false);
+
+    await user.click(summary);
+    expect(details!.open).toBe(true);
+  });
+
+  it('renders the pulsing indicator while streaming', () => {
+    render(<ThinkingBlock content="" isStreaming />);
+    expect(screen.queryByTestId('mast-thinking-pulse')).not.toBeNull();
+  });
+
+  it('omits the pulsing indicator when not streaming', () => {
+    render(<ThinkingBlock content="done" isStreaming={false} />);
+    expect(screen.queryByTestId('mast-thinking-pulse')).toBeNull();
+  });
+
+  it('omits the pulsing indicator when isStreaming is unspecified', () => {
+    render(<ThinkingBlock content="done" />);
+    expect(screen.queryByTestId('mast-thinking-pulse')).toBeNull();
+  });
+
+  it('renders the bundled brain icon by default', () => {
+    const { container } = render(<ThinkingBlock content="x" />);
+    expect(container.querySelector('summary svg')).not.toBeNull();
+  });
+
+  it('forwards className to the root element', () => {
+    render(<ThinkingBlock content="x" className="custom-class" />);
+    const details = screen.getByText('Thinking Process').closest('details');
+    expect(details!.className).toContain('custom-class');
+    expect(details!.className).toContain('mast-thinking-block');
+  });
+
+  it('renders the content inside the details element', () => {
+    render(<ThinkingBlock content="step-by-step thoughts" />);
+    expect(screen.getByText('step-by-step thoughts')).toBeDefined();
+  });
+});

--- a/packages/react-ui/src/components/ThinkingBlock.tsx
+++ b/packages/react-ui/src/components/ThinkingBlock.tsx
@@ -1,0 +1,62 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useIcons } from '../icons';
+
+/**
+ * Props accepted by {@link ThinkingBlock}.
+ */
+export interface ThinkingBlockProps {
+  /** The accumulated thinking/reasoning text to display when expanded. */
+  content: string;
+  /**
+   * `true` while the assistant is still streaming thinking deltas.
+   * Drives a pulsing indicator next to the label.
+   */
+  isStreaming?: boolean;
+  /** Optional class added to the root `<details>` element. */
+  className?: string;
+  /** Header label. Default: `'Thinking Process'`. */
+  label?: string;
+}
+
+/**
+ * Collapsible section for the agent's thinking/reasoning trace.
+ *
+ * Rendered as a native `<details>/<summary>` element so it is keyboard
+ * accessible and works without JavaScript. Collapsed by default; consumers
+ * can override the appearance via the default stylesheet's `mast-thinking-*`
+ * classes or by passing a custom `className`.
+ */
+export function ThinkingBlock({
+  content,
+  isStreaming = false,
+  className,
+  label = 'Thinking Process',
+}: ThinkingBlockProps) {
+  const icons = useIcons();
+  const rootClass = ['mast-thinking-block', className].filter(Boolean).join(' ');
+
+  return (
+    <details
+      data-mast-thinking-block
+      data-streaming={isStreaming ? 'true' : undefined}
+      className={rootClass}
+    >
+      <summary className="mast-thinking-block-summary">
+        <span className="mast-thinking-block-icon" aria-hidden="true">
+          {icons.brain}
+        </span>
+        <span className="mast-thinking-block-label">{label}</span>
+        {isStreaming ? (
+          <span
+            className="mast-thinking-block-pulse"
+            data-testid="mast-thinking-pulse"
+            aria-hidden="true"
+          />
+        ) : null}
+      </summary>
+      <div className="mast-thinking-block-content">{content}</div>
+    </details>
+  );
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -6,3 +6,5 @@ export { useAgentStream } from './hooks/useAgentStream';
 export type { UseAgentStreamReturn } from './hooks/useAgentStream';
 export { AgentProvider, useAgent } from './context';
 export type { AgentProviderProps, UseAgentReturn } from './context';
+export { ThinkingBlock } from './components/ThinkingBlock';
+export type { ThinkingBlockProps } from './components/ThinkingBlock';


### PR DESCRIPTION
## Summary
- Adds `<ThinkingBlock>` component: a native `<details>/<summary>` element for the assistant's thinking trace, collapsed by default, keyboard-accessible without JS.
- Pulsing indicator (`mast-thinking-block-pulse`) shown next to the label while `isStreaming` is true.
- Uses the `brain` icon from `useIcons()`, so consumer overrides via the `icons` prop on `<AgentProvider>` propagate automatically.
- Wires `ThinkingBlock` into `apps/demo-react-ui/src/App.tsx` for assistant entries that have `thinking` content. Tool-call rendering replacement is deferred to #33.

## Implementation notes
- Props match SPEC §4.7: `content`, `isStreaming?`, `className?`, `label?` (defaults to `'Thinking Process'`).
- Pulse element is a sibling `<span>` rather than a class on the icon, so the indicator is independent of any consumer-supplied icon node.
- Tests use explicit `cleanup()` in `afterEach` because `vitest.config.ts` does not enable `globals: true`, which is required for `@testing-library/react` auto-cleanup.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run build` passes
- [x] `npm test` passes (35/35 in `@mast-ai/react-ui`, including 10 new ThinkingBlock tests)
- [x] Manually verified the demo shows the collapsible block when the agent emits thinking content

Closes #32