### PR TITLE
feat(react-ui): conversation persistence hooks and demo

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -1,8 +1,9 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
+import type { Message } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
 import {
   AgentProvider,
@@ -11,12 +12,22 @@ import {
   InlineApproval,
   ToolCallBlock,
   useAgent,
+  type ConversationEntry,
   type IconMap,
   type OnApprovalRequired,
   type PendingApproval,
   type ToolEventEntry,
 } from '@mast-ai/react-ui';
-import { Brain, CircleCheck, CircleX, LoaderCircle, Send, Square, Wrench } from 'lucide-react';
+import {
+  Brain,
+  CircleCheck,
+  CircleX,
+  LoaderCircle,
+  Send,
+  Square,
+  Trash2,
+  Wrench,
+} from 'lucide-react';
 
 import {
   CopyToClipboardTool,
@@ -81,6 +92,55 @@ const THEME_LABEL: Record<ThemeChoice, string> = {
   light: 'Theme: Light',
   dark: 'Theme: Dark',
 };
+
+// ---------------------------------------------------------------------------
+// Conversation persistence
+// ---------------------------------------------------------------------------
+
+interface StoredConversation {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  history: Message[];
+  entries: ConversationEntry[];
+}
+
+type ConversationMap = Record<string, StoredConversation>;
+
+const STORAGE_KEY = 'demo-react-ui:conversations';
+
+function loadConversations(): ConversationMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as ConversationMap;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistConversations(map: ConversationMap) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch (err) {
+    console.warn('Failed to persist conversations to localStorage', err);
+  }
+}
+
+function deriveTitle(entries: ConversationEntry[]): string {
+  const firstUser = entries.find((e) => e.role === 'user');
+  const text = firstUser?.text.trim() ?? '';
+  if (!text) return 'Untitled conversation';
+  return text.length > 40 ? `${text.slice(0, 40)}…` : text;
+}
+
+function pickMostRecent(map: ConversationMap): string | null {
+  const ids = Object.keys(map);
+  if (ids.length === 0) return null;
+  return ids.sort((a, b) => map[b].updatedAt - map[a].updatedAt)[0];
+}
 
 /**
  * Single approval callback that dispatches by tool name across two flows:
@@ -169,18 +229,66 @@ function PendingApprovalsBadge() {
   return <span className="demo-pending-badge">{pendingApprovals.length} pending</span>;
 }
 
-/**
- * Header button that calls `useAgent().reset()` to abort any in-flight run,
- * clear the rendered conversation, and replace the underlying Conversation
- * instance so the next message starts with empty core history.
- */
-function NewConversationButton() {
-  const { reset, messages, isRunning } = useAgent();
-  const disabled = messages.length === 0 && !isRunning;
+interface ConversationListProps {
+  conversations: ConversationMap;
+  activeId: string;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function ConversationList({ conversations, activeId, onSelect, onDelete }: ConversationListProps) {
+  const sorted = Object.values(conversations).sort((a, b) => b.updatedAt - a.updatedAt);
+
   return (
-    <button type="button" className="demo-header-button" onClick={reset} disabled={disabled}>
-      New conversation
-    </button>
+    <aside className="demo-sidebar">
+      <h2 className="demo-sidebar-title">Conversations</h2>
+      {sorted.length === 0 ? (
+        <p className="demo-sidebar-empty">
+          No saved conversations yet. Send a message to start one.
+        </p>
+      ) : (
+        <ul className="demo-conversation-list">
+          {sorted.map((conv) => {
+            const isActive = conv.id === activeId;
+            return (
+              <li
+                key={conv.id}
+                className={
+                  isActive
+                    ? 'demo-conversation-item demo-conversation-item-active'
+                    : 'demo-conversation-item'
+                }
+              >
+                <button
+                  type="button"
+                  className="demo-conversation-select"
+                  onClick={() => onSelect(conv.id)}
+                  aria-current={isActive ? 'true' : undefined}
+                >
+                  <span className="demo-conversation-title">{conv.title}</span>
+                  <span className="demo-conversation-date">
+                    {new Date(conv.updatedAt).toLocaleString(undefined, {
+                      dateStyle: 'short',
+                      timeStyle: 'short',
+                    })}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="demo-conversation-delete"
+                  aria-label={`Delete conversation "${conv.title}"`}
+                  onClick={() => {
+                    if (window.confirm(`Delete "${conv.title}"?`)) onDelete(conv.id);
+                  }}
+                >
+                  <Trash2 size={14} aria-hidden="true" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
   );
 }
 
@@ -188,30 +296,114 @@ export default function App() {
   const [theme, setTheme] = useState<ThemeChoice>('system');
   const panelTheme = theme === 'system' ? undefined : theme;
 
+  const [conversations, setConversations] = useState<ConversationMap>(() => loadConversations());
+  const [activeId, setActiveId] = useState<string>(() => {
+    const stored = loadConversations();
+    return pickMostRecent(stored) ?? crypto.randomUUID();
+  });
+
+  const active: StoredConversation | undefined = conversations[activeId];
+
+  const handleConversationChange = useCallback(
+    (history: Message[], entries: ConversationEntry[]) => {
+      setConversations((prev) => {
+        const existing = prev[activeId];
+        const now = Date.now();
+        const updated: StoredConversation = {
+          id: activeId,
+          title: deriveTitle(entries),
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+          history,
+          entries,
+        };
+        const next = { ...prev, [activeId]: updated };
+        persistConversations(next);
+        return next;
+      });
+    },
+    [activeId],
+  );
+
+  const handleNew = useCallback(() => {
+    setActiveId(crypto.randomUUID());
+  }, []);
+
+  const handleSelect = useCallback((id: string) => {
+    setActiveId(id);
+  }, []);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      setConversations((prev) => {
+        if (!(id in prev)) return prev;
+        const next = { ...prev };
+        delete next[id];
+        persistConversations(next);
+        if (id === activeId) {
+          const fallback = pickMostRecent(next);
+          setActiveId(fallback ?? crypto.randomUUID());
+        }
+        return next;
+      });
+    },
+    [activeId],
+  );
+
+  const isUnsavedNew = !active;
+
   return (
-    <AgentProvider
-      runner={runner}
-      agent={agentConfig}
-      icons={icons}
-      onApprovalRequired={onApprovalRequired}
-    >
-      <div className="demo-shell">
-        <header className="demo-header">
-          <h1>MAST React UI Demo</h1>
-          <div className="demo-header-controls">
-            <PendingApprovalsBadge />
-            <NewConversationButton />
-            <button
-              type="button"
-              className="demo-header-button"
-              onClick={() => setTheme((current) => NEXT_THEME[current])}
-            >
-              {THEME_LABEL[theme]}
-            </button>
-          </div>
-        </header>
-        <ConversationPanel theme={panelTheme} renderToolCall={renderToolCall} />
+    <div className="demo-shell">
+      <header className="demo-header">
+        <h1>MAST React UI Demo</h1>
+        <div className="demo-header-controls">
+          <button
+            type="button"
+            className="demo-header-button"
+            onClick={handleNew}
+            disabled={isUnsavedNew}
+          >
+            New conversation
+          </button>
+          <button
+            type="button"
+            className="demo-header-button"
+            onClick={() => setTheme((current) => NEXT_THEME[current])}
+          >
+            {THEME_LABEL[theme]}
+          </button>
+        </div>
+      </header>
+      <div className="demo-body">
+        <ConversationList
+          conversations={conversations}
+          activeId={activeId}
+          onSelect={handleSelect}
+          onDelete={handleDelete}
+        />
+        <main className="demo-main">
+          {/*
+            Re-key the provider on activeId so switching conversations remounts
+            it with the freshly seeded initialHistory and initialEntries — the
+            simplest way to swap the underlying Conversation instance.
+          */}
+          <AgentProvider
+            key={activeId}
+            runner={runner}
+            agent={agentConfig}
+            icons={icons}
+            onApprovalRequired={onApprovalRequired}
+            initialHistory={active?.history}
+            initialEntries={active?.entries}
+            onConversationChange={handleConversationChange}
+          >
+            <div className="demo-main-header">
+              <PendingApprovalsBadge />
+            </div>
+            <ConversationPanel theme={panelTheme} renderToolCall={renderToolCall} />
+          </AgentProvider>
+        </main>
       </div>
-    </AgentProvider>
+    </div>
   );
 }

--- a/apps/demo-react-ui/src/index.css
+++ b/apps/demo-react-ui/src/index.css
@@ -23,7 +23,7 @@ body {
   flex-direction: column;
   gap: 1rem;
   height: 100%;
-  max-width: 48rem;
+  max-width: 64rem;
   margin: 0 auto;
   padding: 1rem;
   box-sizing: border-box;
@@ -56,7 +56,131 @@ body {
   cursor: not-allowed;
 }
 
-.demo-shell [data-mast-root] {
+.demo-body {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+  min-height: 0;
+  gap: 1rem;
+}
+
+.demo-sidebar {
+  flex: 0 0 14rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid rgba(127, 127, 127, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  overflow: hidden;
+}
+
+.demo-sidebar-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(127, 127, 127, 1);
+}
+
+.demo-sidebar-empty {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: rgba(127, 127, 127, 1);
+}
+
+.demo-conversation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  overflow-y: auto;
+}
+
+.demo-conversation-item {
+  display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  border-radius: 0.375rem;
+}
+
+.demo-conversation-item-active {
+  background: rgba(127, 127, 127, 0.15);
+}
+
+.demo-conversation-select {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.125rem;
+  padding: 0.4rem 0.5rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  min-width: 0;
+}
+
+.demo-conversation-select:hover,
+.demo-conversation-select:focus-visible {
+  background: rgba(127, 127, 127, 0.12);
+}
+
+.demo-conversation-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.demo-conversation-date {
+  font-size: 0.75rem;
+  color: rgba(127, 127, 127, 1);
+}
+
+.demo-conversation-delete {
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0 0.4rem;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  display: flex;
+  align-items: center;
+  opacity: 0.6;
+}
+
+.demo-conversation-delete:hover,
+.demo-conversation-delete:focus-visible {
+  opacity: 1;
+  background: rgba(220, 38, 38, 0.15);
+  color: #dc2626;
+}
+
+.demo-main {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  gap: 0.5rem;
+}
+
+.demo-main-header {
+  display: flex;
+  justify-content: flex-end;
+  min-height: 1.25rem;
+}
+
+.demo-main [data-mast-root] {
   flex: 1 1 auto;
   min-height: 0;
 }

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -890,6 +890,11 @@ surface and a reference implementation.
 5. **Approval flow** — single `onApprovalRequired` callback dispatches by tool name:
    inline tools return `INLINE_APPROVAL`, the others fall through to `window.confirm`.
 6. **Pending approvals queue** — header badge driven by `useAgent().pendingApprovals`.
+7. **Multi-conversation persistence** — sidebar lists every saved conversation, the
+   most recent is auto-loaded on page load, and each entry has a delete button.
+   Save and restore are wired through `onConversationChange` plus `initialHistory` /
+   `initialEntries`; switching conversations remounts the provider via a `key`
+   keyed on the active conversation id. Storage backend is `localStorage`.
 
 ### File structure
 
@@ -897,7 +902,7 @@ surface and a reference implementation.
 apps/demo-react-ui/
 ├── src/
 │   ├── main.tsx        — mounts App
-│   ├── App.tsx         — AgentProvider setup, tool registration, theme toggle, renderToolCall
+│   ├── App.tsx         — AgentProvider setup, tool registration, theme toggle, renderToolCall, conversation list + localStorage persistence
 │   └── tools.ts        — five tool definitions covering every approval/status path
 ├── index.html
 ├── vite.config.ts

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -4,11 +4,11 @@
 import { renderHook, act, render } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ReactNode } from 'react';
-import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
+import type { AgentConfig, AgentEvent, AgentRunner, Conversation, Message } from '@mast-ai/core';
 
 import { AgentProvider, useAgent } from './context';
 import { defaultIcons, useIcons } from './icons';
-import type { IconMap } from './types';
+import type { ConversationEntry, IconMap } from './types';
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -19,22 +19,35 @@ import type { IconMap } from './types';
  * `Conversation` that yields the supplied scripted events on `runStream`.
  *
  * The `vi.fn` wrapping `conversation` lets tests assert how many times a fresh
- * `Conversation` was created.
+ * `Conversation` was created. Each created `Conversation` is appended to
+ * `created` so tests can inspect or mutate them after construction (e.g. to
+ * verify that `initialHistory` was seeded onto `Conversation.history`).
  */
-function makeMockRunner(events: AgentEvent[] = []): AgentRunner {
-  const make = (): Conversation =>
-    ({
-      history: [],
-      runStream(): AsyncIterable<AgentEvent> {
+function makeMockRunner(events: AgentEvent[] = []): {
+  runner: AgentRunner;
+  created: Conversation[];
+  runStreamSpy: ReturnType<typeof vi.fn>;
+} {
+  const created: Conversation[] = [];
+  const runStreamSpy = vi.fn();
+  const make = (): Conversation => {
+    const conv = {
+      history: [] as Message[],
+      runStream(input: string): AsyncIterable<AgentEvent> {
+        runStreamSpy(input, [...conv.history]);
         return (async function* () {
           for (const event of events) yield event;
         })();
       },
-    }) as unknown as Conversation;
+    } as unknown as Conversation;
+    created.push(conv);
+    return conv;
+  };
 
-  return {
+  const runner = {
     conversation: vi.fn(make),
   } as unknown as AgentRunner;
+  return { runner, created, runStreamSpy };
 }
 
 const agentConfig: AgentConfig = {
@@ -74,7 +87,7 @@ describe('useAgent', () => {
   });
 
   it('returns { messages, sendMessage, cancel, isRunning, reset }', () => {
-    const runner = makeMockRunner();
+    const { runner } = makeMockRunner();
     const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
 
     expect(result.current.messages).toEqual([]);
@@ -85,7 +98,7 @@ describe('useAgent', () => {
   });
 
   it('sendMessage appends entries that are exposed via messages', async () => {
-    const runner = makeMockRunner([
+    const { runner } = makeMockRunner([
       { type: 'text_delta', delta: 'Hi' },
       { type: 'done', output: 'Hi', history: [] },
     ]);
@@ -101,14 +114,14 @@ describe('useAgent', () => {
   });
 
   it('exposes the bundled icon defaults when no `icons` prop is provided', () => {
-    const runner = makeMockRunner();
+    const { runner } = makeMockRunner();
     const { result } = renderHook(() => useIcons(), { wrapper: makeWrapper(runner) });
 
     expect(result.current).toBe(defaultIcons);
   });
 
   it('overrides individual icon slots from the `icons` prop, leaving the rest as defaults', () => {
-    const runner = makeMockRunner();
+    const { runner } = makeMockRunner();
     const customSend = <span data-testid="custom-send">SEND</span>;
     const customStop = <span data-testid="custom-stop">STOP</span>;
     const icons: IconMap = { send: customSend, stop: customStop };
@@ -137,7 +150,7 @@ describe('useAgent', () => {
   });
 
   it('reset() clears messages and creates a fresh Conversation', async () => {
-    const runner = makeMockRunner([{ type: 'done', output: 'ok', history: [] }]);
+    const { runner } = makeMockRunner([{ type: 'done', output: 'ok', history: [] }]);
     const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
 
     expect(runner.conversation).toHaveBeenCalledTimes(1);
@@ -154,5 +167,261 @@ describe('useAgent', () => {
 
     expect(result.current.messages).toEqual([]);
     expect(runner.conversation).toHaveBeenCalledTimes(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Conversation persistence (initialHistory, initialEntries, onConversationChange)
+  // -------------------------------------------------------------------------
+
+  const userMessage = (text: string): Message => ({
+    role: 'user',
+    content: { type: 'text', text },
+  });
+  const assistantMessage = (text: string): Message => ({
+    role: 'assistant',
+    content: { type: 'text', text },
+  });
+
+  it('onConversationChange fires after a `done` event with the latest history and entries', async () => {
+    const finalHistory: Message[] = [userMessage('hi'), assistantMessage('Hi back')];
+    const { runner } = makeMockRunner([
+      { type: 'text_delta', delta: 'Hi back' },
+      { type: 'done', output: 'Hi back', history: finalHistory },
+    ]);
+    const onConversationChange = vi.fn();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AgentProvider
+        runner={runner}
+        agent={agentConfig}
+        onConversationChange={onConversationChange}
+      >
+        {children}
+      </AgentProvider>
+    );
+    const { result } = renderHook(() => useAgent(), { wrapper });
+
+    expect(onConversationChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    expect(onConversationChange).toHaveBeenCalledTimes(1);
+    const [history, entries] = onConversationChange.mock.calls[0] as [
+      Message[],
+      ConversationEntry[],
+    ];
+    expect(history).toEqual(finalHistory);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ role: 'user', text: 'hi' });
+    expect(entries[1]).toMatchObject({ role: 'assistant', text: 'Hi back', isStreaming: false });
+  });
+
+  it('does not fire onConversationChange when a run errors before `done`', async () => {
+    const created: Conversation[] = [];
+    const erroringConv: Conversation = {
+      history: [],
+      runStream(): AsyncIterable<AgentEvent> {
+        return (async function* () {
+          yield { type: 'text_delta', delta: 'partial' } as AgentEvent;
+          throw new Error('boom');
+        })();
+      },
+    } as unknown as Conversation;
+    created.push(erroringConv);
+    const runner = {
+      conversation: vi.fn(() => created[0]),
+    } as unknown as AgentRunner;
+    const onConversationChange = vi.fn();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AgentProvider
+        runner={runner}
+        agent={agentConfig}
+        onConversationChange={onConversationChange}
+      >
+        {children}
+      </AgentProvider>
+    );
+    const { result } = renderHook(() => useAgent(), { wrapper });
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(onConversationChange).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onConversationChange when the run is cancelled before `done`', async () => {
+    const cancellableConv: Conversation = {
+      history: [],
+      runStream(_input: string, signal?: AbortSignal): AsyncIterable<AgentEvent> {
+        async function* gen() {
+          await new Promise<never>((_, reject) => {
+            signal?.addEventListener('abort', () => reject(new Error('Aborted')));
+          });
+          yield { type: 'done', output: '', history: [] } as AgentEvent;
+        }
+        return gen();
+      },
+    } as unknown as Conversation;
+    const runner = {
+      conversation: vi.fn(() => cancellableConv),
+    } as unknown as AgentRunner;
+    const onConversationChange = vi.fn();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AgentProvider
+        runner={runner}
+        agent={agentConfig}
+        onConversationChange={onConversationChange}
+      >
+        {children}
+      </AgentProvider>
+    );
+    const { result } = renderHook(() => useAgent(), { wrapper });
+
+    act(() => {
+      result.current.sendMessage('hi');
+    });
+    // Flush the microtask that registers the abort listener.
+    await act(async () => {});
+
+    act(() => {
+      result.current.cancel();
+    });
+    await act(async () => {});
+
+    expect(result.current.isRunning).toBe(false);
+    expect(onConversationChange).not.toHaveBeenCalled();
+  });
+
+  it('seeds Conversation.history with initialHistory before the first run', async () => {
+    const seeded: Message[] = [userMessage('previous question'), assistantMessage('prior answer')];
+    const finalHistory: Message[] = [
+      ...seeded,
+      userMessage('next'),
+      assistantMessage('next answer'),
+    ];
+    const { runner, created, runStreamSpy } = makeMockRunner([
+      { type: 'done', output: 'next answer', history: finalHistory },
+    ]);
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AgentProvider runner={runner} agent={agentConfig} initialHistory={seeded}>
+        {children}
+      </AgentProvider>
+    );
+    const { result } = renderHook(() => useAgent(), { wrapper });
+
+    // Conversation.history is seeded immediately on mount.
+    expect(created).toHaveLength(1);
+    expect(created[0].history).toEqual(seeded);
+
+    // The seeded history is also reflected via useAgent().history before any run.
+    expect(result.current.history).toEqual(seeded);
+
+    // Sending a message forwards the seeded history into the runner.
+    await act(async () => {
+      result.current.sendMessage('next');
+    });
+
+    expect(runStreamSpy).toHaveBeenCalledTimes(1);
+    const [, historyAtRunStart] = runStreamSpy.mock.calls[0] as [string, Message[]];
+    expect(historyAtRunStart).toEqual(seeded);
+
+    // After the turn completes, useAgent().history reflects event.history.
+    expect(result.current.history).toEqual(finalHistory);
+  });
+
+  it('seeds messages from initialEntries on mount', () => {
+    const initialEntries: ConversationEntry[] = [
+      {
+        id: 'u-1',
+        role: 'user',
+        text: 'previously',
+        toolEvents: [],
+        isStreaming: false,
+      },
+      {
+        id: 'a-1',
+        role: 'assistant',
+        text: 'previously answered',
+        toolEvents: [],
+        isStreaming: false,
+      },
+    ];
+    const { runner } = makeMockRunner();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AgentProvider runner={runner} agent={agentConfig} initialEntries={initialEntries}>
+        {children}
+      </AgentProvider>
+    );
+    const { result } = renderHook(() => useAgent(), { wrapper });
+
+    expect(result.current.messages).toEqual(initialEntries);
+  });
+
+  it('reset() clears both messages and history', async () => {
+    const finalHistory: Message[] = [userMessage('hi'), assistantMessage('Hi back')];
+    const { runner } = makeMockRunner([{ type: 'done', output: 'Hi back', history: finalHistory }]);
+    const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.history).toEqual(finalHistory);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.history).toEqual([]);
+  });
+
+  it('useAgent().history reflects the latest core history after each turn', async () => {
+    const firstHistory: Message[] = [userMessage('one'), assistantMessage('first')];
+    const secondHistory: Message[] = [
+      ...firstHistory,
+      userMessage('two'),
+      assistantMessage('second'),
+    ];
+    let scriptedHistory = firstHistory;
+    const created: Conversation[] = [];
+    const runner = {
+      conversation: vi.fn(() => {
+        const conv = {
+          history: [] as Message[],
+          runStream(): AsyncIterable<AgentEvent> {
+            const out = scriptedHistory;
+            return (async function* () {
+              yield { type: 'done', output: 'ok', history: out } as AgentEvent;
+            })();
+          },
+        } as unknown as Conversation;
+        created.push(conv);
+        return conv;
+      }),
+    } as unknown as AgentRunner;
+
+    const { result } = renderHook(() => useAgent(), { wrapper: makeWrapper(runner) });
+
+    expect(result.current.history).toEqual([]);
+
+    await act(async () => {
+      result.current.sendMessage('one');
+    });
+    expect(result.current.history).toEqual(firstHistory);
+
+    scriptedHistory = secondHistory;
+    await act(async () => {
+      result.current.sendMessage('two');
+    });
+    expect(result.current.history).toEqual(secondHistory);
   });
 });

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -4,7 +4,7 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { AgentRunner } from '@mast-ai/core';
-import type { AgentConfig, Conversation } from '@mast-ai/core';
+import type { AgentConfig, Conversation, Message } from '@mast-ai/core';
 
 import { useAgentStream } from './hooks/useAgentStream';
 import { IconProvider } from './icons';
@@ -53,6 +53,24 @@ export interface AgentProviderProps {
    * @example ['third_party_tool', '!safe_tool']
    */
   approvalOverride?: string[];
+  /**
+   * Seed `Conversation.history` with previously-saved messages so the LLM
+   * continues from where it left off. Read once when the provider mounts;
+   * later changes have no effect until `reset()` is called.
+   */
+  initialHistory?: Message[];
+  /**
+   * Seed the rendered entry list with previously-saved entries so existing
+   * turns render immediately on mount. Read once when the provider mounts.
+   */
+  initialEntries?: ConversationEntry[];
+  /**
+   * Called after each completed turn (i.e. after a `done` event) with the
+   * latest core message history and UI entry list. Use this to persist the
+   * conversation to localStorage, IndexedDB, a server, etc. Not invoked when
+   * a run is cancelled or errors before completion.
+   */
+  onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
 }
 
 /**
@@ -61,6 +79,12 @@ export interface AgentProviderProps {
 export interface UseAgentReturn {
   /** Ordered conversation entries, suitable for rendering. */
   messages: ConversationEntry[];
+  /**
+   * Live mirror of the underlying `Conversation.history` — the raw core
+   * `Message[]` sent to the LLM. Updated after every completed turn. Read
+   * this to imperatively persist conversation state.
+   */
+  history: Message[];
   /** Sends a user message and starts a new agent run. */
   sendMessage: (text: string) => void;
   /** Aborts the current run, if any. */
@@ -99,7 +123,17 @@ export function AgentProvider({
   icons,
   onApprovalRequired,
   approvalOverride,
+  initialHistory,
+  initialEntries,
+  onConversationChange,
 }: AgentProviderProps) {
+  const onConversationChangeRef = useRef(onConversationChange);
+  onConversationChangeRef.current = onConversationChange;
+  // Captured once; later changes to initialHistory/initialEntries don't reseed
+  // an in-progress conversation. Callers who need to swap conversations should
+  // call `reset()` and remount the provider with new initial values.
+  const initialHistoryRef = useRef(initialHistory);
+  const initialEntriesRef = useRef(initialEntries);
   // Refs let the approval proxy read the latest callback and override on each
   // tool invocation without rebuilding the wrapped runner on every render.
   const onApprovalRef = useRef(onApprovalRequired);
@@ -135,19 +169,34 @@ export function AgentProvider({
     return new AgentRunner(runner.adapter, provider);
   }, [runner, onApprovalRequired, approvalOverride]);
 
-  const [conversation, setConversation] = useState<Conversation>(() =>
-    wrappedRunner.conversation(agent),
+  const [conversation, setConversation] = useState<Conversation>(() => {
+    const conv = wrappedRunner.conversation(agent);
+    if (initialHistoryRef.current && initialHistoryRef.current.length > 0) {
+      conv.history = [...initialHistoryRef.current];
+    }
+    return conv;
+  });
+
+  const onTurnComplete = useCallback(
+    (committedEntries: ConversationEntry[], committedHistory: Message[]) => {
+      onConversationChangeRef.current?.(committedHistory, committedEntries);
+    },
+    [],
   );
 
   const {
     entries,
+    history,
     sendMessage,
     cancel,
     isRunning,
     reset: resetStream,
     setToolAwaitingApproval,
     setToolStatus,
-  } = useAgentStream(conversation);
+  } = useAgentStream(conversation, {
+    initialEntries: initialEntriesRef.current,
+    onTurnComplete,
+  });
   notifyAwaitingRef.current = setToolAwaitingApproval;
   setStatusRef.current = setToolStatus;
 
@@ -183,8 +232,16 @@ export function AgentProvider({
   }, [resetStream, wrappedRunner, agent]);
 
   const value = useMemo<UseAgentReturn>(
-    () => ({ messages: entries, sendMessage, cancel, isRunning, reset, pendingApprovals }),
-    [entries, sendMessage, cancel, isRunning, reset, pendingApprovals],
+    () => ({
+      messages: entries,
+      history,
+      sendMessage,
+      cancel,
+      isRunning,
+      reset,
+      pendingApprovals,
+    }),
+    [entries, history, sendMessage, cancel, isRunning, reset, pendingApprovals],
   );
 
   return (

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useCallback, useRef } from 'react';
-import type { Conversation } from '@mast-ai/core';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { Conversation, Message } from '@mast-ai/core';
 import type { AgentEvent } from '@mast-ai/core';
 import type { ConversationEntry, ToolCallStatus, ToolEventEntry } from '../types';
 
@@ -59,6 +59,25 @@ function updateToolEvent(
 // ---------------------------------------------------------------------------
 
 /**
+ * Options accepted by {@link useAgentStream}.
+ */
+export interface UseAgentStreamOptions {
+  /**
+   * Initial UI entry list. Used to restore a previously-saved conversation
+   * so existing turns render immediately on mount. Read once when the hook
+   * first initialises; changes to this prop after mount are ignored.
+   */
+  initialEntries?: ConversationEntry[];
+
+  /**
+   * Called after a turn ends with the `done` event, with the freshly
+   * committed `entries` and `history`. Not called when a run is cancelled
+   * or errors before `done` is received.
+   */
+  onTurnComplete?: (entries: ConversationEntry[], history: Message[]) => void;
+}
+
+/**
  * The value returned by {@link useAgentStream}.
  */
 export interface UseAgentStreamReturn {
@@ -69,6 +88,13 @@ export interface UseAgentStreamReturn {
    * stable across renders.
    */
   entries: ConversationEntry[];
+
+  /**
+   * Live mirror of the underlying `Conversation.history`. Initialised from
+   * `conversation.history` and updated to `event.history` whenever a `done`
+   * event is observed. Use this to imperatively persist conversation state.
+   */
+  history: Message[];
 
   /**
    * `true` while the agent is generating a response; `false` otherwise.
@@ -163,10 +189,28 @@ export interface UseAgentStreamReturn {
  * const { entries, sendMessage, cancel, isRunning } = useAgentStream(conversation);
  * ```
  */
-export function useAgentStream(conversation: Conversation): UseAgentStreamReturn {
-  const [entries, setEntries] = useState<ConversationEntry[]>([]);
+export function useAgentStream(
+  conversation: Conversation,
+  options?: UseAgentStreamOptions,
+): UseAgentStreamReturn {
+  const [entries, setEntries] = useState<ConversationEntry[]>(() => options?.initialEntries ?? []);
+  const [history, setHistory] = useState<Message[]>(() => [...conversation.history]);
   const [isRunning, setIsRunning] = useState(false);
+  // Bumped after every `done` event to trigger the onTurnComplete effect once
+  // the new entries and history have been committed by React.
+  const [completedTurnId, setCompletedTurnId] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
+
+  const onTurnCompleteRef = useRef(options?.onTurnComplete);
+  onTurnCompleteRef.current = options?.onTurnComplete;
+
+  // Effect intentionally depends only on completedTurnId — it ticks atomically
+  // with the state updates from the `done` event, and we do not want it to
+  // fire on intermediate streaming updates to entries/history.
+  useEffect(() => {
+    if (completedTurnId === 0) return;
+    onTurnCompleteRef.current?.(entries, history);
+  }, [completedTurnId]);
 
   const findStreamingAssistantId = (entries: ConversationEntry[]): string | undefined => {
     for (let i = entries.length - 1; i >= 0; i--) {
@@ -277,6 +321,7 @@ export function useAgentStream(conversation: Conversation): UseAgentStreamReturn
                 })),
               );
             } else if (event.type === 'done') {
+              const finalHistory = event.history;
               setEntries((prev) =>
                 updateEntry(prev, assistantId, (e) => ({
                   ...e,
@@ -284,6 +329,8 @@ export function useAgentStream(conversation: Conversation): UseAgentStreamReturn
                   isStreaming: false,
                 })),
               );
+              setHistory(finalHistory);
+              setCompletedTurnId((n) => n + 1);
             }
           }
         } catch {
@@ -308,11 +355,13 @@ export function useAgentStream(conversation: Conversation): UseAgentStreamReturn
     abortRef.current?.abort();
     abortRef.current = null;
     setEntries([]);
+    setHistory([]);
     setIsRunning(false);
   }, []);
 
   return {
     entries,
+    history,
     isRunning,
     sendMessage,
     cancel,

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -3,7 +3,7 @@
 
 export type { ConversationEntry, ToolEventEntry, ToolCallStatus, IconMap } from './types';
 export { useAgentStream } from './hooks/useAgentStream';
-export type { UseAgentStreamReturn } from './hooks/useAgentStream';
+export type { UseAgentStreamOptions, UseAgentStreamReturn } from './hooks/useAgentStream';
 export { AgentProvider, useAgent } from './context';
 export type { AgentProviderProps, UseAgentReturn } from './context';
 export { INLINE_APPROVAL } from './approval';


### PR DESCRIPTION
## Summary

- Adds `initialHistory`, `initialEntries`, and `onConversationChange` props to `<AgentProvider>` so consumers can save and restore conversations through any storage backend.
- Exposes `history: Message[]` on `useAgent()`, mirroring the underlying `Conversation.history` and updated after every completed turn.
- `useAgentStream` accepts a new options arg (`initialEntries`, `onTurnComplete`); a `completedTurnId` counter ticks atomically with the `done` state updates so `onTurnComplete` fires exactly once per completed turn (never on cancel or error).
- Wires `apps/demo-react-ui` to `localStorage`: a left sidebar lists every saved conversation with delete buttons, the most recent is auto-loaded on page load, and switching conversations remounts the provider via a `key` keyed on the active id.
- 5 new tests in `context.test.tsx` cover the SPEC §11.2 persistence scenarios; total suite is 91 passing.

Closes #44

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test --workspaces`
- [x] Manual: send a message, refresh the page, see conversation restored in sidebar
- [x] Manual: switch between saved conversations
- [x] Manual: delete a conversation
- [x] Manual: "New conversation" starts fresh; conversation only enters list after first completed turn