### PR TITLE
feat(react-ui): ChatInput component

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -1,12 +1,12 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, type KeyboardEvent } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
 import {
   AgentProvider,
   AssistantMessage,
+  ChatInput,
   UserMessage,
   useAgent,
   type IconMap,
@@ -41,22 +41,7 @@ const icons: IconMap = {
 };
 
 function ChatUI() {
-  const { messages, sendMessage, cancel, isRunning } = useAgent();
-  const [input, setInput] = useState('');
-
-  const handleSend = () => {
-    const text = input.trim();
-    if (!text || isRunning) return;
-    setInput('');
-    sendMessage(text);
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === 'Enter' && !event.shiftKey) {
-      event.preventDefault();
-      handleSend();
-    }
-  };
+  const { messages } = useAgent();
 
   return (
     <div>
@@ -74,24 +59,7 @@ function ChatUI() {
           </li>
         ))}
       </ul>
-      <textarea
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onKeyDown={handleKeyDown}
-        rows={3}
-        placeholder="Type a message and press Enter."
-        disabled={isRunning}
-      />
-      <div>
-        <button type="button" onClick={handleSend} disabled={isRunning || !input.trim()}>
-          Send
-        </button>
-        {isRunning ? (
-          <button type="button" onClick={cancel}>
-            Cancel
-          </button>
-        ) : null}
-      </div>
+      <ChatInput />
     </div>
   );
 }

--- a/packages/react-ui/src/components/ChatInput.test.tsx
+++ b/packages/react-ui/src/components/ChatInput.test.tsx
@@ -1,0 +1,212 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
+
+import { AgentProvider } from '../context';
+import { ChatInput } from './ChatInput';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+interface MockRunnerOptions {
+  /** Events to emit before resolving. Default: `[done]`. */
+  events?: AgentEvent[];
+  /** When true the conversation never resolves until aborted, so `isRunning` stays true. */
+  hang?: boolean;
+}
+
+function makeMockRunner({ events, hang }: MockRunnerOptions = {}): AgentRunner {
+  const stream = (signal: AbortSignal | undefined): AsyncIterable<AgentEvent> =>
+    (async function* () {
+      const yielded: AgentEvent[] = events ?? [{ type: 'done', output: 'ok', history: [] }];
+      for (const event of yielded) yield event;
+      if (hang) {
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+    })();
+
+  const conversation: Conversation = {
+    history: [],
+    runStream: vi.fn((_text: string, signal?: AbortSignal) => stream(signal)),
+  } as unknown as Conversation;
+
+  return {
+    conversation: vi.fn(() => conversation),
+  } as unknown as AgentRunner;
+}
+
+const agentConfig: AgentConfig = {
+  name: 'TestAgent',
+  instructions: 'A test agent.',
+};
+
+function renderWithProvider(runner: AgentRunner, child: ReactNode) {
+  return render(
+    <AgentProvider runner={runner} agent={agentConfig}>
+      {child}
+    </AgentProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('<ChatInput>', () => {
+  beforeEach(() => {
+    // Suppress `act` warnings emitted while a hung run is still in flight at
+    // teardown — the tests for the running state intentionally leave it open.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('submits the message on Enter and clears the input', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello world');
+    await user.keyboard('{Enter}');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect(conversation.runStream).toHaveBeenCalledTimes(1);
+    expect((conversation.runStream as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'hello world',
+    );
+    expect((textarea as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('does not submit on Shift+Enter and inserts a newline instead', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    await user.type(textarea, 'line one');
+    await user.keyboard('{Shift>}{Enter}{/Shift}');
+    await user.type(textarea, 'line two');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect(conversation.runStream).not.toHaveBeenCalled();
+    expect(textarea.value).toBe('line one\nline two');
+  });
+
+  it('does not submit when the message is empty or whitespace', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.click(textarea);
+    await user.keyboard('{Enter}');
+    await user.type(textarea, '   ');
+    await user.keyboard('{Enter}');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect(conversation.runStream).not.toHaveBeenCalled();
+  });
+
+  it('shows the send button while idle', () => {
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput />);
+
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  it('swaps to a cancel button while a run is in progress', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner({ hang: true });
+    renderWithProvider(runner, <ChatInput />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('button', { name: 'Cancel' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull();
+  });
+
+  it('disables the textarea while a run is in progress', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner({ hang: true });
+    renderWithProvider(runner, <ChatInput />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    await screen.findByRole('button', { name: 'Cancel' });
+    expect(textarea.disabled).toBe(true);
+  });
+
+  it('calls cancel when the cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner({ hang: true });
+    renderWithProvider(runner, <ChatInput />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
+
+    // Once the run is cancelled the send button reappears.
+    expect(await screen.findByRole('button', { name: 'Send' })).toBeDefined();
+  });
+
+  it('renders custom sendLabel and cancelLabel content', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner({ hang: true });
+    renderWithProvider(
+      runner,
+      <ChatInput sendLabel={<span>SEND</span>} cancelLabel={<span>CANCEL</span>} />,
+    );
+
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    expect(sendButton.textContent).toBe('SEND');
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hi');
+    await user.keyboard('{Enter}');
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+    expect(cancelButton.textContent).toBe('CANCEL');
+  });
+
+  it('uses the supplied placeholder', () => {
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput placeholder="Ask the agent" />);
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).placeholder).toBe('Ask the agent');
+  });
+
+  it('forwards className to the root element', () => {
+    const runner = makeMockRunner();
+    const { container } = renderWithProvider(runner, <ChatInput className="custom-class" />);
+    const root = container.querySelector('[data-mast-chat-input]');
+    expect(root).not.toBeNull();
+    expect(root!.className).toContain('mast-chat-input');
+    expect(root!.className).toContain('custom-class');
+  });
+});

--- a/packages/react-ui/src/components/ChatInput.tsx
+++ b/packages/react-ui/src/components/ChatInput.tsx
@@ -1,0 +1,121 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
+
+import { useAgent } from '../context';
+import { useIcons } from '../icons';
+
+/**
+ * Props accepted by {@link ChatInput}.
+ */
+export interface ChatInputProps {
+  /** Optional class added to the root element. */
+  className?: string;
+  /** Placeholder text shown in the empty textarea. */
+  placeholder?: string;
+  /** Overrides the default send button content (the `send` icon). */
+  sendLabel?: ReactNode;
+  /** Overrides the default cancel button content (the `stop` icon). */
+  cancelLabel?: ReactNode;
+}
+
+const MIN_ROWS = 1;
+const MAX_ROWS = 8;
+
+/**
+ * Counts the number of rows the textarea should display for the given text.
+ *
+ * Uses the line count of the input clamped between {@link MIN_ROWS} and
+ * {@link MAX_ROWS} so the textarea grows with content but does not push the
+ * conversation off-screen on very long drafts.
+ */
+function rowsForText(text: string): number {
+  const lineCount = text.split('\n').length;
+  return Math.min(MAX_ROWS, Math.max(MIN_ROWS, lineCount));
+}
+
+/**
+ * Text input wired to {@link useAgent}.
+ *
+ * - Pressing Enter submits the message; Shift+Enter inserts a newline.
+ * - The textarea grows vertically with content (via the `rows` attribute).
+ * - While a run is in progress the send button is replaced by a cancel button
+ *   that calls `cancel()`. The textarea itself is disabled during the run so
+ *   the user cannot edit while the agent streams.
+ * - Send and cancel slot their content from `useIcons().send` / `.stop` by
+ *   default; consumers can override either via the `sendLabel` / `cancelLabel`
+ *   props without giving up the surrounding accessibility wiring.
+ */
+export function ChatInput({
+  className,
+  placeholder = 'Type a message and press Enter.',
+  sendLabel,
+  cancelLabel,
+}: ChatInputProps) {
+  const { sendMessage, cancel, isRunning } = useAgent();
+  const icons = useIcons();
+  const [value, setValue] = useState('');
+
+  const rootClass = ['mast-chat-input', className].filter(Boolean).join(' ');
+  const trimmed = value.trim();
+  const canSend = !isRunning && trimmed.length > 0;
+
+  const submit = () => {
+    if (!canSend) return;
+    sendMessage(trimmed);
+    setValue('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <form
+      data-mast-chat-input
+      className={rootClass}
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <label className="mast-chat-input-label mast-visually-hidden" htmlFor="mast-chat-input-field">
+        Message
+      </label>
+      <textarea
+        id="mast-chat-input-field"
+        className="mast-chat-input-textarea"
+        value={value}
+        placeholder={placeholder}
+        rows={rowsForText(value)}
+        disabled={isRunning}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      {isRunning ? (
+        <button
+          type="button"
+          className="mast-chat-input-cancel"
+          aria-label="Cancel"
+          onClick={cancel}
+        >
+          {cancelLabel ?? icons.stop}
+        </button>
+      ) : (
+        <button
+          type="submit"
+          className="mast-chat-input-send"
+          aria-label="Send"
+          disabled={!canSend}
+        >
+          {sendLabel ?? icons.send}
+        </button>
+      )}
+    </form>
+  );
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -14,3 +14,5 @@ export { UserMessage } from './components/UserMessage';
 export type { UserMessageProps } from './components/UserMessage';
 export { AssistantMessage } from './components/AssistantMessage';
 export type { AssistantMessageProps } from './components/AssistantMessage';
+export { ChatInput } from './components/ChatInput';
+export type { ChatInputProps } from './components/ChatInput';


### PR DESCRIPTION
## Summary
- Adds `<ChatInput>`: textarea wired to `useAgent()` with Enter-to-send, Shift+Enter newline, auto-growing rows (1-8), and a send button that swaps to cancel while a run is in flight.
- Uses `send` / `stop` from `useIcons()` with `sendLabel` / `cancelLabel` overrides; accepts `placeholder` and `className` props.
- Replaces the raw textarea + send/cancel `<button>`s in `apps/demo-react-ui/src/App.tsx` with `<ChatInput />`.

## Test plan
- [x] `npm test` passes across all workspaces (60/60 react-ui)
- [x] `npm run lint`, `npm run format`, `npm run build` clean from repo root
- [x] Manually verified in `apps/demo-react-ui`: Enter submits, Shift+Enter inserts a newline, send button swaps to cancel while running, cancel aborts the run, textarea disabled during the run

Closes #35