### PR TITLE
chore: ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Claude Code local settings
+.claude


### PR DESCRIPTION
Adds the local `.claude/` directory to `.gitignore` so per-machine Claude Code settings don't get committed.