### PR TITLE
feat(demo-react-ui): polish pass for issue 12

### DIFF
--- a/apps/demo-react-ui/.env.example
+++ b/apps/demo-react-ui/.env.example
@@ -1,1 +1,0 @@
-VITE_GEMINI_API_KEY=your_key_here

--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState, type FormEvent } from 'react';
 import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
 import type { Message } from '@mast-ai/core';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
@@ -42,20 +42,23 @@ import {
   type DemoDoc,
 } from './tools';
 
-const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
-if (!apiKey) {
-  console.warn('VITE_GEMINI_API_KEY is not set. Copy .env.example to .env and set your key.');
+/**
+ * Builds a fresh `AgentRunner` for the given API key. The key is held by the
+ * app in `localStorage` rather than baked in via a Vite env var, so the
+ * built bundle can be deployed publicly without leaking credentials.
+ */
+function createRunner(apiKey: string): AgentRunner {
+  const registry = new ToolRegistry()
+    .register(new GetCurrentTimeTool())
+    .register(new GetPageTitleTool())
+    .register(new SetPageTitleTool())
+    .register(new CopyToClipboardTool())
+    .register(new ParseIntegerTool())
+    .register(new ReadDocTool());
+  const next = new AgentRunner(new GoogleGenAIAdapter(apiKey), registry);
+  registry.register(createSummarizeDocumentsTool(next));
+  return next;
 }
-
-const registry = new ToolRegistry()
-  .register(new GetCurrentTimeTool())
-  .register(new GetPageTitleTool())
-  .register(new SetPageTitleTool())
-  .register(new CopyToClipboardTool())
-  .register(new ParseIntegerTool())
-  .register(new ReadDocTool());
-const runner = new AgentRunner(new GoogleGenAIAdapter(apiKey ?? ''), registry);
-registry.register(createSummarizeDocumentsTool(runner));
 
 const agentConfig = createAgent({
   name: 'DemoAssistant',
@@ -129,6 +132,94 @@ const THEME_LABEL: Record<ThemeChoice, string> = {
   light: 'Theme: Light',
   dark: 'Theme: Dark',
 };
+
+// ---------------------------------------------------------------------------
+// API key (browser-side only, kept in localStorage)
+// ---------------------------------------------------------------------------
+
+const API_KEY_STORAGE = 'demo-react-ui:api-key';
+
+function loadApiKey(): string | null {
+  try {
+    return localStorage.getItem(API_KEY_STORAGE);
+  } catch {
+    return null;
+  }
+}
+
+function saveApiKey(key: string) {
+  try {
+    localStorage.setItem(API_KEY_STORAGE, key);
+  } catch (err) {
+    console.warn('Failed to persist API key to localStorage', err);
+  }
+}
+
+function clearApiKey() {
+  try {
+    localStorage.removeItem(API_KEY_STORAGE);
+  } catch (err) {
+    console.warn('Failed to clear API key from localStorage', err);
+  }
+}
+
+interface ApiKeySetupProps {
+  onSubmit: (key: string) => void;
+}
+
+function ApiKeySetup({ onSubmit }: ApiKeySetupProps) {
+  const [value, setValue] = useState('');
+  const trimmed = value.trim();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (trimmed) onSubmit(trimmed);
+  };
+
+  return (
+    <div className="demo-shell">
+      <header className="demo-header">
+        <h1>MAST React UI Demo</h1>
+      </header>
+      <div className="demo-api-key-setup">
+        <form className="demo-api-key-card" onSubmit={handleSubmit}>
+          <h2 className="demo-api-key-title">Enter your Gemini API key</h2>
+          <p>
+            The demo runs entirely in your browser. Your key is saved to this device's{' '}
+            <code>localStorage</code> and is sent only to Google's API, never to any other
+            server.
+          </p>
+          <p>
+            Get a free key at{' '}
+            <a
+              href="https://aistudio.google.com/app/apikey"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              aistudio.google.com/app/apikey
+            </a>
+            .
+          </p>
+          <label className="demo-api-key-label">
+            <span>API key</span>
+            <input
+              type="password"
+              autoComplete="off"
+              spellCheck={false}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="AIzaSy..."
+              autoFocus
+            />
+          </label>
+          <button type="submit" className="demo-header-button" disabled={!trimmed}>
+            Save and continue
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Conversation persistence
@@ -235,12 +326,41 @@ function SetPageTitleApproval({
 }
 
 /**
+ * Wraps `<ToolCallBlock>` in a `<details>` so the bubble starts collapsed and
+ * only shows tool name + status until the user clicks to expand. The inner
+ * `<ToolCallBlock>` header is hidden via CSS to avoid showing the name twice.
+ */
+function CollapsibleToolCall({ entry }: { entry: ToolEventEntry }) {
+  const statusNode = entry.isStreaming ? (
+    <LoaderCircle size={14} className="mast-spin" aria-hidden="true" />
+  ) : entry.status === 'error' || entry.status === 'cancelled' ? (
+    <CircleX size={14} aria-hidden="true" />
+  ) : (
+    <CircleCheck size={14} aria-hidden="true" />
+  );
+  return (
+    <details
+      className="demo-collapsible-tool-call"
+      data-status={entry.status}
+      data-streaming={entry.isStreaming ? 'true' : undefined}
+    >
+      <summary className="demo-collapsible-tool-call-summary">
+        <span className="demo-collapsible-tool-call-status">{statusNode}</span>
+        <Wrench size={14} aria-hidden="true" />
+        <span className="demo-collapsible-tool-call-name">{entry.name}</span>
+      </summary>
+      <ToolCallBlock entry={entry} />
+    </details>
+  );
+}
+
+/**
  * Single render function dispatches across all states:
  *
  * - `set_page_title` awaiting approval → custom card (option a).
  * - any other tool awaiting approval → bundled `<InlineApproval>` (option b).
- * - everything else → bundled `<ToolCallBlock>` with success/error/cancelled
- *   status indicators.
+ * - everything else → `<ToolCallBlock>` wrapped in a collapsible `<details>`
+ *   so the conversation stays scannable.
  */
 const renderToolCall = (entry: ToolEventEntry, approval?: PendingApproval) => {
   if (approval) {
@@ -256,7 +376,7 @@ const renderToolCall = (entry: ToolEventEntry, approval?: PendingApproval) => {
       />
     );
   }
-  return <ToolCallBlock entry={entry} />;
+  return <CollapsibleToolCall entry={entry} />;
 };
 
 /** Header indicator that demonstrates reading `pendingApprovals` via `useAgent`. */
@@ -329,9 +449,68 @@ function ConversationList({ conversations, activeId, onSelect, onDelete }: Conve
   );
 }
 
+/**
+ * Right-hand "How to try it" panel. Static content, kept in the demo so a
+ * fresh visitor knows which example prompts exercise each tool, the mention
+ * picker, the approval flow, and the persistence layer.
+ */
+function InstructionsPanel() {
+  return (
+    <aside className="demo-instructions" aria-labelledby="demo-instructions-title">
+      <h2 id="demo-instructions-title" className="demo-sidebar-title">
+        How to try it
+      </h2>
+      <section className="demo-instructions-section">
+        <h3>Tools</h3>
+        <ul>
+          <li>
+            <strong>“What time is it?”</strong> — runs <code>get_current_time</code> with no
+            approval.
+          </li>
+          <li>
+            <strong>“What is the page title?”</strong> — pauses for an inline approval
+            card.
+          </li>
+          <li>
+            <strong>“Set the page title to <em>Hello</em>.”</strong> — opens a custom
+            Apply / Discard preview.
+          </li>
+          <li>
+            <strong>“Copy <em>foo</em> to the clipboard.”</strong> — pauses for a{' '}
+            <code>window.confirm</code> dialog.
+          </li>
+          <li>
+            <strong>“Parse <em>abc</em> as an integer.”</strong> — surfaces the{' '}
+            <code>error</code> status on the bubble.
+          </li>
+        </ul>
+      </section>
+      <section className="demo-instructions-section">
+        <h3>@-mentions</h3>
+        <p>
+          Type <code>@</code> in the input to pick a demo doc. Try{' '}
+          <em>“Summarise @Roadmap and @Style Guide”</em> to see a sub-agent fan out
+          calls to <code>read_doc</code> nested under <code>summarize_documents</code>.
+        </p>
+      </section>
+      <section className="demo-instructions-section">
+        <h3>UI tips</h3>
+        <ul>
+          <li>Click any tool bubble to expand its arguments and result.</li>
+          <li>Use the theme button to cycle System / Light / Dark.</li>
+          <li>Conversations save to <code>localStorage</code> and reload on refresh.</li>
+          <li>Use “Reset API key” to wipe the saved Gemini key.</li>
+        </ul>
+      </section>
+    </aside>
+  );
+}
+
 export default function App() {
   const [theme, setTheme] = useState<ThemeChoice>('system');
   const panelTheme = theme === 'system' ? undefined : theme;
+
+  const [apiKey, setApiKey] = useState<string | null>(() => loadApiKey());
 
   const [conversations, setConversations] = useState<ConversationMap>(() => loadConversations());
   const [activeId, setActiveId] = useState<string>(() => {
@@ -340,6 +519,19 @@ export default function App() {
   });
 
   const active: StoredConversation | undefined = conversations[activeId];
+
+  const runner = useMemo(() => (apiKey ? createRunner(apiKey) : null), [apiKey]);
+
+  const handleApiKey = useCallback((key: string) => {
+    saveApiKey(key);
+    setApiKey(key);
+  }, []);
+
+  const handleResetApiKey = useCallback(() => {
+    if (!window.confirm('Forget the saved API key? You will need to re-enter it.')) return;
+    clearApiKey();
+    setApiKey(null);
+  }, []);
 
   const handleConversationChange = useCallback(
     (history: Message[], entries: ConversationEntry[]) => {
@@ -389,6 +581,10 @@ export default function App() {
 
   const isUnsavedNew = !active;
 
+  if (!apiKey || !runner) {
+    return <ApiKeySetup onSubmit={handleApiKey} />;
+  }
+
   return (
     <div className="demo-shell">
       <header className="demo-header">
@@ -408,6 +604,9 @@ export default function App() {
             onClick={() => setTheme((current) => NEXT_THEME[current])}
           >
             {THEME_LABEL[theme]}
+          </button>
+          <button type="button" className="demo-header-button" onClick={handleResetApiKey}>
+            Reset API key
           </button>
         </div>
       </header>
@@ -445,6 +644,7 @@ export default function App() {
             />
           </AgentProvider>
         </main>
+        <InstructionsPanel />
       </div>
     </div>
   );

--- a/apps/demo-react-ui/src/index.css
+++ b/apps/demo-react-ui/src/index.css
@@ -23,7 +23,7 @@ body {
   flex-direction: column;
   gap: 1rem;
   height: 100%;
-  max-width: 64rem;
+  width: 100%;
   margin: 0 auto;
   padding: 1rem;
   box-sizing: border-box;
@@ -233,21 +233,9 @@ body {
   font-weight: 600;
 }
 
-.demo-set-title-approval-actions,
-.demo-simple-approval-actions {
+.demo-set-title-approval-actions {
   display: flex;
   gap: 0.5rem;
-}
-
-.demo-simple-approval {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--mast-tool-pending, #f59e0b);
-  border-radius: var(--mast-radius, 0.5rem);
-  background: var(--mast-thinking-bg, #fefce8);
 }
 
 .demo-approval-button {
@@ -266,5 +254,184 @@ body {
 .demo-approval-reject {
   background: transparent;
   border-color: currentColor;
+  color: inherit;
+}
+
+.demo-collapsible-tool-call {
+  border: 1px solid var(--mast-border, #e5e7eb);
+  border-radius: var(--mast-radius, 0.5rem);
+  background: var(--mast-tool-bg, #f0fdf4);
+  color: var(--mast-tool-fg, #166534);
+  font-size: var(--mast-text-sm, 0.875rem);
+}
+
+.demo-collapsible-tool-call[data-status='error'] {
+  background: var(--mast-tool-error-bg, #fef2f2);
+  color: var(--mast-tool-error-fg, #991b1b);
+}
+
+.demo-collapsible-tool-call[data-status='cancelled'] {
+  background: var(--mast-tool-cancelled-bg, #f3f4f6);
+  color: var(--mast-tool-cancelled-fg, #4b5563);
+}
+
+.demo-collapsible-tool-call-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.demo-collapsible-tool-call-summary::-webkit-details-marker {
+  display: none;
+}
+
+.demo-collapsible-tool-call-summary::before {
+  content: '▸';
+  display: inline-block;
+  width: 0.75rem;
+  color: var(--mast-fg-muted, #6b7280);
+  transition: transform 0.15s ease;
+}
+
+.demo-collapsible-tool-call[open] > .demo-collapsible-tool-call-summary::before {
+  transform: rotate(90deg);
+}
+
+.demo-collapsible-tool-call[data-streaming='true'] .demo-collapsible-tool-call-status {
+  color: var(--mast-tool-pending, #f59e0b);
+}
+
+.demo-collapsible-tool-call-name {
+  font-family: var(--mast-font-mono, ui-monospace, monospace);
+  font-weight: 500;
+}
+
+/* The wrapped <ToolCallBlock> already provides its own header. Hide it so the
+   tool name is not shown twice once the section is expanded, and drop the
+   duplicate background and border. */
+.demo-collapsible-tool-call > .mast-tool-call-block {
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0 0.6rem 0.5rem;
+}
+
+.demo-collapsible-tool-call > .mast-tool-call-block > .mast-tool-call-block-header {
+  display: none;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Instructions panel                                                         */
+/* -------------------------------------------------------------------------- */
+
+.demo-instructions {
+  flex: 0 0 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+  border: 1px solid rgba(127, 127, 127, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  overflow-y: auto;
+  font-size: 0.875rem;
+}
+
+.demo-instructions-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.demo-instructions-section h3 {
+  margin: 0;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(127, 127, 127, 1);
+}
+
+.demo-instructions-section p,
+.demo-instructions-section ul {
+  margin: 0;
+}
+
+.demo-instructions-section ul {
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.demo-instructions-section code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125rem;
+  padding: 0 0.2rem;
+  border-radius: 0.2rem;
+  background: rgba(127, 127, 127, 0.15);
+}
+
+/* -------------------------------------------------------------------------- */
+/* API key setup screen                                                       */
+/* -------------------------------------------------------------------------- */
+
+.demo-api-key-setup {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  min-height: 0;
+}
+
+.demo-api-key-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 28rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(127, 127, 127, 0.3);
+  border-radius: 0.75rem;
+  background: rgba(127, 127, 127, 0.05);
+}
+
+.demo-api-key-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.demo-api-key-card p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.demo-api-key-card code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125rem;
+}
+
+.demo-api-key-card a {
+  color: inherit;
+}
+
+.demo-api-key-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.8125rem;
+}
+
+.demo-api-key-label input {
+  font: inherit;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  border-radius: 0.375rem;
+  background: transparent;
   color: inherit;
 }

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -879,12 +879,17 @@ surface and a reference implementation.
 
 ### Stack
 
-| Concern     | Choice                                                                |
-| ----------- | --------------------------------------------------------------------- |
-| Bundler     | Vite                                                                  |
-| LLM adapter | `@mast-ai/google-genai` (API key via `VITE_GEMINI_API_KEY` in `.env`) |
-| Icons       | `lucide-react` (demonstrates icon override)                           |
-| Markdown    | `react-markdown` + `remark-gfm` + `rehype-sanitize`                   |
+| Concern     | Choice                                                            |
+| ----------- | ----------------------------------------------------------------- |
+| Bundler     | Vite                                                              |
+| LLM adapter | `@mast-ai/google-genai` (API key entered in-app, kept in `localStorage`) |
+| Icons       | `lucide-react` (demonstrates icon override)                       |
+| Markdown    | `react-markdown` + `remark-gfm` + `rehype-sanitize`               |
+
+The Gemini API key is **not** read from a Vite env var; baking it into the
+bundle would leak it on any public deployment. The app gates rendering on a
+key stored in `localStorage` and exposes a "Reset API key" button in the
+header to clear it.
 
 ### What it demonstrates
 
@@ -900,6 +905,8 @@ surface and a reference implementation.
    - `copy_to_clipboard` — write, modal approval via `window.confirm` outside the chat.
    - `parse_integer` — read, no approval; throws on invalid input to surface the
      `'error'` status in `<ToolCallBlock>`.
+   Tool bubbles are wrapped in a `<details>` so they start collapsed and can be
+   expanded for arguments, sub-agent output, and the final result.
 4. **Dark mode** — a toggle button that sets `theme="dark"` / `"light"` on
    `<ConversationPanel>`, demonstrating manual theme control alongside the OS default.
 5. **Approval flow** — single `onApprovalRequired` callback dispatches by tool name:
@@ -910,6 +917,9 @@ surface and a reference implementation.
    Save and restore are wired through `onConversationChange` plus `initialHistory` /
    `initialEntries`; switching conversations remounts the provider via a `key`
    keyed on the active conversation id. Storage backend is `localStorage`.
+8. **In-app instructions** — a static right-hand panel listing example prompts
+   (one per tool, one for `@`-mentions) and UI tips so a fresh visitor can drive
+   the demo without external docs.
 
 ### File structure
 
@@ -917,13 +927,12 @@ surface and a reference implementation.
 apps/demo-react-ui/
 ├── src/
 │   ├── main.tsx        — mounts App
-│   ├── App.tsx         — AgentProvider setup, tool registration, theme toggle, renderToolCall, conversation list + localStorage persistence
+│   ├── App.tsx         — API key gate + AgentProvider setup, tool registration, theme toggle, renderToolCall, conversation list + localStorage persistence, instructions panel
 │   └── tools.ts        — five tool definitions covering every approval/status path
 ├── index.html
 ├── vite.config.ts
 ├── tsconfig.json
-├── package.json
-└── .env.example        — VITE_GEMINI_API_KEY=your_key_here
+└── package.json
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Tool call bubbles now wrap in a `<details>` and default to collapsed; a chevron in the summary expands them to show args, sub-agent output, and the result.
- New right-hand instructions panel walks a fresh visitor through example prompts (one per tool, one for `@`-mentions) and UI tips.
- Gemini API key is no longer read from `VITE_GEMINI_API_KEY`. The app gates rendering on a key entered into an in-app form and saved to `localStorage`. Header gets a "Reset API key" button. `.env.example` is removed so the deployed bundle can never leak a key.
- Removed the `max-width: 64rem` cap so the three-column layout fills the full desktop viewport; sidebars keep their fixed widths and the conversation column expands.
- Cleaned up unused `.demo-simple-approval` CSS left from an earlier iteration of the approval card.
- `docs/react-ui/SPEC.md` §12 updated to reflect the new key-handling, collapsible bubbles, and instructions panel.

Closes #40

## Test plan
- [x] `npm run build` from repo root
- [x] `npm run lint` from repo root
- [x] `npm run --workspaces test` (all packages with tests pass)
- [x] Manual: send messages, exercise every tool (`get_current_time`, `get_page_title`, `set_page_title`, `copy_to_clipboard`, `parse_integer`), `@`-mention picker, sub-agent tool nesting via `summarize_documents`
- [x] Manual: reload page, conversation persistence works
- [x] Manual: theme cycle (System / Light / Dark)
- [x] Manual: collapsible tool bubbles open/close on click
- [x] Manual: API key entry, persistence, and Reset flow
- [x] Manual: full-width layout fills the desktop viewport