### PR TITLE
chore: apply prettier formatting

### DIFF
--- a/apps/demo-agent-tool/index.html
+++ b/apps/demo-agent-tool/index.html
@@ -20,8 +20,8 @@
         <div class="info-panel">
           <h3>Architecture</h3>
           <p>
-            <strong>Parent agent</strong>: an orchestrator that picks tools. It runs through its
-            own <code>AgentRunner</code> + <code>GoogleGenAIAdapter</code>.
+            <strong>Parent agent</strong>: an orchestrator that picks tools. It runs through its own
+            <code>AgentRunner</code> + <code>GoogleGenAIAdapter</code>.
           </p>
           <p>
             <strong>Child agent</strong>: a specialised rewriter. It runs through a separate

--- a/docs/react-ui/PLAN.md
+++ b/docs/react-ui/PLAN.md
@@ -12,6 +12,7 @@ Set up the two new workspace members so the monorepo builds end-to-end with the 
 packages present but empty.
 
 **`packages/react-ui`**
+
 - `package.json`: name, peer deps (`react`, `react-dom`, `@mast-ai/core`,
   `@tanstack/react-virtual`), optional deps (`react-markdown`, `remark-gfm`,
   `rehype-sanitize`), dev deps (Vite, Vitest, `@testing-library/react`,
@@ -23,6 +24,7 @@ packages present but empty.
 - `styles/default.css`: empty
 
 **`apps/demo-react-ui`**
+
 - Vite + React + TypeScript app, `package.json` with workspace deps
   (`@mast-ai/react-ui`, `@mast-ai/google-genai`, `lucide-react`,
   `react-markdown`, `remark-gfm`, `rehype-sanitize`)
@@ -39,13 +41,16 @@ The streaming state machine is the heart of the library. Ship it fully tested be
 any component depends on it.
 
 **`packages/react-ui/src/types.ts`**
+
 - `ConversationEntry`, `ToolEventEntry`, `IconMap` (as specified in SPEC §3 and §6.3)
 
 **`packages/react-ui/src/hooks/useAgentStream.ts`**
+
 - Subscribes to `AgentEvent` stream from a `Conversation` instance
 - Builds and maintains `ConversationEntry[]` per the state table in SPEC §8
 
 **`src/hooks/useAgentStream.test.ts`**
+
 - All scenarios from SPEC §11.2: text streaming, thinking, tool call lifecycle,
   sub-agent thinking and text via `onToolEvent`, sub-agent `done` ignored,
   concurrent tool calls, `done`, error/cancel, new turn sequencing
@@ -61,11 +66,13 @@ No demo wiring — the hook is internal and cannot be used without `AgentProvide
 ## Issue 3 — `AgentProvider` and `useAgent` hook
 
 **`packages/react-ui/src/context.tsx`**
+
 - `AgentProvider`: creates a `Conversation` from `runner.conversation(agent)`,
   invokes `useAgentStream`, exposes state via `AgentContext`
 - `useAgent()`: reads context, throws with a clear message if called outside the provider
 
 **`src/context.test.tsx`**
+
 - `useAgent()` throws outside provider
 - `useAgent()` returns `{ messages, sendMessage, cancel, isRunning, reset }`
 - `reset()` clears entries and creates a fresh `Conversation`
@@ -73,6 +80,7 @@ No demo wiring — the hook is internal and cannot be used without `AgentProvide
 Exported from `src/index.ts`.
 
 **`apps/demo-react-ui`** — first functional wiring:
+
 - `src/tools.ts`: `get_current_time` tool (returns `new Date().toISOString()`)
 - `App.tsx`: wrap with `AgentProvider` (using `GoogleGenAIAdapter` + `VITE_GEMINI_API_KEY`),
   register `get_current_time`, render a minimal custom UI with `useAgent()`:
@@ -86,15 +94,18 @@ Exported from `src/index.ts`.
 ## Issue 4 — Icon system
 
 **`packages/react-ui/src/icons.tsx`**
+
 - Six hand-authored inline SVG components (brain, wrench, check, loader, send, stop)
 - `IconContext` and `useIcons()` internal hook
 - `IconMap` type (re-exported from `src/index.ts`)
 - `icons` prop wired into `AgentProvider` (update `AgentProviderProps`)
 
 **`src/context.test.tsx`** (extend)
+
 - Custom icon node from `icons` prop is rendered in place of bundled default
 
 **`apps/demo-react-ui`**
+
 - Pass all six `lucide-react` icon slots via the `icons` prop on `AgentProvider`
 
 **Depends on:** Issue 3
@@ -104,6 +115,7 @@ Exported from `src/index.ts`.
 ## Issue 5 — `ThinkingBlock` and `ToolCallBlock`
 
 Sub-issues:
+
 - **5a — `ThinkingBlock`**: `<details>/<summary>` element, pulsing indicator when
   `isStreaming`, uses `brain` icon from `useIcons()`. Tests: collapsed by default,
   expands on click, pulse indicator present/absent.
@@ -115,6 +127,7 @@ Sub-issues:
   tools.
 
 **`apps/demo-react-ui`**
+
 - Replace raw tool-call rendering in `App.tsx` with `ThinkingBlock` and `ToolCallBlock`
 
 **Depends on:** Issue 4
@@ -134,6 +147,7 @@ No dedicated tests beyond what Issue 5 already covers; component correctness is
 verified through `MessageList` tests in Issue 8.
 
 **`apps/demo-react-ui`**
+
 - Replace per-entry rendering in `App.tsx` with `UserMessage` and `AssistantMessage`
 
 **Depends on:** Issue 5
@@ -143,6 +157,7 @@ verified through `MessageList` tests in Issue 8.
 ## Issue 7 — `ChatInput`
 
 **`packages/react-ui/src/components/ChatInput.tsx`**
+
 - Textarea that grows with content
 - Enter submits, Shift+Enter inserts newline
 - Send button → calls `sendMessage`; swaps to cancel button while `isRunning`
@@ -150,10 +165,12 @@ verified through `MessageList` tests in Issue 8.
 - Accepts `sendLabel`, `cancelLabel`, `placeholder`, `className` props
 
 **`src/components/ChatInput.test.tsx`**
+
 - All scenarios from SPEC §11.2: Enter submits, Shift+Enter does not, cancel button
   appears while running
 
 **`apps/demo-react-ui`**
+
 - Replace the raw `<textarea>` + `<button>`s in `App.tsx` with `ChatInput`
 
 **Depends on:** Issue 4 (icons), Issue 3 (useAgent)
@@ -163,6 +180,7 @@ verified through `MessageList` tests in Issue 8.
 ## Issue 8 — `MessageList` with virtual scrolling
 
 **`packages/react-ui/src/components/MessageList.tsx`**
+
 - `useVirtualizer` from `@tanstack/react-virtual` with `measureElement` for dynamic
   item heights
 - `useEffect` that scrolls to the bottom when `entries.length` grows or the last
@@ -171,9 +189,11 @@ verified through `MessageList` tests in Issue 8.
 - Accepts `renderToolCall` and `renderMessage` override props
 
 **`src/components/MessageList.test.tsx`**
+
 - Renders user and assistant entries; scrolls to bottom on new entry
 
 **`apps/demo-react-ui`**
+
 - Replace the raw `<ul>` in `App.tsx` with `MessageList`
 
 **Depends on:** Issue 6
@@ -183,17 +203,20 @@ verified through `MessageList` tests in Issue 8.
 ## Issue 9 — `ConversationPanel` and default CSS
 
 **`packages/react-ui/src/components/ConversationPanel.tsx`**
+
 - Thin compositor: renders `MessageList` + `ChatInput` inside a `[data-mast-root]` div
 - Accepts `theme`, `className`, `renderToolCall`, `renderMessage`, `inputPlaceholder`
 - Sets `data-mast-theme` attribute from `theme` prop
 
 **`styles/default.css`**
+
 - Full light theme (CSS custom properties on `[data-mast-root]`)
 - `prefers-color-scheme: dark` block
 - `[data-mast-theme="dark"]` explicit override block
 - All `mast-*` class rules for every component
 
 **`apps/demo-react-ui`**
+
 - Replace `MessageList` + `ChatInput` in `App.tsx` with `ConversationPanel`
 - Import `@mast-ai/react-ui/styles.css`
 - Add a dark mode toggle button that sets the `theme` prop on `ConversationPanel`
@@ -236,11 +259,13 @@ needsApproval = (def.requiresApproval || overrideSet.has(name)) && !suppressSet.
 ```
 
 **`src/approval.test.tsx`**
+
 - All six scenarios from SPEC §11.2: `requiresApproval: true` triggers callback;
   callback returns `false` / `string` / `true`; `approvalOverride` adds and suppresses;
   no callback → silent execution.
 
 **`apps/demo-react-ui`**
+
 - Add `get_page_title` tool to `src/tools.ts` (returns `document.title`, marked
   `requiresApproval: true`)
 - Register `get_page_title` and wire `onApprovalRequired` to `window.confirm`
@@ -254,14 +279,17 @@ needsApproval = (def.requiresApproval || overrideSet.has(name)) && !suppressSet.
 Extends `AgentProvider` with save/load hooks.
 
 **`AgentProviderProps` additions**
+
 - `initialHistory?: Message[]` — seeds `Conversation.history` before the first turn
 - `initialEntries?: ConversationEntry[]` — seeds the UI entry list on mount
 - `onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void` — fired after each completed turn
 
 **`useAgent()` addition**
+
 - `history: Message[]` — live reference to the underlying `Conversation.history`
 
 **`src/context.test.tsx`** (extend)
+
 - `onConversationChange` fires after `done`; not fired on cancel or error
 - `initialHistory` is set on the `Conversation` before the first run
 - `initialEntries` populates `messages` immediately on mount
@@ -269,6 +297,7 @@ Extends `AgentProvider` with save/load hooks.
 - `useAgent().history` reflects current core state
 
 **`apps/demo-react-ui`**
+
 - Wire `onConversationChange` to persist `history` and `entries` to `localStorage`
 - Pass `initialHistory` and `initialEntries` loaded from `localStorage` on startup
 
@@ -295,6 +324,7 @@ polish before the library is considered complete.
 ## Issue 13 — Post-implementation deliverables
 
 Sub-issues:
+
 - **13a — Developer documentation**: `docs/react-ui/USAGE.md` covering all topics
   from SPEC §13.1
 - **13b — Skill update**: add `@mast-ai/react-ui` to `skills/mast-ai/SKILL.md`,

--- a/docs/react-ui/PRD.md
+++ b/docs/react-ui/PRD.md
@@ -40,6 +40,7 @@ by hundreds of lines of app-specific boilerplate that cannot be shared.
 ## 4. User Stories
 
 ### 4.1 Zero-config chat panel
+
 > As a developer who has an `AgentRunner` and a tool registry, I want to render a full
 > chat panel by adding a single component, without configuring any styling system.
 
@@ -50,6 +51,7 @@ by hundreds of lines of app-specific boilerplate that cannot be shared.
 ```
 
 ### 4.2 Custom layout with library primitives
+
 > As a developer building a text editor, I want a floating chat sidebar that shares
 > the same message rendering logic as the default panel, but with my own layout and
 > header chrome.
@@ -64,6 +66,7 @@ by hundreds of lines of app-specific boilerplate that cannot be shared.
 ```
 
 ### 4.3 Fully headless custom UI
+
 > As a developer whose app already uses a design system, I want access to the streaming
 > state and message data via a hook so I can render everything myself without any library
 > styles conflicting with mine.
@@ -76,17 +79,17 @@ function MyAgentPanel() {
 ```
 
 ### 4.4 Custom tool call rendering
+
 > As a developer whose tools have rich results (images, charts, code diffs), I want to
 > replace the default tool call block with my own renderer while keeping everything else
 > from the library.
 
 ```tsx
-<ConversationPanel
-  renderToolCall={(toolCall) => <MyRichToolCallRenderer toolCall={toolCall} />}
-/>
+<ConversationPanel renderToolCall={(toolCall) => <MyRichToolCallRenderer toolCall={toolCall} />} />
 ```
 
 ### 4.5 Conversation persistence
+
 > As a developer building a multi-session app, I want to save the conversation after
 > each turn and restore it on the next page load so users can continue where they left off.
 
@@ -111,6 +114,7 @@ function MyAgentPanel() {
 ```
 
 ### 4.6 Approval callback
+
 > As a developer whose agent uses tools that require human confirmation, I want to
 > hook into the approval flow so I can render my own confirmation UI before the tool
 > executes.
@@ -150,9 +154,9 @@ function MyAgentPanel() {
 
 ## 6. Risks & Mitigations
 
-| Risk | Mitigation |
-|------|-----------|
-| CSS conflicts with consuming app | Namespace all default classes with `mast-` prefix; use CSS custom properties scoped to `[data-mast]` so they don't bleed |
-| `react-markdown` adds weight | Make it optional; `renderMessage` prop lets apps supply their own renderer |
-| Streaming state logic diverges from core | Keep all streaming wiring in one `useAgentStream` internal hook derived directly from `AgentEvent` types |
-| API surface locks in early design | Keep `ConversationPanel` as a thin compositor over exported primitives; breaking the top-level API is tolerable if primitives remain stable |
+| Risk                                     | Mitigation                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| CSS conflicts with consuming app         | Namespace all default classes with `mast-` prefix; use CSS custom properties scoped to `[data-mast]` so they don't bleed                    |
+| `react-markdown` adds weight             | Make it optional; `renderMessage` prop lets apps supply their own renderer                                                                  |
+| Streaming state logic diverges from core | Keep all streaming wiring in one `useAgentStream` internal hook derived directly from `AgentEvent` types                                    |
+| API surface locks in early design        | Keep `ConversationPanel` as a thin compositor over exported primitives; breaking the top-level API is tolerable if primitives remain stable |

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -2,12 +2,12 @@
 
 ## 1. Package
 
-| Field | Value |
-|-------|-------|
-| Name | `@mast-ai/react-ui` |
-| Location | `packages/react-ui` |
+| Field      | Value               |
+| ---------- | ------------------- |
+| Name       | `@mast-ai/react-ui` |
+| Location   | `packages/react-ui` |
 | Build tool | Vite (library mode) |
-| Language | TypeScript (strict) |
+| Language   | TypeScript (strict) |
 
 ### Peer Dependencies
 
@@ -25,8 +25,8 @@ scrolling by default because agent conversations grow unboundedly during long se
 
 ### Optional Dependencies
 
-| Package | Used for | How to activate |
-|---------|----------|-----------------|
+| Package                                             | Used for                            | How to activate                                                |
+| --------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------- |
 | `react-markdown` + `remark-gfm` + `rehype-sanitize` | Markdown rendering in `MessageItem` | Installed automatically when present; falls back to plain text |
 
 When `react-markdown` is detected, `rehype-sanitize` is **always applied** — the library
@@ -93,7 +93,7 @@ at any scope without `!important`.
 
 /* Dark theme — activated by OS preference OR explicit attribute */
 @media (prefers-color-scheme: dark) {
-  [data-mast-root]:not([data-mast-theme="light"]) {
+  [data-mast-root]:not([data-mast-theme='light']) {
     --mast-bg: #111827;
     --mast-bg-subtle: #1f2937;
     --mast-fg: #f9fafb;
@@ -112,7 +112,7 @@ at any scope without `!important`.
 }
 
 /* Explicit dark override (for apps using next-themes or similar) */
-[data-mast-root][data-mast-theme="dark"] {
+[data-mast-root][data-mast-theme='dark'] {
   /* same tokens as above */
 }
 ```
@@ -137,7 +137,7 @@ This avoids collisions with Tailwind utility classes and other CSS frameworks.
 ## 3. Data Types
 
 These types live in `@mast-ai/react-ui` and are separate from the `@mast-ai/core` types
-they are derived from. The UI types represent the *rendered state* of a conversation, not
+they are derived from. The UI types represent the _rendered state_ of a conversation, not
 the raw protocol messages.
 
 ```typescript
@@ -146,16 +146,16 @@ export interface ToolEventEntry {
   name: string;
   args?: unknown;
   result?: unknown;
-  subThinking?: string;  // accumulated thinking streamed from inside the tool/sub-agent
-  subText?: string;      // accumulated text streamed from inside the tool/sub-agent
-  isStreaming: boolean;  // true while the tool is executing
+  subThinking?: string; // accumulated thinking streamed from inside the tool/sub-agent
+  subText?: string; // accumulated text streamed from inside the tool/sub-agent
+  isStreaming: boolean; // true while the tool is executing
 }
 
 export interface ConversationEntry {
-  id: string;               // stable key for React reconciliation
+  id: string; // stable key for React reconciliation
   role: 'user' | 'assistant';
-  text: string;             // accumulated text (empty while streaming)
-  thinking?: string;        // accumulated thinking (empty while streaming)
+  text: string; // accumulated text (empty while streaming)
+  thinking?: string; // accumulated thinking (empty while streaming)
   toolEvents: ToolEventEntry[];
   isStreaming: boolean;
 }
@@ -224,6 +224,7 @@ interface AgentProviderProps {
 ```
 
 **Internal state managed by `AgentProvider`:**
+
 - `conversation` — `Conversation` instance (from `@mast-ai/core`)
 - `entries` — `ConversationEntry[]` built by processing `AgentEvent` stream
 - `isRunning` — boolean
@@ -253,8 +254,8 @@ Renders:
 
 ```html
 <div data-mast-root class="mast-conversation-panel {className}">
-  <MessageList renderToolCall={...} renderMessage={...} />
-  <ChatInput placeholder={...} />
+  <MessageList renderToolCall="{...}" renderMessage="{...}" />
+  <ChatInput placeholder="{...}" />
 </div>
 ```
 
@@ -284,9 +285,9 @@ Renders:
 <div data-mast-message-list class="mast-message-list {className}" role="log" aria-live="polite">
   <div style="height: {totalSize}px; position: relative;">
     {virtualItems.map(item => (
-      <div data-index={item.index} style="position: absolute; top: {item.start}px; width: 100%">
-        <MessageItem entry={entries[item.index]} ... />
-      </div>
+    <div data-index="{item.index}" style="position: absolute; top: {item.start}px; width: 100%">
+      <MessageItem entry="{entries[item.index]}" ... />
+    </div>
     ))}
   </div>
 </div>
@@ -403,11 +404,11 @@ Access agent state from any component inside `<AgentProvider>`.
 ```typescript
 interface UseAgentReturn {
   messages: ConversationEntry[];
-  history: Message[];        // raw core Message[] — read this to imperatively save state
+  history: Message[]; // raw core Message[] — read this to imperatively save state
   sendMessage: (text: string) => void;
   cancel: () => void;
   isRunning: boolean;
-  reset: () => void;         // clears entries and history; starts a new Conversation
+  reset: () => void; // clears entries and history; starts a new Conversation
 }
 
 function useAgent(): UseAgentReturn;
@@ -430,14 +431,14 @@ pass replacements via the `icons` prop on `<AgentProvider>`.
 The following icons ship inside the package as hand-authored SVGs (~50–80 bytes each,
 ~500 bytes total gzipped):
 
-| Key | Used in | Default appearance |
-|-----|---------|--------------------|
-| `brain` | `<ThinkingBlock>` header | Simple brain outline |
-| `wrench` | `<ToolCallBlock>` header (pending) | Simple wrench outline |
-| `check` | `<ToolCallBlock>` header (completed) | Checkmark circle |
-| `loader` | Streaming / pending spinner | Animated spinning circle |
-| `send` | `<ChatInput>` send button | Filled arrow |
-| `stop` | `<ChatInput>` cancel button | Filled square |
+| Key      | Used in                              | Default appearance       |
+| -------- | ------------------------------------ | ------------------------ |
+| `brain`  | `<ThinkingBlock>` header             | Simple brain outline     |
+| `wrench` | `<ToolCallBlock>` header (pending)   | Simple wrench outline    |
+| `check`  | `<ToolCallBlock>` header (completed) | Checkmark circle         |
+| `loader` | Streaming / pending spinner          | Animated spinning circle |
+| `send`   | `<ChatInput>` send button            | Filled arrow             |
+| `stop`   | `<ChatInput>` cancel button          | Filled square            |
 
 ### 6.3 `IconMap` type
 
@@ -484,7 +485,7 @@ import { Brain, Wrench, CircleCheck, LoaderCircle, Send, Square } from 'lucide-r
   }}
 >
   <ConversationPanel />
-</AgentProvider>
+</AgentProvider>;
 ```
 
 ### 6.6 `useIcons()` hook (internal)
@@ -558,18 +559,18 @@ output, not imported from `index.ts`.
 `useAgentStream` subscribes to the `AgentEvent` stream from `AgentRunner` and
 maintains `ConversationEntry[]` as follows:
 
-| Event | Action |
-|-------|--------|
-| User sends message | Append `{ role: 'user', text, isStreaming: false }` |
-| Run starts | Append `{ role: 'assistant', text: '', isStreaming: true }` |
-| `text_delta` | Mutate last entry: append `delta` to `text` |
-| `thinking` | Mutate last entry: append `delta` to `thinking` |
-| `tool_call_started` | Mutate last entry: push `{ type: 'tool_call_started', name, args, isStreaming: true }` to `toolEvents` |
-| `onToolEvent` → `thinking` | Mutate matching `ToolEventEntry`: append `delta` to `subThinking` |
-| `onToolEvent` → `text_delta` | Mutate matching `ToolEventEntry`: append `delta` to `subText` |
-| `tool_call_completed` | Mutate matching `ToolEventEntry`: set `result`, `isStreaming: false` |
-| `done` | Mutate last entry: set `text = output`, `isStreaming = false` |
-| Error / cancel | Mutate last entry: set `isStreaming = false`; optionally append error text |
+| Event                        | Action                                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| User sends message           | Append `{ role: 'user', text, isStreaming: false }`                                                    |
+| Run starts                   | Append `{ role: 'assistant', text: '', isStreaming: true }`                                            |
+| `text_delta`                 | Mutate last entry: append `delta` to `text`                                                            |
+| `thinking`                   | Mutate last entry: append `delta` to `thinking`                                                        |
+| `tool_call_started`          | Mutate last entry: push `{ type: 'tool_call_started', name, args, isStreaming: true }` to `toolEvents` |
+| `onToolEvent` → `thinking`   | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                      |
+| `onToolEvent` → `text_delta` | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                          |
+| `tool_call_completed`        | Mutate matching `ToolEventEntry`: set `result`, `isStreaming: false`                                   |
+| `done`                       | Mutate last entry: set `text = output`, `isStreaming = false`                                          |
+| Error / cancel               | Mutate last entry: set `isStreaming = false`; optionally append error text                             |
 
 `onToolEvent` events are wired by passing an `onToolEvent` handler to `RunBuilder` inside `useAgentStream`. Events are matched to the correct `ToolEventEntry` by `toolName`. The `done` event from a sub-agent is ignored — the parent's `tool_call_completed` is the authoritative signal that a tool finished.
 
@@ -591,7 +592,7 @@ interface ToolDefinition {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
-  requiresApproval?: boolean;  // tool author declares this tool is sensitive
+  requiresApproval?: boolean; // tool author declares this tool is sensitive
 }
 ```
 
@@ -605,6 +606,7 @@ per-app.
 `AgentProvider` pauses the run before executing any tool whose effective approval flag
 is `true` and calls `onApprovalRequired`. The consuming app renders its own confirmation
 UI and returns:
+
 - `true` — proceed with the tool call as normal
 - `false` — cancel the tool call; the runner receives a synthetic "user cancelled" result
 - `string` — skip execution and inject this string as the tool result directly
@@ -667,12 +669,12 @@ execute without pausing — the callback is the opt-in).
 
 ### 11.1 Stack
 
-| Tool | Role |
-|------|------|
-| Vitest | Test runner (consistent with other packages in the monorepo) |
-| `@testing-library/react` | Component rendering and user-event simulation |
-| `jsdom` | DOM environment for Vitest |
-| `@testing-library/user-event` | Realistic keyboard/click interactions |
+| Tool                          | Role                                                         |
+| ----------------------------- | ------------------------------------------------------------ |
+| Vitest                        | Test runner (consistent with other packages in the monorepo) |
+| `@testing-library/react`      | Component rendering and user-event simulation                |
+| `jsdom`                       | DOM environment for Vitest                                   |
+| `@testing-library/user-event` | Realistic keyboard/click interactions                        |
 
 ### 11.2 Unit tests
 
@@ -682,51 +684,51 @@ The streaming state machine is the most complex logic in the library and the har
 to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequence of
 `AgentEvent`s.
 
-| Scenario | What is verified |
-|----------|-----------------|
-| Text streaming | `text_delta` events accumulate into the last entry's `text`; `isStreaming` is true during and false after |
-| Thinking streaming | `thinking` deltas accumulate into `thinking`; co-exists with text deltas |
-| Tool call lifecycle | `tool_call_started` appends a pending `ToolEventEntry` with `isStreaming: true`; `tool_call_completed` sets `result` and `isStreaming: false` |
-| Sub-agent thinking | `onToolEvent` → `thinking` appends to matching `ToolEventEntry.subThinking` |
-| Sub-agent text | `onToolEvent` → `text_delta` appends to matching `ToolEventEntry.subText` |
-| Sub-agent `done` ignored | `onToolEvent` → `done` does not affect parent entry's `isStreaming` |
-| Multiple concurrent tool calls | Each call tracked independently by name; sub-agent events routed to correct entry |
-| `done` event | Sets `isStreaming: false`, finalises `text` from `output` |
-| Error / cancel | Sets `isStreaming: false` on the last entry; prior entries unchanged |
-| New turn while previous is complete | Appends a new entry rather than mutating the last |
+| Scenario                            | What is verified                                                                                                                              |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Text streaming                      | `text_delta` events accumulate into the last entry's `text`; `isStreaming` is true during and false after                                     |
+| Thinking streaming                  | `thinking` deltas accumulate into `thinking`; co-exists with text deltas                                                                      |
+| Tool call lifecycle                 | `tool_call_started` appends a pending `ToolEventEntry` with `isStreaming: true`; `tool_call_completed` sets `result` and `isStreaming: false` |
+| Sub-agent thinking                  | `onToolEvent` → `thinking` appends to matching `ToolEventEntry.subThinking`                                                                   |
+| Sub-agent text                      | `onToolEvent` → `text_delta` appends to matching `ToolEventEntry.subText`                                                                     |
+| Sub-agent `done` ignored            | `onToolEvent` → `done` does not affect parent entry's `isStreaming`                                                                           |
+| Multiple concurrent tool calls      | Each call tracked independently by name; sub-agent events routed to correct entry                                                             |
+| `done` event                        | Sets `isStreaming: false`, finalises `text` from `output`                                                                                     |
+| Error / cancel                      | Sets `isStreaming: false` on the last entry; prior entries unchanged                                                                          |
+| New turn while previous is complete | Appends a new entry rather than mutating the last                                                                                             |
 
 **Approval flow**
 
-| Scenario | What is verified |
-|----------|-----------------|
-| Tool with `requiresApproval: true` | `onApprovalRequired` is called before tool executes |
-| Callback returns `false` | Tool call is cancelled; runner receives synthetic "user cancelled" result |
-| Callback returns a string | Injected as the tool result; tool does not execute |
-| `approvalOverride` adds a name | Unlisted tool triggers approval |
-| `approvalOverride` suppresses with `!` | Tool with `requiresApproval: true` executes without prompting |
-| No `onApprovalRequired` provided | Tools with `requiresApproval: true` execute silently |
+| Scenario                               | What is verified                                                          |
+| -------------------------------------- | ------------------------------------------------------------------------- |
+| Tool with `requiresApproval: true`     | `onApprovalRequired` is called before tool executes                       |
+| Callback returns `false`               | Tool call is cancelled; runner receives synthetic "user cancelled" result |
+| Callback returns a string              | Injected as the tool result; tool does not execute                        |
+| `approvalOverride` adds a name         | Unlisted tool triggers approval                                           |
+| `approvalOverride` suppresses with `!` | Tool with `requiresApproval: true` executes without prompting             |
+| No `onApprovalRequired` provided       | Tools with `requiresApproval: true` execute silently                      |
 
 **Conversation persistence**
 
-| Scenario | What is verified |
-|----------|-----------------|
-| `onConversationChange` fires | Called with current `history` and `entries` after `done` event |
-| Not called on cancel/error | Callback not invoked when run ends without `done` |
+| Scenario                            | What is verified                                               |
+| ----------------------------------- | -------------------------------------------------------------- |
+| `onConversationChange` fires        | Called with current `history` and `entries` after `done` event |
+| Not called on cancel/error          | Callback not invoked when run ends without `done`              |
 | `initialHistory` seeds core history | First turn sent to runner includes the provided prior messages |
-| `initialEntries` seeds UI | Pre-existing entries render immediately on mount |
-| `reset()` clears both | After reset, `messages` is empty and `history` is empty |
-| `useAgent().history` reflects state | Returns the live `Conversation.history` after each turn |
+| `initialEntries` seeds UI           | Pre-existing entries render immediately on mount               |
+| `reset()` clears both               | After reset, `messages` is empty and `history` is empty        |
+| `useAgent().history` reflects state | Returns the live `Conversation.history` after each turn        |
 
 **Components**
 
-| Component | Scenarios tested |
-|-----------|-----------------|
-| `<ThinkingBlock>` | Renders collapsed by default; expands on click; shows pulse indicator when `isStreaming` |
-| `<ToolCallBlock>` | Pending state (spinner, no result); completed state (check, result visible when expanded) |
-| `<ChatInput>` | Enter submits; Shift+Enter does not; button switches to cancel while `isRunning`; disabled while `isRunning` |
-| `<MessageList>` | Renders user and assistant entries; scrolls to bottom on new entry |
-| `<AgentProvider>` | `useAgent()` throws when called outside provider |
-| Icon override | Components render the custom node from `icons` prop instead of default SVG |
+| Component         | Scenarios tested                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `<ThinkingBlock>` | Renders collapsed by default; expands on click; shows pulse indicator when `isStreaming`                     |
+| `<ToolCallBlock>` | Pending state (spinner, no result); completed state (check, result visible when expanded)                    |
+| `<ChatInput>`     | Enter submits; Shift+Enter does not; button switches to cancel while `isRunning`; disabled while `isRunning` |
+| `<MessageList>`   | Renders user and assistant entries; scrolls to bottom on new entry                                           |
+| `<AgentProvider>` | `useAgent()` throws when called outside provider                                                             |
+| Icon override     | Components render the custom node from `icons` prop instead of default SVG                                   |
 
 ### 11.3 File layout
 
@@ -755,12 +757,12 @@ surface and a reference implementation.
 
 ### Stack
 
-| Concern | Choice |
-|---------|--------|
-| Bundler | Vite |
+| Concern     | Choice                                                                |
+| ----------- | --------------------------------------------------------------------- |
+| Bundler     | Vite                                                                  |
 | LLM adapter | `@mast-ai/google-genai` (API key via `VITE_GEMINI_API_KEY` in `.env`) |
-| Icons | `lucide-react` (demonstrates icon override) |
-| Markdown | `react-markdown` + `remark-gfm` + `rehype-sanitize` |
+| Icons       | `lucide-react` (demonstrates icon override)                           |
+| Markdown    | `react-markdown` + `remark-gfm` + `rehype-sanitize`                   |
 
 ### What it demonstrates
 

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime', '@mast-ai/core', '@tanstack/react-virtual'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        '@mast-ai/core',
+        '@tanstack/react-virtual',
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary
- Pure prettier reformatting across files where drift had accumulated. No semantic changes.
- Surfaced when running the workspace-wide `npm run format` during work on #32.

## Changes
- `apps/demo-agent-tool/index.html` — one paragraph re-wrapped.
- `packages/react-ui/vite.config.ts` — `external: [...]` array reflowed to multiple lines.
- `docs/react-ui/SPEC.md` — markdown table column padding; double-quoted CSS strings switched to single quotes.
- `docs/react-ui/PRD.md`, `docs/react-ui/PLAN.md` — blank lines inserted after `**bold**` "headings" before list items (prettier prose rule).

## Test plan
- [x] `npm run format` reports nothing further to change
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes