### PR TITLE
feat(react-ui): @-mention picker for ChatInput

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -14,6 +14,7 @@ import {
   useAgent,
   type ConversationEntry,
   type IconMap,
+  type MentionsConfig,
   type OnApprovalRequired,
   type PendingApproval,
   type ToolEventEntry,
@@ -34,7 +35,10 @@ import {
   GetCurrentTimeTool,
   GetPageTitleTool,
   ParseIntegerTool,
+  ReadDocTool,
   SetPageTitleTool,
+  demoDocs,
+  type DemoDoc,
 } from './tools';
 
 const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
@@ -47,7 +51,8 @@ const registry = new ToolRegistry()
   .register(new GetPageTitleTool())
   .register(new SetPageTitleTool())
   .register(new CopyToClipboardTool())
-  .register(new ParseIntegerTool());
+  .register(new ParseIntegerTool())
+  .register(new ReadDocTool());
 const runner = new AgentRunner(new GoogleGenAIAdapter(apiKey ?? ''), registry);
 
 const agentConfig = createAgent({
@@ -58,13 +63,17 @@ const agentConfig = createAgent({
     'Use the get_page_title tool when the user asks for the page title. ' +
     'Use the set_page_title tool when the user asks to change or set the page title. ' +
     'Use the copy_to_clipboard tool when the user asks to copy something to the clipboard. ' +
-    'Use the parse_integer tool when the user asks to parse a string as an integer.',
+    'Use the parse_integer tool when the user asks to parse a string as an integer. ' +
+    'When a user message starts with "The user has referenced the following documents:", ' +
+    'call the read_doc tool with each listed id to fetch its contents before answering. ' +
+    'Do not assume document contents from the title alone.',
   tools: [
     'get_current_time',
     'get_page_title',
     'set_page_title',
     'copy_to_clipboard',
     'parse_integer',
+    'read_doc',
   ],
 });
 
@@ -77,6 +86,27 @@ const icons: IconMap = {
   loader: <LoaderCircle size={16} className="mast-spin" />,
   send: <Send size={16} />,
   stop: <Square size={16} />,
+};
+
+// ---------------------------------------------------------------------------
+// Mention pipeline demo
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds an augmented prompt that lists referenced documents by id and
+ * title only, leaving the bodies for the agent to fetch on demand via the
+ * `read_doc` tool. This shrinks the per-turn prompt and exercises the
+ * displayText/prompt split: the user bubble shows `@Roadmap` while the
+ * LLM sees the id-only preamble.
+ */
+const mentionsConfig: MentionsConfig<DemoDoc> = {
+  items: demoDocs,
+  buildPrompt: (segments, trailing) => {
+    const inline = segments.map((s) => `${s.text}@${s.item.label}`).join('') + trailing;
+    if (segments.length === 0) return inline;
+    const refs = segments.map((s) => `- "${s.item.label}" (id: ${s.item.id})`).join('\n');
+    return `The user has referenced the following documents:\n${refs}\n\n${inline}`;
+  },
 };
 
 type ThemeChoice = 'system' | 'light' | 'dark';
@@ -400,7 +430,12 @@ export default function App() {
             <div className="demo-main-header">
               <PendingApprovalsBadge />
             </div>
-            <ConversationPanel theme={panelTheme} renderToolCall={renderToolCall} />
+            <ConversationPanel
+              theme={panelTheme}
+              renderToolCall={renderToolCall}
+              mentions={mentionsConfig as MentionsConfig}
+              inputPlaceholder="Type @ to reference a doc, then press Enter."
+            />
           </AgentProvider>
         </main>
       </div>

--- a/apps/demo-react-ui/src/tools.ts
+++ b/apps/demo-react-ui/src/tools.ts
@@ -2,6 +2,92 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Tool, ToolContext } from '@mast-ai/core';
+import type { MentionItem } from '@mast-ai/react-ui';
+
+/** Payload attached to each `@`-mentionable doc in the demo. */
+export interface DemoDoc {
+  path: string;
+  body: string;
+}
+
+/**
+ * In-memory document set powering both the `@`-mention picker and the
+ * `read_doc` tool. The picker only sends document IDs to the LLM via
+ * `mentionsConfig.buildPrompt`; the agent fetches the body lazily by
+ * calling `read_doc(id)`. Keeping the source of truth here means the tool
+ * lookup and the picker can never go out of sync.
+ */
+export const demoDocs: MentionItem<DemoDoc>[] = [
+  {
+    id: 'doc-roadmap',
+    label: 'Roadmap',
+    description: 'Q2 product roadmap',
+    data: {
+      path: 'docs/roadmap.md',
+      body: 'Q2 focus: stabilise the React UI surface and ship a packaged demo.',
+    },
+  },
+  {
+    id: 'doc-style-guide',
+    label: 'Style Guide',
+    description: 'Writing and code style',
+    data: {
+      path: 'docs/style.md',
+      body: 'Prefer short sentences. Avoid em dashes; prefer commas, colons, or parentheses.',
+    },
+  },
+  {
+    id: 'doc-meeting-notes',
+    label: 'Meeting Notes',
+    description: 'Last week with the design team',
+    data: {
+      path: 'docs/meetings/2026-04-29.md',
+      body: 'Decisions: ship the mention picker behind an opt-in flag; revisit theming next sprint.',
+    },
+  },
+];
+
+interface ReadDocArgs {
+  id: string;
+}
+
+/**
+ * Looks up a doc body by id from {@link demoDocs}. Used by the agent to
+ * resolve `@`-mentioned references on demand instead of receiving every
+ * doc body inlined into the prompt — the realistic pattern for non-trivial
+ * documents.
+ */
+export class ReadDocTool implements Tool<ReadDocArgs, string> {
+  definition() {
+    return {
+      name: 'read_doc',
+      description:
+        'Returns the contents of a referenced document by its id. Use the ids from any "The user has referenced..." preamble in the user message.',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'The document id, e.g. "doc-roadmap".',
+          },
+        },
+        required: ['id'],
+      },
+      scope: 'read' as const,
+    };
+  }
+
+  async call(args: ReadDocArgs, _context: ToolContext): Promise<string> {
+    const doc = demoDocs.find((d) => d.id === args.id);
+    if (!doc) throw new Error(`No document with id '${args.id}'.`);
+    return JSON.stringify({
+      id: doc.id,
+      title: doc.label,
+      path: doc.data?.path,
+      body: doc.data?.body,
+    });
+  }
+}
 
 /** Returns the current time as an ISO 8601 string. */
 export class GetCurrentTimeTool implements Tool {

--- a/packages/react-ui/src/components/ChatInput.tsx
+++ b/packages/react-ui/src/components/ChatInput.tsx
@@ -1,11 +1,14 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { Fragment, useId, useState } from 'react';
 import type { KeyboardEvent, ReactNode } from 'react';
 
 import { useAgent } from '../context';
 import { useIcons } from '../icons';
+import { MentionPicker } from '../mentions/MentionPicker';
+import { useMentions } from '../mentions/useMentions';
+import type { MentionsConfig } from '../mentions/types';
 
 /**
  * Props accepted by {@link ChatInput}.
@@ -19,6 +22,17 @@ export interface ChatInputProps {
   sendLabel?: ReactNode;
   /** Overrides the default cancel button content (the `stop` icon). */
   cancelLabel?: ReactNode;
+  /**
+   * Opt-in `@`-mention picker. When supplied, the textarea is wrapped in a
+   * compound input that renders inline chips for committed selections and
+   * shows a keyboard-navigable picker while the user types `@<query>`. On
+   * submit, the input calls `sendMessage(prompt, displayText)` so the user
+   * bubble shows the chip form while the LLM receives the augmented prompt
+   * (from `mentions.buildPrompt` if provided, otherwise the inline text).
+   *
+   * Omit to keep the plain textarea behaviour unchanged.
+   */
+  mentions?: MentionsConfig;
 }
 
 const MIN_ROWS = 1;
@@ -47,13 +61,45 @@ function rowsForText(text: string): number {
  * - Send and cancel slot their content from `useIcons().send` / `.stop` by
  *   default; consumers can override either via the `sendLabel` / `cancelLabel`
  *   props without giving up the surrounding accessibility wiring.
+ * - Pass `mentions` to enable the optional `@`-mention picker; see the
+ *   `mentions` package directory for the full API.
  */
 export function ChatInput({
   className,
   placeholder = 'Type a message and press Enter.',
   sendLabel,
   cancelLabel,
+  mentions,
 }: ChatInputProps) {
+  if (mentions) {
+    return (
+      <MentionsChatInput
+        className={className}
+        placeholder={placeholder}
+        sendLabel={sendLabel}
+        cancelLabel={cancelLabel}
+        mentions={mentions}
+      />
+    );
+  }
+  return (
+    <PlainChatInput
+      className={className}
+      placeholder={placeholder}
+      sendLabel={sendLabel}
+      cancelLabel={cancelLabel}
+    />
+  );
+}
+
+interface PlainChatInputProps {
+  className?: string;
+  placeholder: string;
+  sendLabel?: ReactNode;
+  cancelLabel?: ReactNode;
+}
+
+function PlainChatInput({ className, placeholder, sendLabel, cancelLabel }: PlainChatInputProps) {
   const { sendMessage, cancel, isRunning } = useAgent();
   const icons = useIcons();
   const [value, setValue] = useState('');
@@ -97,6 +143,150 @@ export function ChatInput({
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
       />
+      {isRunning ? (
+        <button
+          type="button"
+          className="mast-chat-input-cancel"
+          aria-label="Cancel"
+          onClick={cancel}
+        >
+          {cancelLabel ?? icons.stop}
+        </button>
+      ) : (
+        <button
+          type="submit"
+          className="mast-chat-input-send"
+          aria-label="Send"
+          disabled={!canSend}
+        >
+          {sendLabel ?? icons.send}
+        </button>
+      )}
+    </form>
+  );
+}
+
+interface MentionsChatInputProps extends PlainChatInputProps {
+  mentions: MentionsConfig;
+}
+
+/**
+ * Compound input variant rendered when `<ChatInput mentions>` is set.
+ *
+ * Layout: chips and the textarea share a single bordered surface so the
+ * inline form reads as one continuous field; the picker floats above on
+ * `position: absolute` while a query is in progress.
+ *
+ * Submit calls `sendMessage(prompt, displayText)` — the LLM sees `prompt`
+ * (from `buildPrompt` if provided, otherwise the inline form) while the
+ * user bubble renders `displayText` (always the inline form).
+ */
+function MentionsChatInput({
+  className,
+  placeholder,
+  sendLabel,
+  cancelLabel,
+  mentions,
+}: MentionsChatInputProps) {
+  const { sendMessage, cancel, isRunning } = useAgent();
+  const icons = useIcons();
+  const pickerIdPrefix = useId();
+  const {
+    segments,
+    trailingInput,
+    mentionQuery,
+    filteredItems,
+    pickerIndex,
+    setTrailingInput,
+    handleKeyDown: handleMentionKeyDown,
+    selectItem,
+    removeChip,
+    buildSubmission,
+    clear,
+  } = useMentions(mentions);
+
+  const rootClass = ['mast-chat-input', 'mast-mention-input', className].filter(Boolean).join(' ');
+  const hasContent = segments.length > 0 || trailingInput.trim().length > 0;
+  const canSend = !isRunning && hasContent;
+  const pickerOpen = mentionQuery !== null && filteredItems.length > 0;
+  const activeId = pickerOpen ? `${pickerIdPrefix}-${pickerIndex}` : undefined;
+
+  const submit = () => {
+    if (!canSend) return;
+    const { prompt, displayText } = buildSubmission();
+    if (!displayText.trim()) return;
+    sendMessage(prompt, displayText);
+    clear();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (handleMentionKeyDown(event)) return;
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <form
+      data-mast-chat-input
+      className={rootClass}
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <label className="mast-chat-input-label mast-visually-hidden" htmlFor="mast-chat-input-field">
+        Message
+      </label>
+      <div className="mast-mention-input-field">
+        {pickerOpen && (
+          <MentionPicker
+            items={filteredItems}
+            activeIndex={pickerIndex}
+            onSelect={selectItem}
+            idPrefix={pickerIdPrefix}
+            renderItem={mentions.renderItem}
+          />
+        )}
+        <div className="mast-mention-input-content">
+          {segments.map((segment) => (
+            <Fragment key={segment.item.id}>
+              {segment.text && <span className="mast-mention-segment-text">{segment.text}</span>}
+              {mentions.renderChip ? (
+                mentions.renderChip(segment.item, () => removeChip(segment.item.id))
+              ) : (
+                <span className="mast-mention-chip">
+                  @{segment.item.label}
+                  <button
+                    type="button"
+                    className="mast-mention-chip-remove"
+                    aria-label={`Remove reference to ${segment.item.label}`}
+                    onClick={() => removeChip(segment.item.id)}
+                  >
+                    ×
+                  </button>
+                </span>
+              )}
+            </Fragment>
+          ))}
+          <textarea
+            id="mast-chat-input-field"
+            className="mast-chat-input-textarea mast-mention-input-textarea"
+            value={trailingInput}
+            placeholder={segments.length === 0 ? placeholder : ''}
+            rows={rowsForText(trailingInput)}
+            disabled={isRunning}
+            onChange={(event) => setTrailingInput(event.target.value)}
+            onKeyDown={handleKeyDown}
+            role="combobox"
+            aria-expanded={pickerOpen}
+            aria-controls={pickerOpen ? `${pickerIdPrefix}-listbox` : undefined}
+            aria-autocomplete="list"
+            aria-activedescendant={activeId}
+          />
+        </div>
+      </div>
       {isRunning ? (
         <button
           type="button"

--- a/packages/react-ui/src/components/ChatInputMentions.test.tsx
+++ b/packages/react-ui/src/components/ChatInputMentions.test.tsx
@@ -1,0 +1,317 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
+
+import { AgentProvider, useAgent } from '../context';
+import { ChatInput } from './ChatInput';
+import type { MentionItem, MentionsConfig } from '../mentions/types';
+
+/** Inline spy that surfaces user-bubble text to the DOM for assertions. */
+function MessagesSpy() {
+  const { messages } = useAgent();
+  return (
+    <ul data-testid="messages-spy">
+      {messages.map((m) => (
+        <li key={m.id} data-role={m.role}>
+          {m.text}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+interface MockRunnerOptions {
+  events?: AgentEvent[];
+  hang?: boolean;
+}
+
+function makeMockRunner({ events, hang }: MockRunnerOptions = {}): AgentRunner {
+  const stream = (signal: AbortSignal | undefined): AsyncIterable<AgentEvent> =>
+    (async function* () {
+      const yielded: AgentEvent[] = events ?? [{ type: 'done', output: 'ok', history: [] }];
+      for (const event of yielded) yield event;
+      if (hang) {
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+    })();
+
+  const conversation: Conversation = {
+    history: [],
+    runStream: vi.fn((_text: string, signal?: AbortSignal) => stream(signal)),
+  } as unknown as Conversation;
+
+  return {
+    conversation: vi.fn(() => conversation),
+  } as unknown as AgentRunner;
+}
+
+const agentConfig: AgentConfig = {
+  name: 'TestAgent',
+  instructions: 'A test agent.',
+};
+
+function renderWithProvider(runner: AgentRunner, child: ReactNode) {
+  return render(
+    <AgentProvider runner={runner} agent={agentConfig}>
+      {child}
+    </AgentProvider>,
+  );
+}
+
+interface DocPayload {
+  path: string;
+}
+
+const items: MentionItem<DocPayload>[] = [
+  { id: '1', label: 'README', data: { path: 'README.md' } },
+  { id: '2', label: 'CHANGELOG', data: { path: 'CHANGELOG.md' } },
+];
+
+describe('<ChatInput mentions>', () => {
+  beforeEach(() => {
+    // Some tests intentionally leave the runner hanging; suppress act warnings.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the picker when the user types `@`', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox');
+    await user.type(textarea, 'hello @');
+
+    const listbox = screen.getByRole('listbox', { name: 'Mention picker' });
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toContain('README');
+    expect(options[1].textContent).toContain('CHANGELOG');
+  });
+
+  it('selects a chip on Enter and renders the chip in the compound input', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    const { container } = renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox') as HTMLTextAreaElement;
+    await user.type(textarea, 'hi @');
+    // Picker is open with all items; press Enter to select the active row.
+    await user.keyboard('{Enter}');
+
+    const chip = container.querySelector('.mast-mention-chip');
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain('@README');
+    expect(textarea.value).toBe('');
+    // After selecting, the picker is closed.
+    expect(screen.queryByRole('listbox', { name: 'Mention picker' })).toBeNull();
+  });
+
+  it('navigates the picker with ArrowDown / ArrowUp and exposes aria-activedescendant', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox') as HTMLTextAreaElement;
+    await user.type(textarea, '@');
+
+    const listbox = screen.getByRole('listbox', { name: 'Mention picker' });
+    const options = within(listbox).getAllByRole('option');
+    expect(textarea.getAttribute('aria-activedescendant')).toBe(options[0].id);
+
+    await user.keyboard('{ArrowDown}');
+    expect(textarea.getAttribute('aria-activedescendant')).toBe(options[1].id);
+    expect(options[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('Escape closes the picker without selecting', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    const { container } = renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox');
+    await user.type(textarea, '@');
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('listbox', { name: 'Mention picker' })).toBeNull();
+    expect(container.querySelectorAll('.mast-mention-chip')).toHaveLength(0);
+  });
+
+  it('removeChip merges the segment text into the trailing input', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    const { container } = renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox') as HTMLTextAreaElement;
+    await user.type(textarea, 'hello @');
+    await user.keyboard('{Enter}');
+    await user.type(textarea, ' world');
+
+    const removeButton = screen.getByRole('button', { name: 'Remove reference to README' });
+    await user.click(removeButton);
+
+    expect(container.querySelectorAll('.mast-mention-chip')).toHaveLength(0);
+    // Segment text "hello " plus trailing input " world" → "hello  world"
+    // (the user's input verbatim, minus the chip).
+    expect(textarea.value).toBe('hello  world');
+  });
+
+  it('submits with sendMessage(prompt, displayText) using buildPrompt when supplied', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    const buildPrompt: NonNullable<MentionsConfig<DocPayload>['buildPrompt']> = (
+      segments,
+      trailing,
+    ) =>
+      `Refs: ${segments.map((s) => `${s.item.label}#${s.item.id}`).join(', ')}\n\n` +
+      segments.map((s) => `${s.text}@${s.item.label}`).join('') +
+      trailing;
+
+    renderWithProvider(
+      runner,
+      <>
+        <MessagesSpy />
+        <ChatInput mentions={{ items, buildPrompt } as MentionsConfig} />
+      </>,
+    );
+
+    const textarea = screen.getByRole('combobox') as HTMLTextAreaElement;
+    await user.type(textarea, 'hi @');
+    await user.keyboard('{Enter}');
+    await user.type(textarea, ' there');
+    await user.keyboard('{Enter}');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect(conversation.runStream).toHaveBeenCalledTimes(1);
+    const promptArg = (conversation.runStream as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(promptArg).toBe('Refs: README#1\n\nhi @README there');
+
+    // The user bubble shows the inline displayText, not the augmented prompt.
+    const userBubble = await screen.findByText('hi @README there');
+    expect(userBubble.getAttribute('data-role')).toBe('user');
+    // The chip+textarea cleared after submit.
+    expect(textarea.value).toBe('');
+  });
+
+  it('falls back to the inline form for both prompt and displayText when buildPrompt is omitted', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox');
+    await user.type(textarea, 'check @');
+    await user.keyboard('{Enter}');
+    await user.type(textarea, '!');
+    await user.keyboard('{Enter}');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect((conversation.runStream as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'check @README!',
+    );
+  });
+
+  it('keeps the plain textarea behaviour when `mentions` is omitted', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput />);
+
+    // Without `mentions`, the input is a plain textarea — no combobox role.
+    expect(screen.queryByRole('combobox')).toBeNull();
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'plain @text and Enter');
+    await user.keyboard('{Enter}');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect(conversation.runStream).toHaveBeenCalledTimes(1);
+    expect((conversation.runStream as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'plain @text and Enter',
+    );
+  });
+
+  it('does not submit on Enter while the picker is open with no matches', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    renderWithProvider(runner, <ChatInput mentions={{ items }} />);
+
+    const textarea = screen.getByRole('combobox');
+    // `@nope` has no matches, so the picker hides — but Enter still submits
+    // because the picker isn't consuming keys when filteredItems is empty.
+    await user.type(textarea, 'hi @');
+    // Open with matches, press Enter to commit a chip.
+    await user.keyboard('{Enter}');
+    // Now type @nope which produces no matches.
+    await user.type(textarea, ' more @nope');
+    await user.keyboard('{Enter}');
+
+    const conversation = (runner.conversation as ReturnType<typeof vi.fn>).mock.results[0]
+      .value as Conversation;
+    expect(conversation.runStream).toHaveBeenCalledTimes(1);
+    expect((conversation.runStream as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      'hi @README more @nope',
+    );
+  });
+
+  it('renders the chip via a custom renderChip when supplied', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    const renderChip: NonNullable<MentionsConfig<DocPayload>['renderChip']> = (item, onRemove) => (
+      <span data-testid="custom-chip">
+        custom:{item.label}
+        <button type="button" onClick={onRemove} aria-label={`Drop ${item.label}`}>
+          drop
+        </button>
+      </span>
+    );
+
+    renderWithProvider(runner, <ChatInput mentions={{ items, renderChip } as MentionsConfig} />);
+
+    const textarea = screen.getByRole('combobox');
+    await user.type(textarea, '@');
+    await user.keyboard('{Enter}');
+
+    const chip = screen.getByTestId('custom-chip');
+    expect(chip.textContent).toContain('custom:README');
+    expect(screen.getByRole('button', { name: 'Drop README' })).toBeDefined();
+  });
+
+  it('renders picker rows via a custom renderItem when supplied', async () => {
+    const user = userEvent.setup();
+    const runner = makeMockRunner();
+    const renderItem: NonNullable<MentionsConfig<DocPayload>['renderItem']> = (item, isActive) => (
+      <span data-testid={`custom-item-${item.id}`} data-active={isActive ? 'true' : 'false'}>
+        {item.label}/{item.data?.path}
+      </span>
+    );
+
+    renderWithProvider(runner, <ChatInput mentions={{ items, renderItem } as MentionsConfig} />);
+
+    const textarea = screen.getByRole('combobox');
+    await user.type(textarea, '@');
+
+    const customRow = screen.getByTestId('custom-item-1');
+    expect(customRow.textContent).toBe('README/README.md');
+    expect(customRow.getAttribute('data-active')).toBe('true');
+  });
+});

--- a/packages/react-ui/src/components/ConversationPanel.tsx
+++ b/packages/react-ui/src/components/ConversationPanel.tsx
@@ -4,6 +4,7 @@
 import type { ReactNode } from 'react';
 
 import type { PendingApproval } from '../approval';
+import type { MentionsConfig } from '../mentions/types';
 import type { ToolEventEntry } from '../types';
 import { ChatInput } from './ChatInput';
 import { MessageList } from './MessageList';
@@ -30,6 +31,11 @@ export interface ConversationPanelProps {
   renderMessage?: (text: string) => ReactNode;
   /** Placeholder text for the {@link ChatInput} field. */
   inputPlaceholder?: string;
+  /**
+   * Forwarded to the internal {@link ChatInput} when the optional `@`-mention
+   * picker should be enabled. Omit to keep the plain textarea behaviour.
+   */
+  mentions?: MentionsConfig;
 }
 
 /**
@@ -48,13 +54,14 @@ export function ConversationPanel({
   renderToolCall,
   renderMessage,
   inputPlaceholder,
+  mentions,
 }: ConversationPanelProps) {
   const rootClass = ['mast-conversation-panel', className].filter(Boolean).join(' ');
 
   return (
     <div data-mast-root data-mast-theme={theme} className={rootClass}>
       <MessageList renderToolCall={renderToolCall} renderMessage={renderMessage} />
-      <ChatInput placeholder={inputPlaceholder} />
+      <ChatInput placeholder={inputPlaceholder} mentions={mentions} />
     </div>
   );
 }

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -26,3 +26,11 @@ export { MessageList } from './components/MessageList';
 export type { MessageListProps } from './components/MessageList';
 export { ConversationPanel } from './components/ConversationPanel';
 export type { ConversationPanelProps } from './components/ConversationPanel';
+export { useMentions } from './mentions/useMentions';
+export type { UseMentionsReturn } from './mentions/useMentions';
+export {
+  buildInlineMentionPrompt,
+  extractMentionQuery,
+  removeMentionTrigger,
+} from './mentions/utils';
+export type { MentionItem, MentionSegment, MentionsConfig } from './mentions/types';

--- a/packages/react-ui/src/mentions/MentionPicker.tsx
+++ b/packages/react-ui/src/mentions/MentionPicker.tsx
@@ -1,0 +1,86 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+
+import type { MentionItem } from './types';
+
+/**
+ * Props accepted by {@link MentionPicker}. Exported for consumers building
+ * a bespoke compound input on top of {@link useMentions}.
+ */
+export interface MentionPickerProps<T = unknown> {
+  /** Items to render. Empty list hides the picker entirely. */
+  items: MentionItem<T>[];
+  /** Index of the keyboard-active row. */
+  activeIndex: number;
+  /** Called when the user clicks a row. */
+  onSelect: (item: MentionItem<T>) => void;
+  /**
+   * Stable id prefix used to build the per-option DOM id. Consumers that
+   * wire `aria-activedescendant` on a textarea should pass the same prefix
+   * and read the active id as `${idPrefix}-${activeIndex}`.
+   */
+  idPrefix: string;
+  /** Renders a custom row body. Default: a `<div>` showing `item.label`. */
+  renderItem?: (item: MentionItem<T>, isActive: boolean) => ReactNode;
+}
+
+/**
+ * Floating popover rendered above {@link import('../components/ChatInput').ChatInput}
+ * when an in-progress mention has at least one filtered item.
+ *
+ * Uses `role="listbox"` with `role="option"` rows so screen readers announce
+ * the active row when the textarea's `aria-activedescendant` updates.
+ */
+export function MentionPicker<T = unknown>({
+  items,
+  activeIndex,
+  onSelect,
+  idPrefix,
+  renderItem,
+}: MentionPickerProps<T>) {
+  if (items.length === 0) return null;
+  return (
+    <ul
+      className="mast-mention-picker"
+      id={`${idPrefix}-listbox`}
+      role="listbox"
+      aria-label="Mention picker"
+    >
+      {items.map((item, index) => {
+        const isActive = index === activeIndex;
+        const className = isActive
+          ? 'mast-mention-picker-item mast-mention-picker-active'
+          : 'mast-mention-picker-item';
+        return (
+          <li
+            key={item.id}
+            id={`${idPrefix}-${index}`}
+            role="option"
+            aria-selected={isActive}
+            className={className}
+            // `mousedown` rather than `click` so the textarea does not lose
+            // focus before we commit the selection — `preventDefault` keeps
+            // the caret in place.
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onSelect(item);
+            }}
+          >
+            {renderItem ? (
+              renderItem(item, isActive)
+            ) : (
+              <div>
+                <div className="mast-mention-picker-item-label">{item.label}</div>
+                {item.description && (
+                  <div className="mast-mention-picker-item-description">{item.description}</div>
+                )}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/react-ui/src/mentions/index.ts
+++ b/packages/react-ui/src/mentions/index.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export type { MentionItem, MentionSegment, MentionsConfig } from './types';
+export { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils';
+export { useMentions } from './useMentions';
+export type { UseMentionsReturn } from './useMentions';
+export { MentionPicker } from './MentionPicker';
+export type { MentionPickerProps } from './MentionPicker';

--- a/packages/react-ui/src/mentions/types.ts
+++ b/packages/react-ui/src/mentions/types.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+
+/**
+ * A single picker entry. Generic over `T` so consumers can attach arbitrary
+ * payloads (document records, file paths, skill descriptors, …) without the
+ * library knowing the domain shape.
+ */
+export interface MentionItem<T = unknown> {
+  /** Stable key. Used as the React key in the picker and the chip identifier. */
+  id: string;
+  /** Shown in the picker row and rendered as the chip text after the trigger. */
+  label: string;
+  /** Optional secondary text rendered alongside `label` in the picker. */
+  description?: string;
+  /** Arbitrary payload accessible from `buildPrompt`, `renderItem`, `renderChip`. */
+  data?: T;
+}
+
+/**
+ * The committed compound input is `MentionSegment<T>[]` followed by a free-form
+ * trailing string. Each segment is the plain text immediately preceding a chip
+ * plus the mentioned item itself; selecting a new item from the picker
+ * appends a segment and starts a fresh trailing region.
+ */
+export interface MentionSegment<T = unknown> {
+  /** Plain text preceding the chip. */
+  text: string;
+  /** The mentioned item that terminates this segment. */
+  item: MentionItem<T>;
+}
+
+/**
+ * Configuration object accepted by `<ChatInput mentions={...}>`,
+ * `<ConversationPanel mentions={...}>`, and `useMentions`. Every field except
+ * one of `items` / `onSearch` is optional.
+ */
+export interface MentionsConfig<T = unknown> {
+  /** Trigger character. Default: `'@'`. Must be a single character. */
+  trigger?: string;
+  /**
+   * Static item list. The picker filters by case-insensitive substring on
+   * `label`. Mutually exclusive with `onSearch`; if both are provided
+   * `onSearch` wins.
+   */
+  items?: MentionItem<T>[];
+  /**
+   * Async or sync search function. Called with the current query each time it
+   * changes. The latest result wins — stale resolutions are discarded so
+   * out-of-order responses cannot replace newer matches.
+   */
+  onSearch?: (query: string) => MentionItem<T>[] | Promise<MentionItem<T>[]>;
+  /** Renders a custom row in the picker. Default: `<div>{item.label}</div>`. */
+  renderItem?: (item: MentionItem<T>, isActive: boolean) => ReactNode;
+  /**
+   * Renders the chip that replaces the in-progress `@<query>` once selected.
+   * Default: the library renders `@<label>` followed by an `x` remove button.
+   */
+  renderChip?: (item: MentionItem<T>, onRemove: () => void) => ReactNode;
+  /**
+   * Builds the prompt sent to the LLM from the segment list and trailing
+   * text. Default: returns the inline display form (segments joined as
+   * `<text>@<label>...<trailing>`). Override this to inject context
+   * (document IDs, file paths, …) around or before the inline text.
+   */
+  buildPrompt?: (segments: MentionSegment<T>[], trailing: string) => string;
+}

--- a/packages/react-ui/src/mentions/useMentions.test.ts
+++ b/packages/react-ui/src/mentions/useMentions.test.ts
@@ -1,0 +1,295 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { StrictMode, type KeyboardEvent } from 'react';
+
+import { useMentions } from './useMentions';
+import type { MentionItem } from './types';
+
+interface DocPayload {
+  path: string;
+}
+
+const items: MentionItem<DocPayload>[] = [
+  { id: '1', label: 'README', data: { path: 'README.md' } },
+  { id: '2', label: 'README-extra', data: { path: 'README-extra.md' } },
+  { id: '3', label: 'CHANGELOG', data: { path: 'CHANGELOG.md' } },
+];
+
+/**
+ * Builds a fake KeyboardEvent good enough for `handleKeyDown` to consume —
+ * `key` and a spy `preventDefault` are all the hook touches.
+ */
+function fakeKey(key: string): KeyboardEvent<HTMLTextAreaElement> {
+  return { key, preventDefault: vi.fn() } as unknown as KeyboardEvent<HTMLTextAreaElement>;
+}
+
+describe('useMentions', () => {
+  describe('synchronous items', () => {
+    it('filters by case-insensitive substring on label', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hello @read'));
+      expect(result.current.mentionQuery).toBe('read');
+      expect(result.current.filteredItems.map((i) => i.id)).toEqual(['1', '2']);
+    });
+
+    it('returns no items when no trigger is active', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hello world'));
+      expect(result.current.mentionQuery).toBeNull();
+      expect(result.current.filteredItems).toEqual([]);
+    });
+
+    it('omits already-selected items from the filtered list', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hello @'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput('next @r'));
+      expect(result.current.filteredItems.map((i) => i.id)).toEqual(['2']);
+    });
+  });
+
+  describe('segment management', () => {
+    it('appends a segment with the preceding text (whitespace preserved) and resets the trailing input', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hello @read'));
+      act(() => result.current.selectItem(items[0]));
+      expect(result.current.segments).toHaveLength(1);
+      // Trailing whitespace before `@` is preserved so the inline display
+      // form (`hello @README`) reads naturally.
+      expect(result.current.segments[0].text).toBe('hello ');
+      expect(result.current.segments[0].item.id).toBe('1');
+      expect(result.current.trailingInput).toBe('');
+      expect(result.current.mentionQuery).toBeNull();
+    });
+
+    it('removeChip merges the chip text into the next segment', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('a @'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput(' b @'));
+      act(() => result.current.selectItem(items[1]));
+      expect(result.current.segments).toHaveLength(2);
+      act(() => result.current.removeChip('1'));
+      expect(result.current.segments).toHaveLength(1);
+      // Both segment texts kept their trailing space; concatenated they
+      // produce "a  b " (two spaces at the join — the user's typed input
+      // verbatim, minus the now-removed chip).
+      expect(result.current.segments[0].text).toBe('a  b ');
+      expect(result.current.segments[0].item.id).toBe('2');
+    });
+
+    it('removeChip pushes orphan text into the trailing region when removing the last chip', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hello @'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput(' world'));
+      act(() => result.current.removeChip('1'));
+      expect(result.current.segments).toHaveLength(0);
+      // The segment text "hello " plus the trailing input " world" become
+      // "hello  world" — the user's typed input verbatim minus the chip.
+      expect(result.current.trailingInput).toBe('hello  world');
+    });
+
+    it('selectItem is a no-op when the item is already selected', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('@'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput('@'));
+      act(() => result.current.selectItem(items[0]));
+      expect(result.current.segments).toHaveLength(1);
+    });
+
+    it('clear() resets segments, trailing text, and the picker', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hi @'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput('more text @r'));
+      act(() => result.current.clear());
+      expect(result.current.segments).toEqual([]);
+      expect(result.current.trailingInput).toBe('');
+      expect(result.current.mentionQuery).toBeNull();
+      expect(result.current.pickerIndex).toBe(0);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('ArrowDown / ArrowUp wrap around the filtered list', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('@'));
+      // 3 items visible — start at 0
+      expect(result.current.pickerIndex).toBe(0);
+      act(() => {
+        result.current.handleKeyDown(fakeKey('ArrowDown'));
+      });
+      expect(result.current.pickerIndex).toBe(1);
+      act(() => {
+        result.current.handleKeyDown(fakeKey('ArrowDown'));
+      });
+      act(() => {
+        result.current.handleKeyDown(fakeKey('ArrowDown'));
+      });
+      expect(result.current.pickerIndex).toBe(0);
+      act(() => {
+        result.current.handleKeyDown(fakeKey('ArrowUp'));
+      });
+      expect(result.current.pickerIndex).toBe(2);
+    });
+
+    it('Enter selects the active item', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('@'));
+      act(() => {
+        result.current.handleKeyDown(fakeKey('ArrowDown'));
+      });
+      act(() => {
+        result.current.handleKeyDown(fakeKey('Enter'));
+      });
+      expect(result.current.segments).toHaveLength(1);
+      expect(result.current.segments[0].item.id).toBe('2');
+    });
+
+    it('Escape closes the picker without selecting', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('@r'));
+      expect(result.current.mentionQuery).toBe('r');
+      act(() => {
+        result.current.handleKeyDown(fakeKey('Escape'));
+      });
+      expect(result.current.mentionQuery).toBeNull();
+      expect(result.current.segments).toHaveLength(0);
+    });
+
+    it('handleKeyDown returns false (does not consume) when the picker is closed', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      let consumed = true;
+      act(() => {
+        consumed = result.current.handleKeyDown(fakeKey('Enter'));
+      });
+      expect(consumed).toBe(false);
+    });
+
+    it('handleKeyDown returns false when filteredItems is empty', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('@nomatch'));
+      expect(result.current.mentionQuery).toBe('nomatch');
+      expect(result.current.filteredItems).toHaveLength(0);
+      let consumed = true;
+      act(() => {
+        consumed = result.current.handleKeyDown(fakeKey('Enter'));
+      });
+      expect(consumed).toBe(false);
+    });
+  });
+
+  describe('async onSearch', () => {
+    it('uses async results once the promise resolves', async () => {
+      const onSearch = vi.fn(async (query: string) => {
+        return items.filter((i) => i.label.toLowerCase().includes(query.toLowerCase()));
+      });
+      const { result } = renderHook(() => useMentions<DocPayload>({ onSearch }));
+      act(() => result.current.setTrailingInput('@change'));
+      await waitFor(() => {
+        expect(result.current.filteredItems.map((i) => i.id)).toEqual(['3']);
+      });
+    });
+
+    it('discards stale resolutions when newer queries supersede them', async () => {
+      const resolvers: Array<(items: MentionItem<DocPayload>[]) => void> = [];
+      const onSearch = vi.fn(
+        () =>
+          new Promise<MentionItem<DocPayload>[]>((resolve) => {
+            resolvers.push(resolve);
+          }),
+      );
+      const { result } = renderHook(() => useMentions<DocPayload>({ onSearch }));
+
+      act(() => result.current.setTrailingInput('@a'));
+      await waitFor(() => expect(resolvers.length).toBe(1));
+      act(() => result.current.setTrailingInput('@b'));
+      await waitFor(() => expect(resolvers.length).toBe(2));
+
+      // Resolve the *newer* request first, then the older one. The older
+      // resolution must not overwrite the newer items.
+      act(() => resolvers[1]([items[2]]));
+      await waitFor(() => {
+        expect(result.current.filteredItems.map((i) => i.id)).toEqual(['3']);
+      });
+      act(() => resolvers[0]([items[0]]));
+      // Stale promise resolved — `filteredItems` must still reflect the
+      // newer query's result.
+      expect(result.current.filteredItems.map((i) => i.id)).toEqual(['3']);
+    });
+  });
+
+  describe('buildSubmission', () => {
+    it('returns the inline form for both prompt and displayText by default', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }));
+      act(() => result.current.setTrailingInput('hello @'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput(' world'));
+      const submission = result.current.buildSubmission();
+      expect(submission.prompt).toBe('hello @README world');
+      expect(submission.displayText).toBe('hello @README world');
+    });
+
+    it('runs buildPrompt when supplied while preserving the inline displayText', () => {
+      const buildPrompt = vi.fn(
+        (segments: typeof items extends Array<infer _U> ? unknown[] : never, trailing: string) => {
+          const segs = segments as Array<{ text: string; item: MentionItem<DocPayload> }>;
+          const ids = segs.map((s) => s.item.id).join(',');
+          return `[refs:${ids}] ${trailing}`;
+        },
+      );
+      const { result } = renderHook(() =>
+        useMentions<DocPayload>({ items, buildPrompt: buildPrompt as never }),
+      );
+      act(() => result.current.setTrailingInput('@'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput('do thing'));
+      const submission = result.current.buildSubmission();
+      expect(submission.prompt).toBe('[refs:1] do thing');
+      expect(submission.displayText).toBe('@READMEdo thing');
+    });
+  });
+
+  describe('StrictMode safety', () => {
+    it('does not double-append a segment when selectItem runs under StrictMode', () => {
+      // StrictMode intentionally double-invokes state-updater functions so
+      // impure updaters surface in dev. selectItem must remain idempotent —
+      // a previous version nested setSegments inside setTrailingInputState's
+      // updater, which caused the chip to be added twice.
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }), {
+        wrapper: StrictMode,
+      });
+      act(() => result.current.setTrailingInput('hello @'));
+      act(() => result.current.selectItem(items[0]));
+      expect(result.current.segments).toHaveLength(1);
+      expect(result.current.segments[0].item.id).toBe('1');
+    });
+
+    it('does not double-merge text when removeChip runs under StrictMode', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items }), {
+        wrapper: StrictMode,
+      });
+      act(() => result.current.setTrailingInput('hi @'));
+      act(() => result.current.selectItem(items[0]));
+      act(() => result.current.setTrailingInput(' world'));
+      act(() => result.current.removeChip('1'));
+      expect(result.current.segments).toHaveLength(0);
+      // The segment text "hi " plus trailing input " world" → "hi  world".
+      expect(result.current.trailingInput).toBe('hi  world');
+    });
+  });
+
+  describe('custom trigger', () => {
+    it('respects a custom trigger character', () => {
+      const { result } = renderHook(() => useMentions<DocPayload>({ items, trigger: '#' }));
+      act(() => result.current.setTrailingInput('hi #read'));
+      expect(result.current.mentionQuery).toBe('read');
+      expect(result.current.filteredItems.map((i) => i.id)).toEqual(['1', '2']);
+    });
+  });
+});

--- a/packages/react-ui/src/mentions/useMentions.ts
+++ b/packages/react-ui/src/mentions/useMentions.ts
@@ -1,0 +1,207 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+
+import type { MentionItem, MentionSegment, MentionsConfig } from './types';
+import { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils';
+
+/**
+ * Return shape of {@link useMentions}.
+ *
+ * Consumers either pass the whole object to `<ChatInput mentions>` (via the
+ * `mentions` config — `<ChatInput>` calls `useMentions` internally) or wire
+ * the individual fields into a bespoke compound input.
+ */
+export interface UseMentionsReturn<T = unknown> {
+  /** Committed segments preceding the trailing-text region. */
+  segments: MentionSegment<T>[];
+  /** Free-form text after the last chip (or the whole field when no chips). */
+  trailingInput: string;
+  /** Current `@<query>` if the cursor is inside an in-progress mention. */
+  mentionQuery: string | null;
+  /** Items the picker should render right now (filtered or async-resolved). */
+  filteredItems: MentionItem<T>[];
+  /** Index of the keyboard-highlighted picker row. */
+  pickerIndex: number;
+
+  /** Set the trailing-text region. Recomputes `mentionQuery` and resets picker focus. */
+  setTrailingInput: (text: string) => void;
+  /**
+   * Wire to the textarea's `onKeyDown`. Returns `true` if the key was
+   * consumed by the picker so the host can suppress its own handling. Up /
+   * Down / Enter / Escape are only consumed when the picker has at least one
+   * filtered item.
+   */
+  handleKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  /** Append a chip and reset the in-progress mention. */
+  selectItem: (item: MentionItem<T>) => void;
+  /** Remove a chip by id, re-merging its preceding text into the next region. */
+  removeChip: (id: string) => void;
+  /** Build `{ prompt, displayText }` for `sendMessage`. */
+  buildSubmission: () => { prompt: string; displayText: string };
+  /** Clear all segments and trailing text. */
+  clear: () => void;
+}
+
+/**
+ * Owns the segment / trailing-text / picker-index state behind the optional
+ * `<ChatInput mentions>` UI. Exported so consumers can build a bespoke input
+ * (e.g. with their own picker component or virtualisation) without giving up
+ * the segment management and async-search plumbing.
+ *
+ * - `config.items` filters by case-insensitive substring on `label`.
+ * - `config.onSearch` is called every time the query changes; the latest
+ *   resolution wins so out-of-order responses cannot replace newer matches.
+ *   Already-selected items are filtered out of the picker so the same
+ *   reference cannot be picked twice.
+ */
+export function useMentions<T = unknown>(config: MentionsConfig<T>): UseMentionsReturn<T> {
+  const trigger = config.trigger ?? '@';
+
+  const [segments, setSegments] = useState<MentionSegment<T>[]>([]);
+  const [trailingInput, setTrailingInputState] = useState('');
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [pickerIndex, setPickerIndex] = useState(0);
+  const [searchResults, setSearchResults] = useState<MentionItem<T>[]>([]);
+
+  // Refs mirror the latest committed state so event-handler callbacks
+  // (`selectItem`, `removeChip`) can read it without nesting one state
+  // setter inside another's updater function — that nesting double-runs in
+  // React StrictMode and would duplicate appends.
+  const segmentsRef = useRef(segments);
+  segmentsRef.current = segments;
+  const trailingInputRef = useRef(trailingInput);
+  trailingInputRef.current = trailingInput;
+
+  // Tracks the most recent `onSearch` invocation so stale resolutions can be
+  // discarded — out-of-order async results must not overwrite newer matches.
+  const searchTokenRef = useRef(0);
+
+  useEffect(() => {
+    if (mentionQuery === null) {
+      setSearchResults([]);
+      return;
+    }
+    const token = ++searchTokenRef.current;
+    if (config.onSearch) {
+      const result = config.onSearch(mentionQuery);
+      if (result instanceof Promise) {
+        result.then((items) => {
+          if (token === searchTokenRef.current) setSearchResults(items);
+        });
+      } else {
+        setSearchResults(result);
+      }
+    }
+    // `items` mode is handled by `filteredItems` below — no async work required.
+  }, [mentionQuery, config.onSearch]);
+
+  const selectedIds = new Set(segments.map((s) => s.item.id));
+
+  const filteredItems: MentionItem<T>[] = (() => {
+    if (mentionQuery === null) return [];
+    if (config.onSearch) {
+      return searchResults.filter((item) => !selectedIds.has(item.id));
+    }
+    const lowered = mentionQuery.toLowerCase();
+    return (config.items ?? []).filter(
+      (item) => !selectedIds.has(item.id) && item.label.toLowerCase().includes(lowered),
+    );
+  })();
+
+  const setTrailingInput = useCallback(
+    (text: string) => {
+      setTrailingInputState(text);
+      setMentionQuery(extractMentionQuery(text, trigger));
+      setPickerIndex(0);
+    },
+    [trigger],
+  );
+
+  const selectItem = useCallback(
+    (item: MentionItem<T>) => {
+      const currentSegments = segmentsRef.current;
+      if (currentSegments.some((s) => s.item.id === item.id)) return;
+      const textBefore = removeMentionTrigger(trailingInputRef.current, trigger);
+      setSegments([...currentSegments, { text: textBefore, item }]);
+      setTrailingInputState('');
+      setMentionQuery(null);
+      setPickerIndex(0);
+    },
+    [trigger],
+  );
+
+  const removeChip = useCallback((id: string) => {
+    const prev = segmentsRef.current;
+    const idx = prev.findIndex((s) => s.item.id === id);
+    if (idx === -1) return;
+    const removedText = prev[idx].text;
+    const without = [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+    if (idx < without.length) {
+      // Merge the removed chip's preceding text into the next segment so
+      // the visible text reflows seamlessly.
+      without[idx] = { ...without[idx], text: removedText + without[idx].text };
+      setSegments(without);
+      return;
+    }
+    // Removed the last chip: orphan text becomes part of the trailing region.
+    setSegments(without);
+    setTrailingInputState(removedText + trailingInputRef.current);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (mentionQuery === null || filteredItems.length === 0) return false;
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          setPickerIndex((i) => (i + 1) % filteredItems.length);
+          return true;
+        case 'ArrowUp':
+          event.preventDefault();
+          setPickerIndex((i) => (i === 0 ? filteredItems.length - 1 : i - 1));
+          return true;
+        case 'Enter':
+          event.preventDefault();
+          selectItem(filteredItems[pickerIndex] ?? filteredItems[0]);
+          return true;
+        case 'Escape':
+          event.preventDefault();
+          setMentionQuery(null);
+          return true;
+        default:
+          return false;
+      }
+    },
+    [mentionQuery, filteredItems, pickerIndex, selectItem],
+  );
+
+  const buildSubmission = useCallback((): { prompt: string; displayText: string } => {
+    const displayText = buildInlineMentionPrompt(segments, trailingInput);
+    const prompt = config.buildPrompt ? config.buildPrompt(segments, trailingInput) : displayText;
+    return { prompt, displayText };
+  }, [segments, trailingInput, config.buildPrompt]);
+
+  const clear = useCallback(() => {
+    setSegments([]);
+    setTrailingInputState('');
+    setMentionQuery(null);
+    setPickerIndex(0);
+  }, []);
+
+  return {
+    segments,
+    trailingInput,
+    mentionQuery,
+    filteredItems,
+    pickerIndex,
+    setTrailingInput,
+    handleKeyDown,
+    selectItem,
+    removeChip,
+    buildSubmission,
+    clear,
+  };
+}

--- a/packages/react-ui/src/mentions/utils.test.ts
+++ b/packages/react-ui/src/mentions/utils.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils';
+import type { MentionSegment } from './types';
+
+describe('extractMentionQuery', () => {
+  it('returns the query when the input ends with `@<chars>`', () => {
+    expect(extractMentionQuery('hello @doc')).toBe('doc');
+    expect(extractMentionQuery('hi @abc.txt')).toBe('abc.txt');
+  });
+
+  it('returns an empty string when the input ends with a bare trigger', () => {
+    expect(extractMentionQuery('hello @')).toBe('');
+    expect(extractMentionQuery('@')).toBe('');
+  });
+
+  it('returns null after a whitespace ends the mention', () => {
+    expect(extractMentionQuery('hello @doc ')).toBeNull();
+    expect(extractMentionQuery('hello @doc world')).toBeNull();
+    expect(extractMentionQuery('hello @doc\n')).toBeNull();
+  });
+
+  it('returns null when there is no trigger', () => {
+    expect(extractMentionQuery('hello world')).toBeNull();
+    expect(extractMentionQuery('')).toBeNull();
+  });
+
+  it('only considers the last trigger when more than one is typed', () => {
+    expect(extractMentionQuery('@first @sec')).toBe('sec');
+  });
+
+  it('treats consecutive triggers as starting a new in-progress mention', () => {
+    // The token after the most recent `@` cannot itself contain `@`, so the
+    // trailing region after `@@` is the empty string belonging to the last
+    // trigger.
+    expect(extractMentionQuery('hi @@')).toBe('');
+  });
+
+  it('respects a custom trigger character', () => {
+    expect(extractMentionQuery('hello #doc', '#')).toBe('doc');
+    expect(extractMentionQuery('hello @doc', '#')).toBeNull();
+    expect(extractMentionQuery('hello #', '#')).toBe('');
+  });
+
+  it('escapes regex-meta trigger characters', () => {
+    expect(extractMentionQuery('hello .doc', '.')).toBe('doc');
+    expect(extractMentionQuery('hello $doc', '$')).toBe('doc');
+  });
+});
+
+describe('removeMentionTrigger', () => {
+  it('strips a trailing `@<query>` while preserving whitespace before the trigger', () => {
+    expect(removeMentionTrigger('hello @doc')).toBe('hello ');
+    expect(removeMentionTrigger('hello @')).toBe('hello ');
+  });
+
+  it('leaves text without a trailing trigger untouched', () => {
+    expect(removeMentionTrigger('hello world')).toBe('hello world');
+    expect(removeMentionTrigger('')).toBe('');
+  });
+
+  it('returns an empty string when the input is just the trigger', () => {
+    expect(removeMentionTrigger('@')).toBe('');
+    expect(removeMentionTrigger('@doc')).toBe('');
+  });
+
+  it('only strips the most recent trigger', () => {
+    expect(removeMentionTrigger('@first text @sec')).toBe('@first text ');
+  });
+
+  it('respects a custom trigger character', () => {
+    expect(removeMentionTrigger('hello #doc', '#')).toBe('hello ');
+    expect(removeMentionTrigger('hello @doc', '#')).toBe('hello @doc');
+  });
+});
+
+describe('buildInlineMentionPrompt', () => {
+  it('returns just the trailing text when there are no segments', () => {
+    expect(buildInlineMentionPrompt([], 'just text')).toBe('just text');
+    expect(buildInlineMentionPrompt([], '')).toBe('');
+  });
+
+  it('joins segments inline with the trigger character followed by the label', () => {
+    const segments: MentionSegment<unknown>[] = [
+      { text: 'hello ', item: { id: '1', label: 'one' } },
+      { text: ' and ', item: { id: '2', label: 'two' } },
+    ];
+    expect(buildInlineMentionPrompt(segments, ' here')).toBe('hello @one and @two here');
+  });
+
+  it('preserves an empty inter-segment text', () => {
+    const segments: MentionSegment<unknown>[] = [
+      { text: '', item: { id: '1', label: 'one' } },
+      { text: '', item: { id: '2', label: 'two' } },
+    ];
+    expect(buildInlineMentionPrompt(segments, '')).toBe('@one@two');
+  });
+});

--- a/packages/react-ui/src/mentions/utils.ts
+++ b/packages/react-ui/src/mentions/utils.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MentionSegment } from './types';
+
+const DEFAULT_TRIGGER = '@';
+
+function escapeForRegex(char: string): string {
+  return char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Returns the query suffix at the end of `input` if the user is currently
+ * typing an in-progress mention, or `null` otherwise.
+ *
+ * A mention is considered in-progress when the trigger character appears
+ * after the last whitespace and is not followed by another whitespace
+ * character. The query may be empty (just typed `@` and nothing after).
+ *
+ * @example
+ *   extractMentionQuery('hello @doc') === 'doc'
+ *   extractMentionQuery('hello @')    === ''
+ *   extractMentionQuery('hello @doc ') === null   // space ends the mention
+ *   extractMentionQuery('hello world') === null   // no trigger
+ */
+export function extractMentionQuery(
+  input: string,
+  trigger: string = DEFAULT_TRIGGER,
+): string | null {
+  const escaped = escapeForRegex(trigger);
+  const re = new RegExp(`${escaped}([^\\s${escaped}]*)$`);
+  const match = input.match(re);
+  if (!match) return null;
+  return match[1];
+}
+
+/**
+ * Strips a trailing `@<query>` from `input`, preserving any whitespace
+ * the user typed before the trigger. Used after the user commits a picker
+ * selection — the preserved whitespace survives into the segment text so
+ * the inline display form (`<text>@<label>`) keeps the natural space
+ * between the preceding word and the chip.
+ */
+export function removeMentionTrigger(input: string, trigger: string = DEFAULT_TRIGGER): string {
+  const escaped = escapeForRegex(trigger);
+  const re = new RegExp(`${escaped}[^\\s${escaped}]*$`);
+  return input.replace(re, '');
+}
+
+/**
+ * Default `buildPrompt` implementation: returns the inline form
+ * `<text1>@<label1><text2>@<label2>...<trailing>`.
+ *
+ * Apps that want to inject extra context (document IDs, file paths, …) can
+ * call this and prepend / wrap the result, or build the string from scratch
+ * using `segments` and `trailing`.
+ */
+export function buildInlineMentionPrompt<T>(
+  segments: MentionSegment<T>[],
+  trailing: string,
+): string {
+  return segments.map((s) => `${s.text}${DEFAULT_TRIGGER}${s.item.label}`).join('') + trailing;
+}

--- a/packages/react-ui/styles/default.css
+++ b/packages/react-ui/styles/default.css
@@ -24,6 +24,11 @@
   --mast-tool-cancelled-fg: #4b5563;
   --mast-user-bubble: #dbeafe;
   --mast-user-fg: #1e3a8a;
+  --mast-mention-chip-bg: #dbeafe;
+  --mast-mention-chip-fg: #1e3a8a;
+  --mast-mention-picker-bg: var(--mast-bg);
+  --mast-mention-picker-active-bg: var(--mast-bg-subtle);
+  --mast-mention-picker-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
   /* Typography */
   --mast-font: system-ui, sans-serif;
@@ -56,6 +61,9 @@
     --mast-tool-cancelled-fg: #d1d5db;
     --mast-user-bubble: #1e3a8a;
     --mast-user-fg: #bfdbfe;
+    --mast-mention-chip-bg: #1e3a8a;
+    --mast-mention-chip-fg: #bfdbfe;
+    --mast-mention-picker-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   }
 }
 
@@ -78,6 +86,9 @@
   --mast-tool-cancelled-fg: #d1d5db;
   --mast-user-bubble: #1e3a8a;
   --mast-user-fg: #bfdbfe;
+  --mast-mention-chip-bg: #1e3a8a;
+  --mast-mention-chip-fg: #bfdbfe;
+  --mast-mention-picker-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -503,4 +514,109 @@
   background: transparent;
   border-color: currentColor;
   color: inherit;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Mention picker                                                             */
+/* -------------------------------------------------------------------------- */
+
+.mast-mention-input .mast-mention-input-field {
+  flex: 1 1 auto;
+  position: relative;
+  min-width: 0;
+}
+
+.mast-mention-input-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.25rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.mast-mention-input .mast-mention-input-textarea {
+  flex: 1 1 8rem;
+  min-width: 8rem;
+}
+
+.mast-mention-segment-text {
+  white-space: pre-wrap;
+  align-self: center;
+  font-size: var(--mast-text-base);
+}
+
+.mast-mention-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1rem 0.4rem;
+  background: var(--mast-mention-chip-bg);
+  color: var(--mast-mention-chip-fg);
+  border-radius: 9999px;
+  font-size: var(--mast-text-sm);
+  font-weight: 500;
+}
+
+.mast-mention-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  line-height: 1;
+}
+
+.mast-mention-chip-remove:hover,
+.mast-mention-chip-remove:focus-visible {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.mast-mention-picker {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin: 0 0 0.25rem 0;
+  padding: 0.25rem;
+  list-style: none;
+  background: var(--mast-mention-picker-bg);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  box-shadow: var(--mast-mention-picker-shadow);
+  max-height: 14rem;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.mast-mention-picker-item {
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: var(--mast-text-sm);
+  color: var(--mast-fg);
+}
+
+.mast-mention-picker-item:hover {
+  background: var(--mast-mention-picker-active-bg);
+}
+
+.mast-mention-picker-active {
+  background: var(--mast-mention-picker-active-bg);
+}
+
+.mast-mention-picker-item-label {
+  font-weight: 500;
+}
+
+.mast-mention-picker-item-description {
+  font-size: var(--mast-text-sm);
+  color: var(--mast-fg-muted);
 }


### PR DESCRIPTION
## Summary

- Adds an opt-in `@`-mention picker to `<ChatInput>` and `<ConversationPanel>` via a new `mentions` prop. When supplied, the textarea is wrapped in a compound input with inline chips and a keyboard-navigable picker; on submit the input calls `sendMessage(prompt, displayText)` so the user bubble shows the chip form while the LLM receives the augmented prompt.
- Introduces `useMentions` (exported) for consumers building bespoke inputs, plus pure utilities (`extractMentionQuery`, `removeMentionTrigger`, `buildInlineMentionPrompt`) and `MentionsConfig<T>` / `MentionItem<T>` / `MentionSegment<T>` types.
- Demo wires three in-memory documents through the picker plus a new `read_doc` tool: `mentionsConfig.buildPrompt` injects only ids and titles into the prompt, and the agent fetches bodies on demand — a realistic illustration of the displayText/prompt split.

## Implementation

New module `packages/react-ui/src/mentions/`:

- `types.ts` — generic `MentionItem<T>`, `MentionSegment<T>`, `MentionsConfig<T>`
- `utils.ts` — `extractMentionQuery`, `removeMentionTrigger`, `buildInlineMentionPrompt` (escapes regex-meta trigger characters)
- `useMentions.ts` — segment / trailing / query / picker-index state. Supports sync `items` (case-insensitive substring filter on `label`) and async `onSearch` with stale-resolution discarding. Refs mirror committed state so callbacks stay StrictMode-safe.
- `MentionPicker.tsx` — internal listbox popover used by `<ChatInput>`

`<ChatInput mentions>` integration:

- Compound input lives behind a separate `MentionsChatInput` subcomponent so the plain-textarea path is bit-for-bit unchanged when `mentions` is omitted
- Textarea exposes `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`; picker rows expose `role="option"` with `aria-selected`; chip remove buttons have `aria-label="Remove reference to <label>"`
- Picker uses `mousedown` (not `click`) to commit selections so the textarea keeps focus

CSS additions in `styles/default.css`:

- Classes: `mast-mention-input`, `mast-mention-chip`, `mast-mention-chip-remove`, `mast-mention-picker`, `mast-mention-picker-item`, `mast-mention-picker-active` (plus a few internal layout helpers)
- Tokens: `--mast-mention-chip-bg`, `--mast-mention-chip-fg`, `--mast-mention-picker-bg`, `--mast-mention-picker-active-bg`, `--mast-mention-picker-shadow` with light + dark overrides

Demo (`apps/demo-react-ui`):

- `tools.ts` now owns `demoDocs` (the source of truth) and a new `ReadDocTool` that returns `{ id, title, path, body }` JSON for a given id
- `App.tsx` registers `read_doc`, slims `mentionsConfig.buildPrompt` to id+title only, and updates the agent instructions to call `read_doc` whenever a user message starts with the `"The user has referenced..."` preamble

## Bug fixes during integration

- `useMentions.selectItem` and `removeChip` no longer nest one state setter inside another's updater function — that nesting double-ran under React StrictMode and caused chip duplication. Added two `<StrictMode>`-wrapped regression tests.
- `removeMentionTrigger` no longer calls `.trimEnd()` after stripping the trigger, so whitespace the user typed before `@` is preserved as part of the segment text. The displayText now reads `"hello @Roadmap"` instead of `"hello@Roadmap"`.

## Tests

44 new tests (15 utils + 20 hook + 11 integration); full suite now 141 passing.

| Layer       | File                                              | Coverage |
| ----------- | ------------------------------------------------- | -------- |
| Utilities   | `mentions/utils.test.ts`                          | regex edge cases, custom trigger, regex-meta escaping, default prompt builder |
| Hook        | `mentions/useMentions.test.ts`                    | segment management, picker keyboard nav, sync filter, async `onSearch` stale-resolution discarding, custom trigger, StrictMode safety |
| Integration | `components/ChatInputMentions.test.tsx`           | picker open/close, ArrowUp/Down + Enter + Escape, `aria-activedescendant`, chip removal, send path with and without `buildPrompt`, no-prop fallback identical to today, `renderItem` and `renderChip` overrides |

Closes #63

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test --workspaces --if-present` (141 passing)
- [x] Manual: type `@`, ArrowUp/Down to highlight, Enter to commit a chip
- [x] Manual: chip remove button merges adjacent text
- [x] Manual: agent calls `read_doc` to fetch referenced doc bodies on demand
- [x] Manual: user bubble shows `@Roadmap` (display form) not the augmented prompt
- [x] Manual: no React StrictMode duplicate-key warnings in the console