### PR TITLE
feat(demo-react-ui): add New conversation button

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -169,6 +169,21 @@ function PendingApprovalsBadge() {
   return <span className="demo-pending-badge">{pendingApprovals.length} pending</span>;
 }
 
+/**
+ * Header button that calls `useAgent().reset()` to abort any in-flight run,
+ * clear the rendered conversation, and replace the underlying Conversation
+ * instance so the next message starts with empty core history.
+ */
+function NewConversationButton() {
+  const { reset, messages, isRunning } = useAgent();
+  const disabled = messages.length === 0 && !isRunning;
+  return (
+    <button type="button" className="demo-header-button" onClick={reset} disabled={disabled}>
+      New conversation
+    </button>
+  );
+}
+
 export default function App() {
   const [theme, setTheme] = useState<ThemeChoice>('system');
   const panelTheme = theme === 'system' ? undefined : theme;
@@ -185,9 +200,10 @@ export default function App() {
           <h1>MAST React UI Demo</h1>
           <div className="demo-header-controls">
             <PendingApprovalsBadge />
+            <NewConversationButton />
             <button
               type="button"
-              className="demo-theme-toggle"
+              className="demo-header-button"
               onClick={() => setTheme((current) => NEXT_THEME[current])}
             >
               {THEME_LABEL[theme]}

--- a/apps/demo-react-ui/src/index.css
+++ b/apps/demo-react-ui/src/index.css
@@ -41,7 +41,7 @@ body {
   font-size: 1.25rem;
 }
 
-.demo-theme-toggle {
+.demo-header-button {
   background: transparent;
   border: 1px solid currentColor;
   color: inherit;
@@ -49,6 +49,11 @@ body {
   border-radius: 0.5rem;
   cursor: pointer;
   font: inherit;
+}
+
+.demo-header-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .demo-shell [data-mast-root] {


### PR DESCRIPTION
## Summary

- Adds a \"New conversation\" button to the demo header that calls `useAgent().reset()` to abort any in-flight run, clear the rendered conversation, and replace the underlying `Conversation` instance.
- Disabled when the conversation is already empty and idle, so it doesn't sit there as a tease on first load.
- Renames `.demo-theme-toggle` to `.demo-header-button` so both header buttons share styling, with an added `:disabled` rule.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] User confirmed the button works in the browser (sends, then \"New conversation\" clears the panel and the next turn starts fresh)