### PR TITLE
feat(react-ui): ConversationPanel and default stylesheet

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -1,9 +1,10 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
-import { AgentProvider, ChatInput, MessageList, type IconMap } from '@mast-ai/react-ui';
+import { AgentProvider, ConversationPanel, type IconMap } from '@mast-ai/react-ui';
 import { Brain, CircleCheck, LoaderCircle, Send, Square, Wrench } from 'lucide-react';
 
 import { GetCurrentTimeTool } from './tools';
@@ -33,12 +34,39 @@ const icons: IconMap = {
   stop: <Square size={16} />,
 };
 
+type ThemeChoice = 'system' | 'light' | 'dark';
+
+const NEXT_THEME: Record<ThemeChoice, ThemeChoice> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system',
+};
+
+const THEME_LABEL: Record<ThemeChoice, string> = {
+  system: 'Theme: System',
+  light: 'Theme: Light',
+  dark: 'Theme: Dark',
+};
+
 export default function App() {
+  const [theme, setTheme] = useState<ThemeChoice>('system');
+  const panelTheme = theme === 'system' ? undefined : theme;
+
   return (
     <AgentProvider runner={runner} agent={agentConfig} icons={icons}>
-      <h1>MAST React UI Demo</h1>
-      <MessageList />
-      <ChatInput />
+      <div className="demo-shell">
+        <header className="demo-header">
+          <h1>MAST React UI Demo</h1>
+          <button
+            type="button"
+            className="demo-theme-toggle"
+            onClick={() => setTheme((current) => NEXT_THEME[current])}
+          >
+            {THEME_LABEL[theme]}
+          </button>
+        </header>
+        <ConversationPanel theme={panelTheme} />
+      </div>
     </AgentProvider>
   );
 }

--- a/apps/demo-react-ui/src/index.css
+++ b/apps/demo-react-ui/src/index.css
@@ -1,0 +1,57 @@
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+
+body {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0b0f17;
+    color: #f9fafb;
+  }
+}
+
+.demo-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.demo-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.demo-theme-toggle {
+  background: transparent;
+  border: 1px solid currentColor;
+  color: inherit;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+.demo-shell [data-mast-root] {
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/apps/demo-react-ui/src/main.tsx
+++ b/apps/demo-react-ui/src/main.tsx
@@ -4,6 +4,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@mast-ai/react-ui/styles.css';
+import './index.css';
 import App from './App';
 
 createRoot(document.getElementById('root')!).render(

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -10,7 +10,7 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./styles.css": "./styles/default.css"
+    "./styles.css": "./dist/styles.css"
   },
   "scripts": {
     "build": "vite build && tsc",

--- a/packages/react-ui/src/components/ConversationPanel.tsx
+++ b/packages/react-ui/src/components/ConversationPanel.tsx
@@ -1,0 +1,55 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+
+import type { ToolEventEntry } from '../types';
+import { ChatInput } from './ChatInput';
+import { MessageList } from './MessageList';
+
+/**
+ * Props accepted by {@link ConversationPanel}.
+ */
+export interface ConversationPanelProps {
+  /**
+   * Forces a theme regardless of the user's `prefers-color-scheme` setting.
+   * When omitted, the panel follows the OS preference via the default
+   * stylesheet's media query.
+   */
+  theme?: 'light' | 'dark';
+  /** Optional class added to the root `[data-mast-root]` element. */
+  className?: string;
+  /** Replaces the default {@link ToolCallBlock} renderer for the entire list. */
+  renderToolCall?: (entry: ToolEventEntry) => ReactNode;
+  /** Replaces the default assistant text renderer for the entire list. */
+  renderMessage?: (text: string) => ReactNode;
+  /** Placeholder text for the {@link ChatInput} field. */
+  inputPlaceholder?: string;
+}
+
+/**
+ * Renders a complete chat UI as a single composable unit.
+ *
+ * Internally renders {@link MessageList} and {@link ChatInput} inside a
+ * `[data-mast-root]` div so the default stylesheet's CSS custom properties
+ * resolve. Sets `data-mast-theme` from the optional `theme` prop, which the
+ * default stylesheet uses to override the OS-driven dark mode preference.
+ *
+ * Must be rendered inside an `<AgentProvider>`.
+ */
+export function ConversationPanel({
+  theme,
+  className,
+  renderToolCall,
+  renderMessage,
+  inputPlaceholder,
+}: ConversationPanelProps) {
+  const rootClass = ['mast-conversation-panel', className].filter(Boolean).join(' ');
+
+  return (
+    <div data-mast-root data-mast-theme={theme} className={rootClass}>
+      <MessageList renderToolCall={renderToolCall} renderMessage={renderMessage} />
+      <ChatInput placeholder={inputPlaceholder} />
+    </div>
+  );
+}

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -20,3 +20,5 @@ export { MessageItem } from './components/MessageItem';
 export type { MessageItemProps } from './components/MessageItem';
 export { MessageList } from './components/MessageList';
 export type { MessageListProps } from './components/MessageList';
+export { ConversationPanel } from './components/ConversationPanel';
+export type { ConversationPanelProps } from './components/ConversationPanel';

--- a/packages/react-ui/styles/default.css
+++ b/packages/react-ui/styles/default.css
@@ -1,29 +1,188 @@
 /* @mast-ai/react-ui default stylesheet — import as '@mast-ai/react-ui/styles.css' */
 
+/* -------------------------------------------------------------------------- */
+/* Theme tokens                                                               */
+/* -------------------------------------------------------------------------- */
+
+[data-mast-root] {
+  /* Color */
+  --mast-bg: #ffffff;
+  --mast-bg-subtle: #f9fafb;
+  --mast-fg: #111827;
+  --mast-fg-muted: #6b7280;
+  --mast-border: #e5e7eb;
+  --mast-accent: #2563eb;
+  --mast-accent-fg: #ffffff;
+  --mast-thinking-bg: #fefce8;
+  --mast-thinking-fg: #854d0e;
+  --mast-tool-bg: #f0fdf4;
+  --mast-tool-fg: #166534;
+  --mast-tool-pending: #f59e0b;
+  --mast-user-bubble: #dbeafe;
+  --mast-user-fg: #1e3a8a;
+
+  /* Typography */
+  --mast-font: system-ui, sans-serif;
+  --mast-font-mono: ui-monospace, monospace;
+  --mast-text-sm: 0.875rem;
+  --mast-text-base: 1rem;
+
+  /* Spacing */
+  --mast-gap: 0.75rem;
+  --mast-radius: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-mast-root]:not([data-mast-theme='light']) {
+    --mast-bg: #111827;
+    --mast-bg-subtle: #1f2937;
+    --mast-fg: #f9fafb;
+    --mast-fg-muted: #9ca3af;
+    --mast-border: #374151;
+    --mast-accent: #3b82f6;
+    --mast-accent-fg: #ffffff;
+    --mast-thinking-bg: #1c1917;
+    --mast-thinking-fg: #fcd34d;
+    --mast-tool-bg: #052e16;
+    --mast-tool-fg: #86efac;
+    --mast-tool-pending: #fbbf24;
+    --mast-user-bubble: #1e3a8a;
+    --mast-user-fg: #bfdbfe;
+  }
+}
+
+[data-mast-root][data-mast-theme='dark'] {
+  --mast-bg: #111827;
+  --mast-bg-subtle: #1f2937;
+  --mast-fg: #f9fafb;
+  --mast-fg-muted: #9ca3af;
+  --mast-border: #374151;
+  --mast-accent: #3b82f6;
+  --mast-accent-fg: #ffffff;
+  --mast-thinking-bg: #1c1917;
+  --mast-thinking-fg: #fcd34d;
+  --mast-tool-bg: #052e16;
+  --mast-tool-fg: #86efac;
+  --mast-tool-pending: #fbbf24;
+  --mast-user-bubble: #1e3a8a;
+  --mast-user-fg: #bfdbfe;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Utilities                                                                  */
+/* -------------------------------------------------------------------------- */
+
+.mast-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes mast-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.mast-spin {
+  animation: mast-spin 1s linear infinite;
+}
+
+@keyframes mast-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* ConversationPanel                                                          */
+/* -------------------------------------------------------------------------- */
+
+[data-mast-root] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mast-gap);
+  height: 100%;
+  min-height: 0;
+  background: var(--mast-bg);
+  color: var(--mast-fg);
+  font-family: var(--mast-font);
+  font-size: var(--mast-text-base);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  padding: var(--mast-gap);
+  box-sizing: border-box;
+}
+
+[data-mast-root] * {
+  box-sizing: border-box;
+}
+
+/* -------------------------------------------------------------------------- */
+/* MessageList                                                                */
+/* -------------------------------------------------------------------------- */
+
+.mast-message-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--mast-gap);
+  background: var(--mast-bg-subtle);
+  border-radius: var(--mast-radius);
+}
+
+/* -------------------------------------------------------------------------- */
+/* UserMessage                                                                */
+/* -------------------------------------------------------------------------- */
+
 [data-mast-user-message] {
   display: flex;
   justify-content: flex-end;
+  margin-bottom: var(--mast-gap);
 }
 
 .mast-user-message-bubble {
-  background: var(--mast-user-bubble, #dbeafe);
-  color: var(--mast-user-fg, #1e3a8a);
+  background: var(--mast-user-bubble);
+  color: var(--mast-user-fg);
   padding: 0.5rem 0.75rem;
-  border-radius: var(--mast-radius, 0.5rem);
+  border-radius: var(--mast-radius);
   max-width: 80%;
   white-space: pre-wrap;
   word-wrap: break-word;
 }
 
+/* -------------------------------------------------------------------------- */
+/* AssistantMessage                                                           */
+/* -------------------------------------------------------------------------- */
+
 [data-mast-assistant-message] {
   display: flex;
   flex-direction: column;
-  gap: var(--mast-gap, 0.75rem);
+  gap: var(--mast-gap);
+  margin-bottom: var(--mast-gap);
+  color: var(--mast-fg);
 }
 
 .mast-assistant-message-text {
   margin: 0;
   white-space: pre-wrap;
+}
+
+.mast-assistant-message-markdown {
+  line-height: 1.5;
 }
 
 .mast-assistant-message-markdown > :first-child {
@@ -32,4 +191,215 @@
 
 .mast-assistant-message-markdown > :last-child {
   margin-bottom: 0;
+}
+
+.mast-assistant-message-markdown pre {
+  background: var(--mast-bg-subtle);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  padding: 0.5rem 0.75rem;
+  overflow-x: auto;
+  font-family: var(--mast-font-mono);
+  font-size: var(--mast-text-sm);
+}
+
+.mast-assistant-message-markdown code {
+  font-family: var(--mast-font-mono);
+  font-size: 0.9em;
+}
+
+.mast-assistant-message-markdown :not(pre) > code {
+  background: var(--mast-bg-subtle);
+  border: 1px solid var(--mast-border);
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.3rem;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ThinkingBlock                                                              */
+/* -------------------------------------------------------------------------- */
+
+.mast-thinking-block {
+  background: var(--mast-thinking-bg);
+  color: var(--mast-thinking-fg);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  padding: 0.5rem 0.75rem;
+  font-size: var(--mast-text-sm);
+}
+
+.mast-thinking-block-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.mast-thinking-block-summary::-webkit-details-marker {
+  display: none;
+}
+
+.mast-thinking-block-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mast-thinking-block-label {
+  font-weight: 500;
+}
+
+.mast-thinking-block-pulse {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: currentColor;
+  animation: mast-pulse 1.2s ease-in-out infinite;
+}
+
+.mast-thinking-block-content {
+  margin-top: 0.5rem;
+  white-space: pre-wrap;
+  font-family: var(--mast-font-mono);
+  font-size: var(--mast-text-sm);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ToolCallBlock                                                              */
+/* -------------------------------------------------------------------------- */
+
+.mast-tool-call-block {
+  background: var(--mast-tool-bg);
+  color: var(--mast-tool-fg);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  padding: 0.5rem 0.75rem;
+  font-size: var(--mast-text-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mast-tool-call-block[data-streaming='true'] .mast-tool-call-block-status {
+  color: var(--mast-tool-pending);
+}
+
+.mast-tool-call-block-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mast-tool-call-block-status,
+.mast-tool-call-block-wrench {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mast-tool-call-block-name {
+  font-family: var(--mast-font-mono);
+  font-weight: 500;
+}
+
+.mast-tool-call-block-sub-output {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mast-tool-call-block-sub-text {
+  white-space: pre-wrap;
+  color: var(--mast-fg);
+}
+
+.mast-tool-call-block-args,
+.mast-tool-call-block-result {
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  background: var(--mast-bg);
+  color: var(--mast-fg);
+  padding: 0.25rem 0.5rem;
+}
+
+.mast-tool-call-block-args > summary,
+.mast-tool-call-block-result > summary {
+  cursor: pointer;
+  user-select: none;
+  font-size: var(--mast-text-sm);
+  color: var(--mast-fg-muted);
+}
+
+.mast-tool-call-block-pre {
+  margin: 0.5rem 0 0 0;
+  padding: 0.5rem;
+  background: var(--mast-bg-subtle);
+  border-radius: 0.25rem;
+  overflow-x: auto;
+  font-family: var(--mast-font-mono);
+  font-size: var(--mast-text-sm);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ChatInput                                                                  */
+/* -------------------------------------------------------------------------- */
+
+[data-mast-chat-input] {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: var(--mast-bg);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+}
+
+.mast-chat-input-textarea {
+  flex: 1 1 auto;
+  resize: none;
+  background: transparent;
+  color: var(--mast-fg);
+  font: inherit;
+  border: none;
+  outline: none;
+  padding: 0.25rem 0.5rem;
+  min-height: 1.5rem;
+  line-height: 1.4;
+}
+
+.mast-chat-input-textarea::placeholder {
+  color: var(--mast-fg-muted);
+}
+
+.mast-chat-input-textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mast-chat-input-send,
+.mast-chat-input-cancel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  flex-shrink: 0;
+  background: var(--mast-accent);
+  color: var(--mast-accent-fg);
+  border: none;
+  border-radius: var(--mast-radius);
+  cursor: pointer;
+  padding: 0;
+}
+
+.mast-chat-input-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mast-chat-input-cancel {
+  background: var(--mast-tool-pending);
 }

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -1,8 +1,29 @@
-import { defineConfig } from 'vite';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
+/**
+ * Emits `styles/default.css` into the build output as `styles.css` so the
+ * `./styles.css` package export resolves to a published file inside `dist/`.
+ */
+function emitStylesheet(): Plugin {
+  return {
+    name: 'mast-ai-emit-stylesheet',
+    apply: 'build',
+    generateBundle() {
+      const source = readFileSync(resolve(__dirname, 'styles/default.css'), 'utf8');
+      this.emitFile({
+        type: 'asset',
+        fileName: 'styles.css',
+        source,
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), emitStylesheet()],
   build: {
     lib: {
       entry: 'src/index.ts',


### PR DESCRIPTION
## Summary

- Adds `ConversationPanel`, a thin compositor that renders `MessageList` + `ChatInput` inside a `[data-mast-root]` div and forwards a `theme` prop to `data-mast-theme`. Accepts `className`, `renderToolCall`, `renderMessage`, and `inputPlaceholder` props.
- Fills out `styles/default.css` with the full `--mast-*` token system (light, OS-driven dark via `prefers-color-scheme`, and explicit `[data-mast-theme="dark"]` override) plus `mast-*` rules for every component.
- Emits the stylesheet into `dist/styles.css` via a small Vite plugin so the `@mast-ai/react-ui/styles.css` export resolves to a built artifact. The package export now points at `./dist/styles.css`.
- The demo app renders `ConversationPanel` and adds a System/Light/Dark theme toggle.

Closes #37

## Test plan

- [x] `npm run lint`, `npm run format`, `npm run build`, and `npm test --workspaces` all pass
- [x] `dist/styles.css` is emitted by the build
- [x] User confirmed the demo renders correctly in light and dark themes and the toggle forces a theme regardless of OS preference