### PR TITLE
feat(react-ui): sendMessage(text, displayText?) overload

### DIFF
--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -85,8 +85,12 @@ export interface UseAgentReturn {
    * this to imperatively persist conversation state.
    */
   history: Message[];
-  /** Sends a user message and starts a new agent run. */
-  sendMessage: (text: string) => void;
+  /**
+   * Sends a user message and starts a new agent run. The first argument is
+   * the prompt delivered to the LLM. The optional second argument overrides
+   * what is rendered in the user bubble; when omitted, the prompt is shown.
+   */
+  sendMessage: (text: string, displayText?: string) => void;
   /** Aborts the current run, if any. */
   cancel: () => void;
   /** `true` while a run is in progress. */

--- a/packages/react-ui/src/hooks/useAgentStream.test.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.test.ts
@@ -564,6 +564,85 @@ describe('useAgentStream', () => {
     expect(result.current.entries[1].text).toBe('First');
   });
 
+  // -------------------------------------------------------------------------
+  // displayText override
+  // -------------------------------------------------------------------------
+
+  it('uses the prompt as the user bubble text when no displayText is given', async () => {
+    const promptCalls: string[] = [];
+    const conv = {
+      history: [],
+      runStream(input: string): AsyncIterable<AgentEvent> {
+        promptCalls.push(input);
+        return (async function* () {
+          yield { type: 'done', output: 'ok', history: [] };
+        })();
+      },
+    } as unknown as Conversation;
+
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('Hello world');
+    });
+
+    expect(promptCalls).toEqual(['Hello world']);
+    expect(result.current.entries[0]).toMatchObject({
+      role: 'user',
+      text: 'Hello world',
+    });
+  });
+
+  it('uses displayText for the user bubble while the runner receives the prompt', async () => {
+    const promptCalls: string[] = [];
+    const conv = {
+      history: [],
+      runStream(input: string): AsyncIterable<AgentEvent> {
+        promptCalls.push(input);
+        return (async function* () {
+          yield { type: 'done', output: 'ok', history: [] };
+        })();
+      },
+    } as unknown as Conversation;
+
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('Summarize the active document.', '/summarize');
+    });
+
+    expect(promptCalls).toEqual(['Summarize the active document.']);
+    expect(result.current.entries[0]).toMatchObject({
+      role: 'user',
+      text: '/summarize',
+    });
+  });
+
+  it('treats empty-string displayText as a deliberate override', async () => {
+    const promptCalls: string[] = [];
+    const conv = {
+      history: [],
+      runStream(input: string): AsyncIterable<AgentEvent> {
+        promptCalls.push(input);
+        return (async function* () {
+          yield { type: 'done', output: 'ok', history: [] };
+        })();
+      },
+    } as unknown as Conversation;
+
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('hidden prompt', '');
+    });
+
+    expect(promptCalls).toEqual(['hidden prompt']);
+    expect(result.current.entries[0]).toMatchObject({
+      role: 'user',
+      text: '',
+    });
+  });
+
   it('assigns stable unique ids to every entry', async () => {
     const conv = mockConversation([{ type: 'done', output: 'ok', history: [] }]);
     const { result } = renderHook(() => useAgentStream(conv));

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -112,9 +112,14 @@ export interface UseAgentStreamReturn {
    * progress is a no-op (the caller should disable the input while `isRunning`
    * is true).
    *
-   * @param text - The user's message text.
+   * @param text - The prompt sent to the LLM via `Conversation.runStream`.
+   * @param displayText - Optional override for the text rendered in the user
+   *   bubble. When provided, the user `ConversationEntry.text` is set to this
+   *   value while `text` is still passed unchanged to the runner. An empty
+   *   string is treated as a deliberate override (it does not fall back to
+   *   `text`).
    */
-  sendMessage: (text: string) => void;
+  sendMessage: (text: string, displayText?: string) => void;
 
   /**
    * Aborts the current run.
@@ -240,10 +245,12 @@ export function useAgentStream(
   }, []);
 
   const sendMessage = useCallback(
-    (text: string) => {
+    (text: string, displayText?: string) => {
       if (isRunning) return;
 
-      const userEntry = makeEntry('user', text, false);
+      // `??` (not `||`) so an explicit empty-string displayText is respected as
+      // a deliberate override rather than collapsing back to `text`.
+      const userEntry = makeEntry('user', displayText ?? text, false);
       const assistantEntry = makeEntry('assistant', '', true);
       const assistantId = assistantEntry.id;
 


### PR DESCRIPTION
## Summary

- Extends `useAgent().sendMessage` to accept an optional `displayText` second argument: the user bubble shows `displayText ?? text` while the prompt sent to `Conversation.runStream` stays as `text`.
- Empty-string `displayText` is treated as a deliberate override (uses `??`, not `||`), so a caller can hide the bubble entirely while still driving the LLM with a non-empty prompt.
- Threaded through `useAgentStream` and `UseAgentReturn`; SPEC §5/§8/§13.6 already describe this behaviour, no doc changes needed.

Unblocks the slash-command, redaction, and `@`-mention pipeline use cases described in the issue.

Closes #62

## Test plan

- [x] `npm test` (94 tests pass in `@mast-ai/react-ui`, full workspace suite green)
- [x] `npm run lint`, `npm run format`, `npm run build`
- [x] New unit tests cover: single-arg call (bubble == prompt), two-arg call (bubble == displayText, runner receives prompt), empty-string `displayText` (bubble cleared, runner still receives prompt)
- [x] Manually verified existing demo-react-ui flow is unchanged