### PR TITLE
docs(skills): add @mast-ai/react-ui to mast-ai skill

### DIFF
--- a/skills/mast-ai/SKILL.md
+++ b/skills/mast-ai/SKILL.md
@@ -16,6 +16,7 @@ This skill provides expert guidance for implementing AI agents using the MAST li
   - `GoogleGenAIAdapter` (`@mast-ai/google-genai`) calls the Gemini API directly with tool calling, streaming, and thinking mode.
   - `BuiltInAIAdapter` (`@mast-ai/built-in-ai`) runs inference fully on-device via the browser Prompt API (no tool calling).
   - **Custom**: Implement `LlmAdapter` for other providers (Transformers.js, MediaPipe, etc.).
+- **React UI** (`@mast-ai/react-ui`): Drop-in React 19 components (`AgentProvider`, `ConversationPanel`, `useAgent`) for streaming chat UIs, with built-in support for approvals, nested sub-agent tool calls, and `@`-mention pickers.
 
 ## Component References
 
@@ -24,6 +25,7 @@ When implementing MAST features, consult these references for API details and pa
 - **Core API & Agent Configuration**: See [references/core-api.md](references/core-api.md) for `AgentConfig`, `AgentRunner`, `ToolRegistry`, and `Conversation`.
 - **Adapters**: See [references/adapters.md](references/adapters.md) for `UrpAdapter` (HTTP transport), `GoogleGenAIAdapter`, and `BuiltInAIAdapter` with its built-in browser tools.
 - **Custom Adapters**: See [references/custom-adapters.md](references/custom-adapters.md) for implementing your own `LlmAdapter` using Transformers.js, MediaPipe, etc.
+- **React UI**: See [references/react-ui.md](references/react-ui.md) for `@mast-ai/react-ui`: `AgentProvider`, `ConversationPanel`, primitives, the approval flow, nested sub-agent tool events, and the `@`-mention pipeline.
 - **Protocols (URP & ACP)**: See [references/protocols.md](references/protocols.md) if implementing a backend reasoning engine in Rust, Go, or Python.
 
 ## Installation
@@ -57,4 +59,4 @@ _(Note: You may need to specify the workspace subdirectory depending on your pac
 3. **Setup Adapter**: Use `UrpAdapter` for remote inference or implement a custom `LlmAdapter`.
 4. **Run**: Instantiate an `AgentRunner` and use `runner.conversation(agent)` for stateful multi-turn interactions.
 
-For a basic implementation example, see [assets/basic-agent.ts](assets/basic-agent.ts).
+For a basic implementation example, see [assets/basic-agent.ts](assets/basic-agent.ts). For a React UI example wiring `AgentProvider` + `ConversationPanel` to `GoogleGenAIAdapter`, see [assets/react-ui-basic.tsx](assets/react-ui-basic.tsx).

--- a/skills/mast-ai/assets/react-ui-basic.tsx
+++ b/skills/mast-ai/assets/react-ui-basic.tsx
@@ -1,0 +1,59 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
+import type { Tool, ToolContext } from '@mast-ai/core';
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+import { AgentProvider, ConversationPanel } from '@mast-ai/react-ui';
+import '@mast-ai/react-ui/styles.css';
+
+// 1. Define a browser-native tool. The runner sends each tool's definition()
+//    to the LLM and the registry resolves names to implementations at call
+//    time. Tool execution always happens in the browser.
+class GetCurrentTimeTool implements Tool {
+  definition() {
+    return {
+      name: 'get_current_time',
+      description: 'Returns the current time as an ISO 8601 string.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+      scope: 'read' as const,
+    };
+  }
+
+  async call(_args: unknown, _context: ToolContext): Promise<string> {
+    return new Date().toISOString();
+  }
+}
+
+// 2. Build the registry and runner. GoogleGenAIAdapter calls the Gemini API
+//    directly from the browser; for production apps fetch a short-lived token
+//    from a backend instead of baking the key into the bundle.
+const registry = new ToolRegistry().register(new GetCurrentTimeTool());
+const runner = new AgentRunner(
+  new GoogleGenAIAdapter(import.meta.env.VITE_GEMINI_API_KEY),
+  registry,
+);
+
+// 3. Configure the agent. The `tools` array is the LLM's allowlist for the
+//    turn; a tool registered on the registry but missing from this list is
+//    invisible to the model.
+const agent = createAgent({
+  name: 'Assistant',
+  instructions:
+    'You are a helpful assistant. Call get_current_time when the user asks about the current time.',
+  tools: ['get_current_time'],
+});
+
+// 4. Render the chat UI. <AgentProvider> drives a Conversation, exposes the
+//    streaming state via useAgent(), and must wrap any component that calls it.
+export default function App() {
+  return (
+    <AgentProvider runner={runner} agent={agent}>
+      <ConversationPanel inputPlaceholder="Ask me anything." />
+    </AgentProvider>
+  );
+}

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -1,0 +1,256 @@
+# MAST React UI Reference (`@mast-ai/react-ui`)
+
+`@mast-ai/react-ui` turns an `AgentRunner` from `@mast-ai/core` into a streaming chat UI. It ships a default theme, a complete `<ConversationPanel>` widget, and primitives for composing bespoke layouts. The full developer guide is in `docs/react-ui/USAGE.md`; this file is the API reference.
+
+## Installation
+
+```bash
+npm install @mast-ai/core @mast-ai/react-ui @tanstack/react-virtual react react-dom
+```
+
+`@tanstack/react-virtual` is a required peer dependency (used by `<MessageList>`). React must be 19.0 or newer. Optional: `react-markdown` + `remark-gfm` + `rehype-sanitize` for Markdown rendering, `lucide-react` (or any icon set) for icon overrides.
+
+Import the default stylesheet once at app entry:
+
+```ts
+import '@mast-ai/react-ui/styles.css';
+```
+
+CSS custom properties are scoped under `[data-mast-root]` and do not collide with global styles. Skip the import for fully headless usage.
+
+## AgentProvider
+
+Wraps a subtree with agent context. Must be rendered around any component that calls `useAgent()` or any of the bundled rendering primitives.
+
+```typescript
+import { AgentProvider } from '@mast-ai/react-ui';
+
+interface AgentProviderProps {
+  runner: AgentRunner;
+  agent: AgentConfig;
+  children: ReactNode;
+  icons?: IconMap;
+  onApprovalRequired?: OnApprovalRequired;
+  approvalOverride?: string[]; // bare names add approval; '!name' suppresses it
+  initialHistory?: Message[]; // read once on mount
+  initialEntries?: ConversationEntry[]; // read once on mount
+  onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
+}
+```
+
+Internally creates a `Conversation` via `runner.conversation(agent)`. To switch conversations at runtime, remount with a React `key` and seed via `initialHistory` / `initialEntries`. `onConversationChange` fires only after a successful `done` event (not on cancel or error).
+
+## useAgent
+
+Reads the current state from `<AgentProvider>`. Throws if called outside one.
+
+```typescript
+import { useAgent } from '@mast-ai/react-ui';
+
+interface UseAgentReturn {
+  messages: ConversationEntry[];
+  history: Message[];
+  sendMessage: (text: string, displayText?: string) => void;
+  cancel: () => void;
+  isRunning: boolean;
+  reset: () => void;
+  pendingApprovals: PendingApproval[];
+}
+```
+
+`sendMessage(prompt, displayText?)`: when `displayText` is provided the user bubble renders `displayText` while the LLM receives `prompt`. Use this for slash commands, PII redaction, and the mention pipeline.
+
+## ConversationPanel
+
+Drop-in chat UI. Wraps `<MessageList>` and `<ChatInput>` inside a `[data-mast-root]` element.
+
+```typescript
+import { ConversationPanel } from '@mast-ai/react-ui';
+
+interface ConversationPanelProps {
+  theme?: 'light' | 'dark'; // omit to follow prefers-color-scheme
+  className?: string;
+  renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => ReactNode;
+  renderMessage?: (text: string) => ReactNode;
+  inputPlaceholder?: string;
+  mentions?: MentionsConfig;
+}
+```
+
+## Primitives
+
+For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. Add `data-mast-root` to whatever element should anchor the CSS custom properties.
+
+```typescript
+import {
+  MessageList,
+  ChatInput,
+  MessageItem,
+  UserMessage,
+  AssistantMessage,
+  ThinkingBlock,
+  ToolCallBlock,
+  InlineApproval,
+} from '@mast-ai/react-ui';
+```
+
+## ConversationEntry & ToolEventEntry
+
+```typescript
+interface ConversationEntry {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  thinking?: string;
+  toolEvents: ToolEventEntry[];
+  isStreaming: boolean;
+}
+
+interface ToolEventEntry {
+  id: string;
+  type: 'tool_call_started' | 'tool_call_completed';
+  name: string;
+  args?: unknown;
+  result?: unknown;
+  subThinking?: string; // accumulated sub-agent thinking
+  subText?: string; // accumulated sub-agent text
+  nestedToolEvents?: ToolEventEntry[]; // tool calls fired by a sub-agent
+  isStreaming: boolean;
+  awaitingApproval?: boolean;
+  status?: 'success' | 'error' | 'cancelled';
+}
+```
+
+## Approval Flow
+
+Three pieces:
+
+1. Tool author sets `requiresApproval: true` on the tool definition.
+2. App supplies `onApprovalRequired` on `<AgentProvider>`.
+3. Optional: `approvalOverride={['!safe_tool', 'third_party_tool']}` adjusts policy at runtime.
+
+```typescript
+import { INLINE_APPROVAL } from '@mast-ai/react-ui';
+
+type OnApprovalRequired = (toolCall: {
+  name: string;
+  args: unknown;
+}) => Promise<boolean | string | typeof INLINE_APPROVAL>;
+```
+
+Return values:
+
+- `true`: run the tool normally.
+- `false`: runner receives a synthetic "user cancelled" result.
+- `string`: skip execution and inject the string as the tool result.
+- `INLINE_APPROVAL`: defer to the inline approval queue (see below).
+
+### Inline approvals
+
+When `onApprovalRequired` returns `INLINE_APPROVAL`, a `PendingApproval` is added to `useAgent().pendingApprovals` and the runner pauses. `<ConversationPanel renderToolCall>` receives the handle as the second arg:
+
+```typescript
+interface PendingApproval {
+  toolName: string;
+  args: unknown;
+  approve: () => void;
+  reject: () => void;
+  respondWith: (result: unknown) => void; // skip execution, inject custom result
+}
+```
+
+Either compose the bundled `<InlineApproval entry approve reject respondWith />` inside `renderToolCall`, or render a custom card. The library handles all promise plumbing, so consumers never call `new Promise`.
+
+## Nested Sub-Agent Tool Calls
+
+Tools built with `createAgentTool` from `@mast-ai/core` automatically forward their child tool events. `useAgentStream` routes child `tool_call_started` / `tool_call_completed` into `ToolEventEntry.nestedToolEvents`, and `<ToolCallBlock>` renders them recursively. No extra wiring is needed in the consumer.
+
+Currently scoped to a single level: grandchild events route back to the outermost matching parent.
+
+## Mention Pipeline (`@`-mentions)
+
+Opt-in: when `mentions` is omitted, `<ChatInput>` renders an unchanged plain textarea.
+
+```typescript
+interface MentionItem<T = unknown> {
+  id: string;
+  label: string;
+  description?: string;
+  data?: T;
+}
+
+interface MentionSegment<T = unknown> {
+  text: string; // plain text preceding the chip
+  item: MentionItem<T>;
+}
+
+interface MentionsConfig<T = unknown> {
+  trigger?: string; // default '@'
+  items?: MentionItem<T>[]; // static list, filtered by case-insensitive substring on label
+  onSearch?: (query: string) => MentionItem<T>[] | Promise<MentionItem<T>[]>; // wins if both are set
+  renderItem?: (item: MentionItem<T>, isActive: boolean) => ReactNode;
+  renderChip?: (item: MentionItem<T>, onRemove: () => void) => ReactNode;
+  buildPrompt?: (segments: MentionSegment<T>[], trailing: string) => string;
+}
+```
+
+When `buildPrompt` is set, submission calls `sendMessage(buildPrompt(...), inlineDisplayText)`: the LLM receives the augmented prompt while the user bubble shows the inline `@<label>` form.
+
+### useMentions hook
+
+For bespoke inputs (different layout, virtualised picker, non-textarea field):
+
+```typescript
+import { useMentions } from '@mast-ai/react-ui';
+
+const {
+  segments,
+  trailingInput,
+  mentionQuery,
+  filteredItems,
+  pickerIndex,
+  setTrailingInput,
+  handleKeyDown,
+  selectItem,
+  removeChip,
+  buildSubmission, // returns { prompt, displayText }
+  clear,
+} = useMentions(config);
+```
+
+`handleKeyDown` returns `true` when it consumed a key (ArrowUp / ArrowDown / Enter / Escape while the picker has items); the host textarea should suppress its own handling in that case.
+
+## Theming
+
+The default stylesheet ships a light theme and an automatic dark theme that follows `prefers-color-scheme`. Apps that manage their own theme can force a value with `theme="light" | "dark"` on `<ConversationPanel>` (sets `data-mast-theme`).
+
+Override individual tokens by setting CSS custom properties under `[data-mast-root]`:
+
+```css
+[data-mast-root] {
+  --mast-accent: #ec4899;
+  --mast-accent-fg: #ffffff;
+  --mast-radius: 0.25rem;
+}
+```
+
+Mention picker tokens: `--mast-mention-chip-bg`, `--mast-mention-picker-bg`, etc. The full token list is in `docs/react-ui/SPEC.md` §2.2 and §13.7.
+
+## Icons
+
+Override any subset of the bundled inline SVG icons via the `icons` prop on `<AgentProvider>`. Unspecified keys fall back to the defaults.
+
+```typescript
+interface IconMap {
+  brain?: ReactNode; // ThinkingBlock header
+  wrench?: ReactNode; // ToolCallBlock header (pending)
+  check?: ReactNode; // ToolCallBlock header (success)
+  error?: ReactNode; // ToolCallBlock header (error)
+  cancelled?: ReactNode; // ToolCallBlock header (cancelled)
+  loader?: ReactNode; // streaming spinner; apply class 'mast-spin' to rotate
+  send?: ReactNode; // ChatInput send button
+  stop?: ReactNode; // ChatInput cancel button
+}
+```
+
+For a minimal working example, see `assets/react-ui-basic.tsx`.


### PR DESCRIPTION
## Summary

- Adds `skills/mast-ai/references/react-ui.md`: API reference covering `AgentProvider`, `useAgent`, `ConversationPanel`, primitives, the approval flow (`INLINE_APPROVAL`, `<InlineApproval>`, `approvalOverride`), nested sub-agent tool events (#51), and the mention pipeline (#63) including `useMentions` and `sendMessage(prompt, displayText)`. Mirrors `docs/react-ui/USAGE.md` in reference format.
- Adds `skills/mast-ai/assets/react-ui-basic.tsx`: minimal `AgentProvider` + `ConversationPanel` example with `GoogleGenAIAdapter` and one tool. Verified to compile under `apps/demo-react-ui`'s tsconfig.
- Updates `skills/mast-ai/SKILL.md`: adds React UI to the Core Concepts list, the references/react-ui.md link in Component References, and a pointer to the new asset.

Closes #42

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test --workspaces --if-present` (149 passed)
- [x] `npx prettier --check skills/mast-ai/` clean
- [x] Asset compiles under `apps/demo-react-ui` tsconfig (`tsc --noEmit`)