### PR TITLE
feat(react-ui): nested ToolEventEntry for sub-agent tool calls

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -37,6 +37,7 @@ import {
   ParseIntegerTool,
   ReadDocTool,
   SetPageTitleTool,
+  createSummarizeDocumentsTool,
   demoDocs,
   type DemoDoc,
 } from './tools';
@@ -54,6 +55,7 @@ const registry = new ToolRegistry()
   .register(new ParseIntegerTool())
   .register(new ReadDocTool());
 const runner = new AgentRunner(new GoogleGenAIAdapter(apiKey ?? ''), registry);
+registry.register(createSummarizeDocumentsTool(runner));
 
 const agentConfig = createAgent({
   name: 'DemoAssistant',
@@ -64,8 +66,12 @@ const agentConfig = createAgent({
     'Use the set_page_title tool when the user asks to change or set the page title. ' +
     'Use the copy_to_clipboard tool when the user asks to copy something to the clipboard. ' +
     'Use the parse_integer tool when the user asks to parse a string as an integer. ' +
+    'When the user asks to summarise one or more referenced documents, call the ' +
+    'summarize_documents tool with the relevant ids. The summarizer will fetch each ' +
+    'document itself, so you do not need to call read_doc when delegating to it. ' +
+    "For other questions about a referenced document's contents, call read_doc directly. " +
     'When a user message starts with "The user has referenced the following documents:", ' +
-    'call the read_doc tool with each listed id to fetch its contents before answering. ' +
+    'use the listed ids to drive your tool calls. ' +
     'Do not assume document contents from the title alone.',
   tools: [
     'get_current_time',
@@ -74,6 +80,7 @@ const agentConfig = createAgent({
     'copy_to_clipboard',
     'parse_integer',
     'read_doc',
+    'summarize_documents',
   ],
 });
 

--- a/apps/demo-react-ui/src/tools.ts
+++ b/apps/demo-react-ui/src/tools.ts
@@ -1,7 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Tool, ToolContext } from '@mast-ai/core';
+import { createAgent, createAgentTool } from '@mast-ai/core';
+import type { AgentRunner, Tool, ToolContext } from '@mast-ai/core';
 import type { MentionItem } from '@mast-ai/react-ui';
 
 /** Payload attached to each `@`-mentionable doc in the demo. */
@@ -214,4 +215,45 @@ export class ParseIntegerTool implements Tool<ParseIntegerArgs, number> {
     }
     return parseInt(args.value, 10);
   }
+}
+
+/**
+ * Builds a sub-agent tool that summarises one or more demo docs by id. The
+ * sub-agent runs on the provided `runner` with its own restricted allowlist
+ * (`read_doc` only) so its `read_doc` calls show up as nested tool events on
+ * the parent's `summarize_documents` block.
+ */
+export function createSummarizeDocumentsTool(runner: AgentRunner): Tool {
+  const summarizerAgent = createAgent({
+    name: 'DocumentSummarizer',
+    instructions:
+      'You summarise documents the user has referenced. ' +
+      'For each document id you receive, call the read_doc tool to fetch its contents, ' +
+      'then produce a single concise paragraph summarising all of them together. ' +
+      'Do not assume document contents from the title alone.',
+    tools: ['read_doc'],
+  });
+
+  return createAgentTool(runner, summarizerAgent, {
+    name: 'summarize_documents',
+    description:
+      'Summarises one or more referenced documents by id. Internally fetches each ' +
+      'document with read_doc and returns a concise paragraph summary.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'The document ids to summarise, e.g. ["doc-roadmap", "doc-style-guide"].',
+        },
+      },
+      required: ['ids'],
+    },
+    scope: 'read',
+    buildInput: (args) => {
+      const { ids } = args as { ids: string[] };
+      return `Summarise these document ids together: ${ids.join(', ')}.`;
+    },
+  });
 }

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -151,6 +151,7 @@ export interface ToolEventEntry {
   result?: unknown;
   subThinking?: string; // accumulated thinking streamed from inside the tool/sub-agent
   subText?: string; // accumulated text streamed from inside the tool/sub-agent
+  nestedToolEvents?: ToolEventEntry[]; // tool calls fired by a sub-agent inside this tool
   isStreaming: boolean; // true while the tool is executing
   awaitingApproval?: boolean; // true while paused on the inline approval queue or onApprovalRequired
   status?: ToolCallStatus; // populated when isStreaming flips to false
@@ -176,6 +177,15 @@ the `AgentEvent` stream emitted by `AgentRunner`. `status` is derived as:
 A `'cancelled'` status set by the proxy is preserved when the runner emits the
 final `tool_call_completed` event so the synthetic cancelled result does not
 get reclassified as success.
+
+`nestedToolEvents` captures the tool calls a sub-agent fires while the
+parent tool is executing. The list is populated as `tool_call_started` and
+`tool_call_completed` events arrive on the parent's `onToolEvent` callback;
+`<ToolCallBlock>` renders nested entries recursively. Currently scoped to a
+single level of nesting — grandchild events route back to the outermost
+matching parent. Deeper nesting requires either path-based routing in
+`onToolEvent` or recursive plumbing inside `createAgentTool`, and is left to a
+follow-up.
 
 ---
 
@@ -396,6 +406,8 @@ interface ToolCallBlockProps {
   as formatted JSON.
 - Tools that are not sub-agents will have no `subThinking` or `subText`; they show
   only the spinner → check transition and args/result.
+- When `entry.nestedToolEvents` is non-empty, each nested tool call renders
+  recursively inside the parent block, indented with a left border.
 - Uses `<details>/<summary>` for args and result expand/collapse.
 
 ### 4.9 `<ChatInput>`
@@ -620,20 +632,22 @@ output, not imported from `index.ts`.
 `useAgentStream` subscribes to the `AgentEvent` stream from `AgentRunner` and
 maintains `ConversationEntry[]` as follows:
 
-| Event                        | Action                                                                                                                                   |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| User sends message           | Append `{ role: 'user', text: displayText ?? prompt, isStreaming: false }`; pass `prompt` to `runStream`                                 |
-| Run starts                   | Append `{ role: 'assistant', text: '', isStreaming: true }`                                                                              |
-| `text_delta`                 | Mutate last entry: append `delta` to `text`                                                                                              |
-| `thinking`                   | Mutate last entry: append `delta` to `thinking`                                                                                          |
-| `tool_call_started`          | Mutate last entry: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` to `toolEvents`                               |
-| `onToolEvent` → `thinking`   | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                        |
-| `onToolEvent` → `text_delta` | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                            |
-| Approval proxy notifies      | Mutate matching `ToolEventEntry`: set `awaitingApproval` to `true`/`false`                                                               |
-| Approval proxy cancels       | Mutate matching `ToolEventEntry`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                        |
-| `tool_call_completed`        | Mutate matching `ToolEventEntry`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`) |
-| `done`                       | Mutate last entry: set `text = output`, `isStreaming = false`                                                                            |
-| Error / cancel               | Mutate last entry: set `isStreaming = false`; optionally append error text                                                               |
+| Event                                 | Action                                                                                                                                   |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| User sends message                    | Append `{ role: 'user', text: displayText ?? prompt, isStreaming: false }`; pass `prompt` to `runStream`                                 |
+| Run starts                            | Append `{ role: 'assistant', text: '', isStreaming: true }`                                                                              |
+| `text_delta`                          | Mutate last entry: append `delta` to `text`                                                                                              |
+| `thinking`                            | Mutate last entry: append `delta` to `thinking`                                                                                          |
+| `tool_call_started`                   | Mutate last entry: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` to `toolEvents`                               |
+| `onToolEvent` → `thinking`            | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                        |
+| `onToolEvent` → `text_delta`          | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                            |
+| `onToolEvent` → `tool_call_started`   | Mutate matching parent `ToolEventEntry`: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` onto `nestedToolEvents` |
+| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error`              |
+| Approval proxy notifies               | Mutate matching `ToolEventEntry`: set `awaitingApproval` to `true`/`false`                                                               |
+| Approval proxy cancels                | Mutate matching `ToolEventEntry`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                        |
+| `tool_call_completed`                 | Mutate matching `ToolEventEntry`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`) |
+| `done`                                | Mutate last entry: set `text = output`, `isStreaming = false`                                                                            |
+| Error / cancel                        | Mutate last entry: set `isStreaming = false`; optionally append error text                                                               |
 
 `onToolEvent` events are wired by passing an `onToolEvent` handler to `RunBuilder` inside `useAgentStream`. Events are matched to the correct `ToolEventEntry` by `toolName`. The `done` event from a sub-agent is ignored — the parent's `tool_call_completed` is the authoritative signal that a tool finished.
 
@@ -794,6 +808,7 @@ to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequen
 | Sub-agent thinking                  | `onToolEvent` → `thinking` appends to matching `ToolEventEntry.subThinking`                                                                   |
 | Sub-agent text                      | `onToolEvent` → `text_delta` appends to matching `ToolEventEntry.subText`                                                                     |
 | Sub-agent `done` ignored            | `onToolEvent` → `done` does not affect parent entry's `isStreaming`                                                                           |
+| Nested tool calls                   | `onToolEvent` → `tool_call_started` pushes a nested entry onto the parent; `tool_call_completed` finalises it with `result` and `status`      |
 | Multiple concurrent tool calls      | Each call tracked independently by name; sub-agent events routed to correct entry                                                             |
 | `done` event                        | Sets `isStreaming: false`, finalises `text` from `output`                                                                                     |
 | Error / cancel                      | Sets `isStreaming: false` on the last entry; prior entries unchanged                                                                          |

--- a/packages/react-ui/src/components/ToolCallBlock.test.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.test.tsx
@@ -161,6 +161,76 @@ describe('<ToolCallBlock>', () => {
     });
   });
 
+  describe('nested tool events', () => {
+    it('does not render the nested container when nestedToolEvents is undefined', () => {
+      const { container } = render(<ToolCallBlock entry={makeEntry()} />);
+      expect(container.querySelector('.mast-tool-call-block-nested')).toBeNull();
+    });
+
+    it('renders nested entries recursively', () => {
+      const nestedCompleted: ToolEventEntry = {
+        id: 'nested-1',
+        type: 'tool_call_completed',
+        name: 'inner_tool',
+        args: { q: 1 },
+        result: 'inner_result',
+        isStreaming: false,
+        status: 'success',
+      };
+      const parent: ToolEventEntry = {
+        id: 'parent-1',
+        type: 'tool_call_completed',
+        name: 'agent_tool',
+        args: {},
+        result: 'outer_result',
+        isStreaming: false,
+        status: 'success',
+        nestedToolEvents: [nestedCompleted],
+      };
+      const { container } = render(<ToolCallBlock entry={parent} />);
+      const nestedContainer = container.querySelector('.mast-tool-call-block-nested');
+      expect(nestedContainer).not.toBeNull();
+      const nestedBlocks = nestedContainer!.querySelectorAll('[data-mast-tool-call-block]');
+      expect(nestedBlocks).toHaveLength(1);
+      expect(nestedBlocks[0].getAttribute('data-tool-name')).toBe('inner_tool');
+      expect(screen.getByText('inner_tool')).toBeDefined();
+    });
+
+    it('renders multiple nested entries in order', () => {
+      const parent: ToolEventEntry = {
+        id: 'parent',
+        type: 'tool_call_started',
+        name: 'agent_tool',
+        args: {},
+        isStreaming: true,
+        nestedToolEvents: [
+          {
+            id: 'nested-a',
+            type: 'tool_call_completed',
+            name: 'inner_a',
+            args: {},
+            result: 'a',
+            isStreaming: false,
+            status: 'success',
+          },
+          {
+            id: 'nested-b',
+            type: 'tool_call_started',
+            name: 'inner_b',
+            args: {},
+            isStreaming: true,
+          },
+        ],
+      };
+      const { container } = render(<ToolCallBlock entry={parent} />);
+      const nested = container.querySelectorAll(
+        '.mast-tool-call-block-nested [data-mast-tool-call-block]',
+      );
+      const names = Array.from(nested).map((el) => el.getAttribute('data-tool-name'));
+      expect(names).toEqual(['inner_a', 'inner_b']);
+    });
+  });
+
   describe('header content', () => {
     it('renders the tool name', () => {
       render(<ToolCallBlock entry={makeEntry({ name: 'get_current_time' })} />);

--- a/packages/react-ui/src/components/ToolCallBlock.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.tsx
@@ -41,6 +41,10 @@ function formatJson(value: unknown): string {
  *   transition plus collapsible `args` and `result`. No sub-agent slots are
  *   rendered.
  *
+ * When `entry.nestedToolEvents` is non-empty, each nested tool call is rendered
+ * recursively inside the parent block so a sub-agent's tool calls appear
+ * indented beneath the sub-agent's narration.
+ *
  * Args/result expand/collapse uses native `<details>/<summary>` so the
  * component is keyboard-accessible without JavaScript.
  */
@@ -60,6 +64,7 @@ export function ToolCallBlock({ entry, className }: ToolCallBlockProps) {
   const icons = useIcons();
   const rootClass = ['mast-tool-call-block', className].filter(Boolean).join(' ');
   const hasSubAgentOutput = entry.subThinking !== undefined || entry.subText !== undefined;
+  const nestedToolEvents = entry.nestedToolEvents ?? [];
   const statusIcon = pickStatusIcon(entry, icons);
   const argsText = formatJson(entry.args);
   const resultText = formatJson(entry.result);
@@ -101,6 +106,14 @@ export function ToolCallBlock({ entry, className }: ToolCallBlockProps) {
               {entry.subText}
             </div>
           ) : null}
+        </div>
+      ) : null}
+
+      {nestedToolEvents.length > 0 ? (
+        <div className="mast-tool-call-block-nested" data-testid="mast-tool-call-nested">
+          {nestedToolEvents.map((nested) => (
+            <ToolCallBlock key={nested.id} entry={nested} />
+          ))}
         </div>
       ) : null}
 

--- a/packages/react-ui/src/hooks/useAgentStream.test.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.test.ts
@@ -419,6 +419,200 @@ describe('useAgentStream', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Nested tool calls (sub-agent fires its own tool calls)
+  // -------------------------------------------------------------------------
+
+  it('appends a nested ToolEventEntry on a child tool_call_started', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      [
+        'agent_tool',
+        [
+          { type: 'tool_call_started', name: 'inner_tool', args: { q: 1 } },
+          { type: 'tool_call_completed', name: 'inner_tool', result: 'inner_result' },
+        ],
+      ],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'agent_tool', args: {} },
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'outer_result' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run nested');
+    });
+
+    const parent = result.current.entries[1].toolEvents[0];
+    expect(parent.name).toBe('agent_tool');
+    expect(parent.nestedToolEvents).toHaveLength(1);
+    expect(parent.nestedToolEvents![0]).toMatchObject({
+      type: 'tool_call_completed',
+      name: 'inner_tool',
+      args: { q: 1 },
+      result: 'inner_result',
+      isStreaming: false,
+      status: 'success',
+    });
+  });
+
+  it('marks a nested entry isStreaming: true while the child tool is in flight', async () => {
+    const { conversation, resume } = pausableConversation(
+      [{ type: 'tool_call_started', name: 'agent_tool', args: {} }],
+      [
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'outer_result' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+    );
+
+    // Patch runStream so the child fires tool_call_started but not completed
+    // while the gate is closed.
+    const base = conversation.runStream.bind(conversation);
+    (conversation as unknown as { runStream: typeof base }).runStream = function (
+      input: string,
+      signal?: AbortSignal,
+      onToolEvent?: OnToolEvent,
+    ) {
+      const inner = base(input, signal, onToolEvent);
+      return (async function* () {
+        for await (const event of inner) {
+          yield event;
+          if (event.type === 'tool_call_started' && onToolEvent) {
+            onToolEvent('agent_tool', {
+              type: 'tool_call_started',
+              name: 'inner_tool',
+              args: {},
+            });
+          }
+        }
+      })();
+    };
+
+    const { result } = renderHook(() => useAgentStream(conversation));
+
+    act(() => {
+      result.current.sendMessage('run');
+    });
+
+    await waitFor(() => {
+      const parent = result.current.entries[1].toolEvents[0];
+      expect(parent?.nestedToolEvents).toHaveLength(1);
+    });
+
+    const parent = result.current.entries[1].toolEvents[0];
+    expect(parent.nestedToolEvents![0]).toMatchObject({
+      type: 'tool_call_started',
+      name: 'inner_tool',
+      isStreaming: true,
+    });
+
+    resume();
+    await act(async () => {});
+  });
+
+  it('records error status on a nested tool_call_completed with error: true', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      [
+        'agent_tool',
+        [
+          { type: 'tool_call_started', name: 'inner_tool', args: {} },
+          {
+            type: 'tool_call_completed',
+            name: 'inner_tool',
+            result: 'boom',
+            error: true,
+          },
+        ],
+      ],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'agent_tool', args: {} },
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'outer_result' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run');
+    });
+
+    const parent = result.current.entries[1].toolEvents[0];
+    expect(parent.nestedToolEvents![0].status).toBe('error');
+  });
+
+  it('routes multiple nested tool calls under the same parent in order', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      [
+        'agent_tool',
+        [
+          { type: 'tool_call_started', name: 'inner_a', args: {} },
+          { type: 'tool_call_completed', name: 'inner_a', result: 'a' },
+          { type: 'tool_call_started', name: 'inner_b', args: {} },
+          { type: 'tool_call_completed', name: 'inner_b', result: 'b' },
+        ],
+      ],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'agent_tool', args: {} },
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'outer_result' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run');
+    });
+
+    const nested = result.current.entries[1].toolEvents[0].nestedToolEvents!;
+    expect(nested.map((n) => n.name)).toEqual(['inner_a', 'inner_b']);
+    expect(nested.map((n) => n.result)).toEqual(['a', 'b']);
+    expect(nested.every((n) => !n.isStreaming)).toBe(true);
+  });
+
+  it('still routes child thinking and text deltas to the parent entry, not nested', async () => {
+    const subEvents = new Map<string, AgentEvent[]>([
+      [
+        'agent_tool',
+        [
+          { type: 'thinking', delta: 'planning ' },
+          { type: 'tool_call_started', name: 'inner_tool', args: {} },
+          { type: 'text_delta', delta: 'narration ' },
+          { type: 'tool_call_completed', name: 'inner_tool', result: 'inner' },
+        ],
+      ],
+    ]);
+    const conv = mockConversation(
+      [
+        { type: 'tool_call_started', name: 'agent_tool', args: {} },
+        { type: 'tool_call_completed', name: 'agent_tool', result: 'outer_result' },
+        { type: 'done', output: 'done', history: [] },
+      ],
+      subEvents,
+    );
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('run');
+    });
+
+    const parent = result.current.entries[1].toolEvents[0];
+    expect(parent.subThinking).toBe('planning ');
+    expect(parent.subText).toBe('narration ');
+    expect(parent.nestedToolEvents).toHaveLength(1);
+    expect(parent.nestedToolEvents![0].subThinking).toBeUndefined();
+    expect(parent.nestedToolEvents![0].subText).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
   // Concurrent tool calls
   // -------------------------------------------------------------------------
 

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -54,6 +54,32 @@ function updateToolEvent(
   });
 }
 
+/**
+ * Returns a new array where the first nested `ToolEventEntry` (under the
+ * parent identified by `parentToolName`) that matches `childName` and is
+ * still streaming is replaced by the result of `updater`. All other entries
+ * and tool events are unchanged.
+ */
+function updateNestedToolEvent(
+  entries: ConversationEntry[],
+  entryId: string,
+  parentToolName: string,
+  childName: string,
+  updater: (n: ToolEventEntry) => ToolEventEntry,
+): ConversationEntry[] {
+  return updateToolEvent(entries, entryId, parentToolName, (parent) => {
+    let patched = false;
+    const nested = (parent.nestedToolEvents ?? []).map((n) => {
+      if (!patched && n.name === childName && n.isStreaming) {
+        patched = true;
+        return updater(n);
+      }
+      return n;
+    });
+    return { ...parent, nestedToolEvents: nested };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -180,6 +206,8 @@ export interface UseAgentStreamReturn {
  * | `tool_call_started` | Push new `ToolEventEntry` with `isStreaming: true` |
  * | `onToolEvent` → `thinking` | Append delta to matching `ToolEventEntry.subThinking` |
  * | `onToolEvent` → `text_delta` | Append delta to matching `ToolEventEntry.subText` |
+ * | `onToolEvent` → `tool_call_started` | Push new nested `ToolEventEntry` onto parent's `nestedToolEvents` |
+ * | `onToolEvent` → `tool_call_completed` | Set `result` and `isStreaming: false` on matching nested entry |
  * | `onToolEvent` → `done` | Ignored |
  * | `tool_call_completed` | Set `result` and `isStreaming: false` on matching entry |
  * | `done` | Set `text = output` and `isStreaming: false` on assistant entry |
@@ -278,6 +306,31 @@ export function useAgentStream(
                   updateToolEvent(prev, assistantId, toolName, (t) => ({
                     ...t,
                     subText: (t.subText ?? '') + event.delta,
+                  })),
+                );
+              } else if (event.type === 'tool_call_started') {
+                const nested: ToolEventEntry = {
+                  id: crypto.randomUUID(),
+                  type: 'tool_call_started',
+                  name: event.name,
+                  args: event.args,
+                  isStreaming: true,
+                };
+                setEntries((prev) =>
+                  updateToolEvent(prev, assistantId, toolName, (t) => ({
+                    ...t,
+                    nestedToolEvents: [...(t.nestedToolEvents ?? []), nested],
+                  })),
+                );
+              } else if (event.type === 'tool_call_completed') {
+                const completedEvent = event;
+                setEntries((prev) =>
+                  updateNestedToolEvent(prev, assistantId, toolName, completedEvent.name, (n) => ({
+                    ...n,
+                    type: 'tool_call_completed',
+                    result: completedEvent.result,
+                    isStreaming: false,
+                    status: completedEvent.error ? 'error' : 'success',
                   })),
                 );
               }

--- a/packages/react-ui/src/types.ts
+++ b/packages/react-ui/src/types.ts
@@ -57,6 +57,19 @@ export interface ToolEventEntry {
   subText?: string;
 
   /**
+   * Tool calls fired by a sub-agent running inside this tool's execution.
+   * Populated incrementally via `onToolEvent` → `tool_call_started` /
+   * `tool_call_completed` events forwarded from the child runner.
+   * `undefined` when the tool is not a sub-agent or has not yet emitted
+   * any nested tool calls.
+   *
+   * Currently scoped to a single level of nesting. The state machine routes
+   * grandchild events back to the outermost matching parent; deeper
+   * disambiguation is a future extension.
+   */
+  nestedToolEvents?: ToolEventEntry[];
+
+  /**
    * `true` while the tool is executing; `false` once `tool_call_completed` is received.
    * Drives the spinner → check-mark transition in `<ToolCallBlock>`.
    */

--- a/packages/react-ui/styles/default.css
+++ b/packages/react-ui/styles/default.css
@@ -355,6 +355,15 @@
   color: var(--mast-fg);
 }
 
+.mast-tool-call-block-nested {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-left: 0.75rem;
+  padding-left: 0.5rem;
+  border-left: 2px solid var(--mast-border);
+}
+
 .mast-tool-call-block-args,
 .mast-tool-call-block-result {
   border: 1px solid var(--mast-border);


### PR DESCRIPTION
Closes #51.

## Summary

- Adds `ToolEventEntry.nestedToolEvents?: ToolEventEntry[]` so a sub-agent's tool calls render as discrete blocks under their parent instead of being dropped.
- `useAgentStream` routes child `tool_call_started` / `tool_call_completed` events (delivered via `onToolEvent`) into the matching parent's nested list. Child `thinking` / `text_delta` continue to flow into the outer entry's `subThinking` / `subText`, since that narration belongs to the sub-agent itself.
- `<ToolCallBlock>` renders nested entries recursively, indented with a left border via the new `.mast-tool-call-block-nested` class.
- Scoped to a single level of nesting; deeper nesting needs path-based routing in `onToolEvent` and is left as a follow-up (called out in `docs/react-ui/SPEC.md` §3).

## Demo

The demo now registers a `summarize_documents` sub-agent built with `createAgentTool` (allowlisted to `read_doc`). When the model delegates to it, each `read_doc` it makes shows up as a nested block under `summarize_documents` in the chat.

To exercise it: type `@Roadmap @Style Guide summarize these` and submit.

## Spec changes

- §3: `nestedToolEvents` field added to the `ToolEventEntry` type, plus a paragraph noting the single-level scope and the deeper-nesting follow-up.
- §4.8: notes recursive rendering of nested entries.
- §8: state machine table now includes rows for nested `tool_call_started` and `tool_call_completed`.
- §11.2: new test scenario for the nested lifecycle.

## Test plan

- [x] `npm run lint`, `npm run format`, `npm run build` all clean.
- [x] `npm test --workspaces --if-present` — 149 react-ui tests pass (including 8 new ones covering append on child started, in-flight `isStreaming`, error status propagation, multi-call ordering, narration-vs-nested routing, and recursive rendering).
- [x] Manual: demo shows `read_doc` calls indented under `summarize_documents` as it executes.