### PR TITLE
feat(react-ui): MessageList with virtual scrolling

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -3,14 +3,7 @@
 
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
-import {
-  AgentProvider,
-  AssistantMessage,
-  ChatInput,
-  UserMessage,
-  useAgent,
-  type IconMap,
-} from '@mast-ai/react-ui';
+import { AgentProvider, ChatInput, MessageList, type IconMap } from '@mast-ai/react-ui';
 import { Brain, CircleCheck, LoaderCircle, Send, Square, Wrench } from 'lucide-react';
 
 import { GetCurrentTimeTool } from './tools';
@@ -40,35 +33,12 @@ const icons: IconMap = {
   stop: <Square size={16} />,
 };
 
-function ChatUI() {
-  const { messages } = useAgent();
-
-  return (
-    <div>
-      <ul>
-        {messages.map((entry) => (
-          <li key={entry.id}>
-            {entry.role === 'user' ? (
-              <UserMessage entry={entry} />
-            ) : (
-              <AssistantMessage entry={entry} />
-            )}
-            {entry.isStreaming && entry.text === '' && entry.toolEvents.length === 0 ? (
-              <em> (thinking...)</em>
-            ) : null}
-          </li>
-        ))}
-      </ul>
-      <ChatInput />
-    </div>
-  );
-}
-
 export default function App() {
   return (
     <AgentProvider runner={runner} agent={agentConfig} icons={icons}>
       <h1>MAST React UI Demo</h1>
-      <ChatUI />
+      <MessageList />
+      <ChatInput />
     </AgentProvider>
   );
 }

--- a/packages/react-ui/src/components/MessageItem.tsx
+++ b/packages/react-ui/src/components/MessageItem.tsx
@@ -1,0 +1,48 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+
+import type { ConversationEntry, ToolEventEntry } from '../types';
+import { AssistantMessage } from './AssistantMessage';
+import { UserMessage } from './UserMessage';
+
+/**
+ * Props accepted by {@link MessageItem}.
+ */
+export interface MessageItemProps {
+  /** The conversation entry to render. */
+  entry: ConversationEntry;
+  /** Optional class added to the inner message component. */
+  className?: string;
+  /**
+   * Forwarded to {@link AssistantMessage}. Has no effect when `entry.role` is
+   * `'user'`.
+   */
+  renderToolCall?: (entry: ToolEventEntry) => ReactNode;
+  /**
+   * Forwarded to {@link AssistantMessage}. Has no effect when `entry.role` is
+   * `'user'`.
+   */
+  renderMessage?: (text: string) => ReactNode;
+}
+
+/**
+ * Renders a single {@link ConversationEntry} by dispatching to
+ * {@link UserMessage} or {@link AssistantMessage} based on `entry.role`.
+ *
+ * Used by {@link MessageList} to render each virtualised row.
+ */
+export function MessageItem({ entry, className, renderToolCall, renderMessage }: MessageItemProps) {
+  if (entry.role === 'user') {
+    return <UserMessage entry={entry} className={className} />;
+  }
+  return (
+    <AssistantMessage
+      entry={entry}
+      className={className}
+      renderToolCall={renderToolCall}
+      renderMessage={renderMessage}
+    />
+  );
+}

--- a/packages/react-ui/src/components/MessageList.test.tsx
+++ b/packages/react-ui/src/components/MessageList.test.tsx
@@ -1,0 +1,208 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
+
+import { AgentProvider, useAgent } from '../context';
+import { MessageList } from './MessageList';
+
+// ---------------------------------------------------------------------------
+// jsdom shims for @tanstack/react-virtual
+//
+// `@tanstack/virtual-core` measures the scroll element via `offsetWidth` /
+// `offsetHeight` (which are 0 in jsdom) and scrolls via `Element.scrollTo`
+// (which is not implemented). Without overriding both, the virtualizer treats
+// the viewport as 0×0 and renders no items, and the auto-scroll-to-bottom
+// effect is a silent no-op. The shims are scoped to the test suite and
+// restored afterwards so they do not affect other component tests.
+// ---------------------------------------------------------------------------
+
+const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'offsetHeight',
+);
+const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+const originalScrollTo = HTMLElement.prototype.scrollTo;
+
+function installVirtualizerShims() {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return 80;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get() {
+      return 400;
+    },
+  });
+  HTMLElement.prototype.scrollTo = vi.fn() as unknown as HTMLElement['scrollTo'];
+}
+
+function restoreVirtualizerShims() {
+  if (offsetHeightDescriptor) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor);
+  }
+  if (offsetWidthDescriptor) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor);
+  }
+  if (originalScrollTo) {
+    HTMLElement.prototype.scrollTo = originalScrollTo;
+  } else {
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function makeMockRunner(events: AgentEvent[]): { runner: AgentRunner; conversation: Conversation } {
+  const stream = (): AsyncIterable<AgentEvent> =>
+    (async function* () {
+      for (const event of events) yield event;
+    })();
+
+  const conversation: Conversation = {
+    history: [],
+    runStream: vi.fn(() => stream()),
+  } as unknown as Conversation;
+
+  const runner = {
+    conversation: vi.fn(() => conversation),
+  } as unknown as AgentRunner;
+
+  return { runner, conversation };
+}
+
+const agentConfig: AgentConfig = {
+  name: 'TestAgent',
+  instructions: 'A test agent.',
+};
+
+function SendButton({ text }: { text: string }) {
+  const { sendMessage } = useAgent();
+  return (
+    <button type="button" onClick={() => sendMessage(text)}>
+      send {text}
+    </button>
+  );
+}
+
+function renderWithProvider(runner: AgentRunner, child: ReactNode) {
+  return render(
+    <AgentProvider runner={runner} agent={agentConfig}>
+      {child}
+    </AgentProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('<MessageList>', () => {
+  beforeEach(() => {
+    installVirtualizerShims();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    restoreVirtualizerShims();
+  });
+
+  it('renders user and assistant entries from context', async () => {
+    const user = userEvent.setup();
+    const { runner } = makeMockRunner([
+      { type: 'text_delta', delta: 'hello from agent' },
+      { type: 'done', output: 'hello from agent', history: [] },
+    ]);
+
+    renderWithProvider(
+      runner,
+      <>
+        <SendButton text="hi agent" />
+        <MessageList />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send hi agent' }));
+
+    // User entry rendered via <UserMessage>.
+    expect(await screen.findByText('hi agent')).toBeDefined();
+    // Assistant entry rendered via <AssistantMessage>; final text comes from `done.output`.
+    expect(await screen.findByText('hello from agent')).toBeDefined();
+  });
+
+  it('exposes role="log" and aria-live="polite" for screen readers', () => {
+    const { runner } = makeMockRunner([{ type: 'done', output: 'ok', history: [] }]);
+    const { container } = renderWithProvider(runner, <MessageList />);
+
+    const list = container.querySelector('[data-mast-message-list]');
+    expect(list).not.toBeNull();
+    expect(list!.getAttribute('role')).toBe('log');
+    expect(list!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('forwards className to the root element', () => {
+    const { runner } = makeMockRunner([{ type: 'done', output: 'ok', history: [] }]);
+    const { container } = renderWithProvider(runner, <MessageList className="custom-class" />);
+
+    const list = container.querySelector('[data-mast-message-list]');
+    expect(list).not.toBeNull();
+    expect(list!.className).toContain('mast-message-list');
+    expect(list!.className).toContain('custom-class');
+  });
+
+  it('scrolls to the bottom when a new entry is appended', async () => {
+    const user = userEvent.setup();
+    const { runner } = makeMockRunner([
+      { type: 'text_delta', delta: 'first answer' },
+      { type: 'done', output: 'first answer', history: [] },
+    ]);
+
+    const { container } = renderWithProvider(
+      runner,
+      <>
+        <SendButton text="first" />
+        <MessageList />
+      </>,
+    );
+
+    const list = container.querySelector('[data-mast-message-list]') as HTMLElement;
+    const scrollToSpy = list.scrollTo as ReturnType<typeof vi.fn>;
+    scrollToSpy.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'send first' }));
+    await screen.findByText('first answer');
+
+    expect(scrollToSpy).toHaveBeenCalled();
+  });
+
+  it('forwards renderToolCall to assistant entries', async () => {
+    const user = userEvent.setup();
+    const { runner } = makeMockRunner([
+      { type: 'tool_call_started', name: 'demo_tool', args: { foo: 'bar' } },
+      { type: 'tool_call_completed', name: 'demo_tool', result: 'baz' },
+      { type: 'done', output: '', history: [] },
+    ]);
+
+    renderWithProvider(
+      runner,
+      <>
+        <SendButton text="run tool" />
+        <MessageList renderToolCall={(entry) => <span>tool:{entry.name}</span>} />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send run tool' }));
+
+    expect(await screen.findByText('tool:demo_tool')).toBeDefined();
+  });
+});

--- a/packages/react-ui/src/components/MessageList.tsx
+++ b/packages/react-ui/src/components/MessageList.tsx
@@ -1,0 +1,109 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+import { useAgent } from '../context';
+import type { ToolEventEntry } from '../types';
+import { MessageItem } from './MessageItem';
+
+/**
+ * Props accepted by {@link MessageList}.
+ */
+export interface MessageListProps {
+  /** Optional class added to the scrollable root element. */
+  className?: string;
+  /**
+   * Forwarded to each {@link MessageItem} so consumers can replace the default
+   * tool call renderer for the entire list.
+   */
+  renderToolCall?: (entry: ToolEventEntry) => ReactNode;
+  /**
+   * Forwarded to each {@link MessageItem} so consumers can replace the default
+   * assistant text renderer for the entire list.
+   */
+  renderMessage?: (text: string) => ReactNode;
+}
+
+/**
+ * Estimated height (in pixels) used by the virtualizer before an item has been
+ * measured. The real height is then captured via `measureElement` on first
+ * render of each row, so any reasonable value works — this just keeps initial
+ * scroll offsets sensible while the first paint resolves.
+ */
+const DEFAULT_ESTIMATED_ITEM_HEIGHT = 80;
+
+/**
+ * Scrollable list of {@link ConversationEntry} items rendered with
+ * `@tanstack/react-virtual`.
+ *
+ * Only the visible window of messages is mounted, so long-running conversations
+ * stay performant. Item heights are dynamic: each rendered row is observed via
+ * `virtualizer.measureElement`, so messages with long tool call results or
+ * large markdown blocks expand the viewport correctly.
+ *
+ * Auto-scrolls to the bottom whenever a new entry is appended or the last
+ * entry's `text` grows during streaming.
+ *
+ * Reads `messages` from `useAgent()`, so this component must be rendered
+ * inside an `<AgentProvider>`.
+ */
+export function MessageList({ className, renderToolCall, renderMessage }: MessageListProps) {
+  const { messages } = useAgent();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: messages.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => DEFAULT_ESTIMATED_ITEM_HEIGHT,
+    overscan: 4,
+  });
+
+  const lastEntry = messages.length > 0 ? messages[messages.length - 1] : undefined;
+  const lastTextLength = lastEntry?.text.length ?? 0;
+
+  // Scroll to the end whenever a new entry is added or the last (currently
+  // streaming) entry's text grows. We always pin the scroll to the latest
+  // message; consumers that need scroll-position preservation should compose
+  // their own list using `useAgent()` directly.
+  useEffect(() => {
+    if (messages.length === 0) return;
+    virtualizer.scrollToIndex(messages.length - 1, { align: 'end' });
+  }, [messages.length, lastTextLength, virtualizer]);
+
+  const totalSize = virtualizer.getTotalSize();
+  const virtualItems = virtualizer.getVirtualItems();
+  const rootClass = ['mast-message-list', className].filter(Boolean).join(' ');
+
+  return (
+    <div ref={scrollRef} data-mast-message-list className={rootClass} role="log" aria-live="polite">
+      <div style={{ height: `${totalSize}px`, position: 'relative', width: '100%' }}>
+        {virtualItems.map((item) => {
+          const entry = messages[item.index];
+          return (
+            <div
+              key={entry.id}
+              data-index={item.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${item.start}px)`,
+              }}
+            >
+              <MessageItem
+                entry={entry}
+                renderToolCall={renderToolCall}
+                renderMessage={renderMessage}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -16,3 +16,7 @@ export { AssistantMessage } from './components/AssistantMessage';
 export type { AssistantMessageProps } from './components/AssistantMessage';
 export { ChatInput } from './components/ChatInput';
 export type { ChatInputProps } from './components/ChatInput';
+export { MessageItem } from './components/MessageItem';
+export type { MessageItemProps } from './components/MessageItem';
+export { MessageList } from './components/MessageList';
+export type { MessageListProps } from './components/MessageList';


### PR DESCRIPTION
## Summary
- Adds `<MessageList>`: a virtualized scrollable list of conversation entries built on `@tanstack/react-virtual`. Uses `measureElement` for dynamic item heights and a `useEffect` keyed on `entries.length` and the last entry's text length to keep the view scrolled to the bottom during streaming.
- Exposes `role="log"` / `aria-live="polite"` so new messages are announced to screen readers; accepts `className`, `renderToolCall`, and `renderMessage` props.
- Adds `<MessageItem>` (per SPEC §4.4) as the small dispatcher between `<UserMessage>` and `<AssistantMessage>` that `<MessageList>` renders per virtual row.
- Replaces the raw `<ul>` + inline `useAgent()` wiring in `apps/demo-react-ui/src/App.tsx` with `<MessageList />`.

The demo currently has no height constraint on the list (the default stylesheet ships in #37), so the scroll-to-bottom effect is a visual no-op until then. Rendering of user/assistant entries works correctly.

## Test plan
- [x] `npm run lint`, `npm run format`, `npm run build` clean from repo root
- [x] `npm test` across workspaces — 65/65 react-ui tests pass (5 new for `<MessageList>`); core, google-genai, and built-in-ai green
- [x] New tests cover SPEC §11.2: renders user+assistant entries, ARIA attributes, `className` forwarding, scrolls to bottom on append (verified via `scrollTo` spy with jsdom shims for `offsetWidth`/`offsetHeight`/`scrollTo`), `renderToolCall` forwarding
- [x] Manually verified in `apps/demo-react-ui` that user and assistant entries render through `<MessageList>`

Closes #36