### PR TITLE
feat(react-ui): ToolCallBlock component

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -4,7 +4,13 @@
 import { useState, type KeyboardEvent } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
-import { AgentProvider, ThinkingBlock, useAgent, type IconMap } from '@mast-ai/react-ui';
+import {
+  AgentProvider,
+  ThinkingBlock,
+  ToolCallBlock,
+  useAgent,
+  type IconMap,
+} from '@mast-ai/react-ui';
 import { Brain, CircleCheck, LoaderCircle, Send, Square, Wrench } from 'lucide-react';
 
 import { GetCurrentTimeTool } from './tools';
@@ -61,8 +67,15 @@ function ChatUI() {
             {entry.role === 'assistant' && entry.thinking ? (
               <ThinkingBlock content={entry.thinking} isStreaming={entry.isStreaming} />
             ) : null}
+            {entry.role === 'assistant' && entry.toolEvents.length > 0
+              ? entry.toolEvents.map((toolEvent, i) => (
+                  <ToolCallBlock key={`${toolEvent.name}-${i}`} entry={toolEvent} />
+                ))
+              : null}
             {entry.text}
-            {entry.isStreaming && entry.text === '' ? <em> (thinking...)</em> : null}
+            {entry.isStreaming && entry.text === '' && entry.toolEvents.length === 0 ? (
+              <em> (thinking...)</em>
+            ) : null}
           </li>
         ))}
       </ul>

--- a/packages/react-ui/src/components/ThinkingBlock.tsx
+++ b/packages/react-ui/src/components/ThinkingBlock.tsx
@@ -18,6 +18,13 @@ export interface ThinkingBlockProps {
   className?: string;
   /** Header label. Default: `'Thinking Process'`. */
   label?: string;
+  /**
+   * When provided, controls the `open` attribute on the root `<details>`
+   * element. Useful for auto-expanding the block while streaming and letting
+   * it collapse afterwards (e.g. inside `<ToolCallBlock>`). When omitted, the
+   * block defaults to collapsed and is toggled by the user.
+   */
+  open?: boolean;
 }
 
 /**
@@ -33,6 +40,7 @@ export function ThinkingBlock({
   isStreaming = false,
   className,
   label = 'Thinking Process',
+  open,
 }: ThinkingBlockProps) {
   const icons = useIcons();
   const rootClass = ['mast-thinking-block', className].filter(Boolean).join(' ');
@@ -42,6 +50,7 @@ export function ThinkingBlock({
       data-mast-thinking-block
       data-streaming={isStreaming ? 'true' : undefined}
       className={rootClass}
+      open={open}
     >
       <summary className="mast-thinking-block-summary">
         <span className="mast-thinking-block-icon" aria-hidden="true">

--- a/packages/react-ui/src/components/ToolCallBlock.test.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.test.tsx
@@ -1,0 +1,197 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ToolEventEntry } from '../types';
+import { ToolCallBlock } from './ToolCallBlock';
+
+function makeEntry(overrides: Partial<ToolEventEntry> = {}): ToolEventEntry {
+  return {
+    type: 'tool_call_started',
+    name: 'demo_tool',
+    args: { foo: 'bar' },
+    isStreaming: true,
+    ...overrides,
+  };
+}
+
+describe('<ToolCallBlock>', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('streaming sub-agent state', () => {
+    it('renders the spinner icon while streaming', () => {
+      render(<ToolCallBlock entry={makeEntry({ subThinking: '', subText: '' })} />);
+      const status = screen.getByTestId('mast-tool-call-status');
+      expect(status.querySelector('svg.mast-spin')).not.toBeNull();
+    });
+
+    it('renders subThinking inside an auto-expanded ThinkingBlock while streaming', () => {
+      render(
+        <ToolCallBlock entry={makeEntry({ subThinking: 'sub-agent reasoning', subText: '' })} />,
+      );
+      const summary = screen.getByText('Thinking Process');
+      const details = summary.closest('details');
+      expect(details).not.toBeNull();
+      expect(details!.open).toBe(true);
+      expect(screen.getByText('sub-agent reasoning')).toBeDefined();
+    });
+
+    it('renders subText as live content below the thinking block', () => {
+      render(
+        <ToolCallBlock
+          entry={makeEntry({ subThinking: 'thoughts', subText: 'streaming output' })}
+        />,
+      );
+      const subText = screen.getByTestId('mast-tool-call-sub-text');
+      expect(subText.textContent).toBe('streaming output');
+    });
+
+    it('omits the result section while still streaming', () => {
+      render(
+        <ToolCallBlock
+          entry={makeEntry({ subThinking: 'x', subText: 'y', result: 'should-not-show' })}
+        />,
+      );
+      expect(screen.queryByText('Result')).toBeNull();
+    });
+  });
+
+  describe('completed sub-agent state', () => {
+    const completed: ToolEventEntry = {
+      type: 'tool_call_completed',
+      name: 'demo_tool',
+      args: { foo: 'bar' },
+      result: { ok: true, value: 42 },
+      subThinking: 'final thoughts',
+      subText: 'final answer',
+      isStreaming: false,
+    };
+
+    it('renders the check icon when completed', () => {
+      const { container } = render(<ToolCallBlock entry={completed} />);
+      const status = screen.getByTestId('mast-tool-call-status');
+      expect(status.querySelector('svg')).not.toBeNull();
+      expect(container.querySelector('svg.mast-spin')).toBeNull();
+    });
+
+    it('keeps subThinking visible but collapses it by default', () => {
+      render(<ToolCallBlock entry={completed} />);
+      const details = screen.getByText('Thinking Process').closest('details');
+      expect(details).not.toBeNull();
+      expect(details!.open).toBe(false);
+      expect(screen.getByText('final thoughts')).toBeDefined();
+    });
+
+    it('keeps subText visible after completion', () => {
+      render(<ToolCallBlock entry={completed} />);
+      expect(screen.getByTestId('mast-tool-call-sub-text').textContent).toBe('final answer');
+    });
+
+    it('exposes the result in a collapsible <details> as formatted JSON', async () => {
+      const user = userEvent.setup();
+      render(<ToolCallBlock entry={completed} />);
+
+      const summary = screen.getByText('Result');
+      const details = summary.closest('details');
+      expect(details).not.toBeNull();
+      expect(details!.open).toBe(false);
+
+      await user.click(summary);
+      expect(details!.open).toBe(true);
+
+      const code = details!.querySelector('code');
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toContain('"ok": true');
+      expect(code!.textContent).toContain('"value": 42');
+    });
+  });
+
+  describe('plain tool (no sub-agent output)', () => {
+    it('shows a spinner while streaming and no sub-agent slots', () => {
+      render(<ToolCallBlock entry={makeEntry()} />);
+      const status = screen.getByTestId('mast-tool-call-status');
+      expect(status.querySelector('svg.mast-spin')).not.toBeNull();
+      expect(screen.queryByText('Thinking Process')).toBeNull();
+      expect(screen.queryByTestId('mast-tool-call-sub-text')).toBeNull();
+    });
+
+    it('shows the check icon when completed and no sub-agent slots', () => {
+      const completed: ToolEventEntry = {
+        type: 'tool_call_completed',
+        name: 'demo_tool',
+        args: { foo: 'bar' },
+        result: 'plain result',
+        isStreaming: false,
+      };
+      const { container } = render(<ToolCallBlock entry={completed} />);
+      const status = screen.getByTestId('mast-tool-call-status');
+      expect(status.querySelector('svg')).not.toBeNull();
+      expect(container.querySelector('svg.mast-spin')).toBeNull();
+      expect(screen.queryByText('Thinking Process')).toBeNull();
+      expect(screen.queryByTestId('mast-tool-call-sub-text')).toBeNull();
+    });
+
+    it('still renders args and (after completion) result in <details>', async () => {
+      const user = userEvent.setup();
+      const completed: ToolEventEntry = {
+        type: 'tool_call_completed',
+        name: 'demo_tool',
+        args: { city: 'NYC' },
+        result: 'sunny',
+        isStreaming: false,
+      };
+      render(<ToolCallBlock entry={completed} />);
+
+      const argsSummary = screen.getByText('Arguments');
+      await user.click(argsSummary);
+      const argsDetails = argsSummary.closest('details');
+      expect(argsDetails!.open).toBe(true);
+      expect(argsDetails!.querySelector('code')!.textContent).toContain('"city": "NYC"');
+
+      const resultSummary = screen.getByText('Result');
+      await user.click(resultSummary);
+      const resultDetails = resultSummary.closest('details');
+      expect(resultDetails!.open).toBe(true);
+      expect(resultDetails!.querySelector('code')!.textContent).toContain('sunny');
+    });
+  });
+
+  describe('header content', () => {
+    it('renders the tool name', () => {
+      render(<ToolCallBlock entry={makeEntry({ name: 'get_current_time' })} />);
+      expect(screen.getByText('get_current_time')).toBeDefined();
+    });
+
+    it('forwards className to the root element', () => {
+      const { container } = render(<ToolCallBlock entry={makeEntry()} className="custom-class" />);
+      const root = container.querySelector('[data-mast-tool-call-block]');
+      expect(root).not.toBeNull();
+      expect(root!.className).toContain('custom-class');
+      expect(root!.className).toContain('mast-tool-call-block');
+    });
+
+    it('exposes data-streaming on the root while streaming', () => {
+      const { container } = render(<ToolCallBlock entry={makeEntry()} />);
+      const root = container.querySelector('[data-mast-tool-call-block]');
+      expect(root!.getAttribute('data-streaming')).toBe('true');
+    });
+
+    it('omits data-streaming when not streaming', () => {
+      const completed: ToolEventEntry = {
+        type: 'tool_call_completed',
+        name: 'demo_tool',
+        args: {},
+        result: 'ok',
+        isStreaming: false,
+      };
+      const { container } = render(<ToolCallBlock entry={completed} />);
+      const root = container.querySelector('[data-mast-tool-call-block]');
+      expect(root!.getAttribute('data-streaming')).toBeNull();
+    });
+  });
+});

--- a/packages/react-ui/src/components/ToolCallBlock.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.tsx
@@ -1,0 +1,113 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useIcons } from '../icons';
+import type { ToolEventEntry } from '../types';
+import { ThinkingBlock } from './ThinkingBlock';
+
+/**
+ * Props accepted by {@link ToolCallBlock}.
+ */
+export interface ToolCallBlockProps {
+  /** The tool invocation to render. */
+  entry: ToolEventEntry;
+  /** Optional class added to the root element. */
+  className?: string;
+}
+
+function formatJson(value: unknown): string {
+  if (value === undefined) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Displays a single tool invocation with live streaming of sub-agent output.
+ *
+ * Three rendering modes:
+ *
+ * - **Streaming** (`entry.isStreaming === true`): spinner icon next to the
+ *   tool name; if `subThinking` is present, it renders inside a `<ThinkingBlock>`
+ *   that auto-expands while streaming; if `subText` is present, it renders as
+ *   live text below.
+ * - **Completed** (`entry.isStreaming === false`): check mark icon; sub-agent
+ *   output (if any) remains visible but collapsed by default; `result` is
+ *   accessible inside a `<details>` element as formatted JSON.
+ * - **Plain tool** (no `subThinking` and no `subText`): the spinner-to-check
+ *   transition plus collapsible `args` and `result`. No sub-agent slots are
+ *   rendered.
+ *
+ * Args/result expand/collapse uses native `<details>/<summary>` so the
+ * component is keyboard-accessible without JavaScript.
+ */
+export function ToolCallBlock({ entry, className }: ToolCallBlockProps) {
+  const icons = useIcons();
+  const rootClass = ['mast-tool-call-block', className].filter(Boolean).join(' ');
+  const hasSubAgentOutput = entry.subThinking !== undefined || entry.subText !== undefined;
+  const statusIcon = entry.isStreaming ? icons.loader : icons.check;
+  const argsText = formatJson(entry.args);
+  const resultText = formatJson(entry.result);
+
+  return (
+    <div
+      data-mast-tool-call-block
+      data-streaming={entry.isStreaming ? 'true' : undefined}
+      data-tool-name={entry.name}
+      className={rootClass}
+    >
+      <div className="mast-tool-call-block-header">
+        <span
+          className="mast-tool-call-block-status"
+          data-testid="mast-tool-call-status"
+          aria-hidden="true"
+        >
+          {statusIcon}
+        </span>
+        <span className="mast-tool-call-block-wrench" aria-hidden="true">
+          {icons.wrench}
+        </span>
+        <span className="mast-tool-call-block-name">{entry.name}</span>
+      </div>
+
+      {hasSubAgentOutput ? (
+        <div className="mast-tool-call-block-sub-output">
+          {entry.subThinking !== undefined ? (
+            <ThinkingBlock
+              content={entry.subThinking}
+              isStreaming={entry.isStreaming}
+              className="mast-tool-call-block-sub-thinking"
+              open={entry.isStreaming ? true : undefined}
+            />
+          ) : null}
+          {entry.subText !== undefined ? (
+            <div className="mast-tool-call-block-sub-text" data-testid="mast-tool-call-sub-text">
+              {entry.subText}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {argsText ? (
+        <details className="mast-tool-call-block-args">
+          <summary>Arguments</summary>
+          <pre className="mast-tool-call-block-pre">
+            <code>{argsText}</code>
+          </pre>
+        </details>
+      ) : null}
+
+      {!entry.isStreaming && resultText ? (
+        <details className="mast-tool-call-block-result">
+          <summary>Result</summary>
+          <pre className="mast-tool-call-block-pre">
+            <code>{resultText}</code>
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -8,3 +8,5 @@ export { AgentProvider, useAgent } from './context';
 export type { AgentProviderProps, UseAgentReturn } from './context';
 export { ThinkingBlock } from './components/ThinkingBlock';
 export type { ThinkingBlockProps } from './components/ThinkingBlock';
+export { ToolCallBlock } from './components/ToolCallBlock';
+export type { ToolCallBlockProps } from './components/ToolCallBlock';


### PR DESCRIPTION
## Summary
- Adds `<ToolCallBlock>` per SPEC §4.8 with three rendering modes: streaming (spinner, auto-expanded sub-thinking, live sub-text), completed (check icon, sub-output collapsed, `result` as formatted JSON in a `<details>`), and plain tool (spinner→check transition plus collapsible `Arguments`/`Result`).
- Extends `<ThinkingBlock>` with an optional `open` prop so `ToolCallBlock` can force-expand the sub-thinking block while streaming and let it collapse to the default once `isStreaming` flips to false.
- Wires `<ToolCallBlock>` into `apps/demo-react-ui/src/App.tsx` for assistant entries that have tool events.

## Implementation notes
- Uses native `<details>/<summary>` for the args, result, and sub-thinking sections so the component is keyboard-accessible without JavaScript (SPEC §10).
- The header always renders both a status icon (`loader` while streaming, `check` once complete) and the `wrench` icon next to the tool name, exposing a `data-streaming` attribute on the root for CSS targeting.
- `formatJson` pretty-prints `args`/`result` with 2-space indent, returns the raw value for strings, and falls back to `String()` for values JSON cannot serialise (e.g. circular refs).
- `result` is suppressed while `isStreaming` is true so a stale `result` value cannot leak into the streaming view.
- The `open={entry.isStreaming ? true : undefined}` pattern on the inner `ThinkingBlock` keeps the sub-thinking expanded during streaming and switches back to uncontrolled (user-toggleable, collapsed by default) once streaming ends.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run build` passes
- [x] `npm test` passes (50/50 in `@mast-ai/react-ui`, including 15 new ToolCallBlock tests)
- [x] Manually verified the demo renders `<ToolCallBlock>` for `get_current_time` invocations with the spinner→check transition and the result expandable as JSON

Closes #33