### PR TITLE
fix(core,react-ui): use .js extensions on relative imports for Node ESM

### DIFF
--- a/packages/core/src/adapter/index.ts
+++ b/packages/core/src/adapter/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Message, ToolCall } from '../types';
-import type { ToolDefinition } from '../tool';
+import type { Message, ToolCall } from '../types.js';
+import type { ToolDefinition } from '../tool.js';
 
 /** Provider-specific model configuration options forwarded verbatim to the adapter. */
 export interface ModelConfig {

--- a/packages/core/src/adapter/urp.ts
+++ b/packages/core/src/adapter/urp.ts
@@ -1,9 +1,9 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { LlmAdapter, AdapterRequest, AdapterResponse, AdapterStreamChunk } from './index';
-import type { Message } from '../types';
-import type { ToolDefinition } from '../tool';
+import type { LlmAdapter, AdapterRequest, AdapterResponse, AdapterStreamChunk } from './index.js';
+import type { Message } from '../types.js';
+import type { ToolDefinition } from '../tool.js';
 
 /** Wire format for a request sent over the Universal Runtime Protocol (URP). */
 export interface UrpRequest {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentConfig } from './types';
-import { AgentError } from './error';
+import type { AgentConfig } from './types.js';
+import { AgentError } from './error.js';
 
 /**
  * Validates and returns an {@link AgentConfig}.

--- a/packages/core/src/agentTool.test.ts
+++ b/packages/core/src/agentTool.test.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi } from 'vitest';
-import { createAgentTool } from './agentTool';
-import { AgentRunner } from './runner';
-import { AgentError } from './error';
-import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index';
-import type { AgentConfig, AgentEvent } from './types';
-import type { ToolContext } from './tool';
+import { createAgentTool } from './agentTool.js';
+import { AgentRunner } from './runner.js';
+import { AgentError } from './error.js';
+import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index.js';
+import type { AgentConfig, AgentEvent } from './types.js';
+import type { ToolContext } from './tool.js';
 
 function streamingAdapter(chunks: AdapterStreamChunk[]): LlmAdapter {
   return {

--- a/packages/core/src/agentTool.ts
+++ b/packages/core/src/agentTool.ts
@@ -1,10 +1,10 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentConfig } from './types';
-import type { AgentRunner } from './runner';
-import type { Tool, ToolContext, ToolDefinition } from './tool';
-import { AgentError } from './error';
+import type { AgentConfig } from './types.js';
+import type { AgentRunner } from './runner.js';
+import type { Tool, ToolContext, ToolDefinition } from './tool.js';
+import { AgentError } from './error.js';
 
 /** Configuration for {@link createAgentTool}. */
 export interface AgentToolOptions {

--- a/packages/core/src/conversation.ts
+++ b/packages/core/src/conversation.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentConfig, AgentEvent, AgentResult, Message } from './types';
-import type { AgentRunner } from './runner';
+import type { AgentConfig, AgentEvent, AgentResult, Message } from './types.js';
+import type { AgentRunner } from './runner.js';
 
 /**
  * Stateful wrapper around {@link AgentRunner} that automatically accumulates

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,15 +4,15 @@
 /** Current version of the `@mast-ai/core` package. */
 export const VERSION = '0.1.0';
 
-export * from './types';
-export * from './error';
-export * from './tool';
-export * from './agent';
-export * from './agentTool';
-export * from './runner';
-export * from './conversation';
+export * from './types.js';
+export * from './error.js';
+export * from './tool.js';
+export * from './agent.js';
+export * from './agentTool.js';
+export * from './runner.js';
+export * from './conversation.js';
 
-export * from './adapter/index';
-export * from './adapter/urp';
+export * from './adapter/index.js';
+export * from './adapter/urp.js';
 
-export * from './transport/http';
+export * from './transport/http.js';

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -1,11 +1,11 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentConfig, AgentEvent, AgentResult, Message, ToolCall } from './types';
-import type { LlmAdapter, AdapterRequest } from './adapter/index';
-import { type ToolProvider, ToolRegistry } from './tool';
-import { AgentError } from './error';
-import { Conversation } from './conversation';
+import type { AgentConfig, AgentEvent, AgentResult, Message, ToolCall } from './types.js';
+import type { LlmAdapter, AdapterRequest } from './adapter/index.js';
+import { type ToolProvider, ToolRegistry } from './tool.js';
+import { AgentError } from './error.js';
+import { Conversation } from './conversation.js';
 
 type StreamExecutor = (
   input: string,

--- a/packages/core/src/tool.test.ts
+++ b/packages/core/src/tool.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi } from 'vitest';
-import { ToolRegistry, ToolRegistryView, type ToolProvider } from './tool';
-import type { Tool, ToolDefinition } from './tool';
+import { ToolRegistry, ToolRegistryView, type ToolProvider } from './tool.js';
+import type { Tool, ToolDefinition } from './tool.js';
 
 function makeTool(name: string, scope: 'read' | 'write'): Tool {
   return {

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AgentEvent } from './types';
+import type { AgentEvent } from './types.js';
 
 /** Static description of a tool that is sent to the model so it can decide when to call it. */
 export interface ToolDefinition {

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { UrpRequest, UrpResponse, UrpTransport, UrpStreamChunk } from '../adapter/urp';
-import { AdapterError } from '../error';
+import type { UrpRequest, UrpResponse, UrpTransport, UrpStreamChunk } from '../adapter/urp.js';
+import { AdapterError } from '../error.js';
 
 /** Configuration for {@link HttpTransport}. */
 export interface HttpTransportOptions {

--- a/packages/react-ui/src/approval.test.tsx
+++ b/packages/react-ui/src/approval.test.tsx
@@ -16,8 +16,8 @@ import {
   type ToolDefinition,
 } from '@mast-ai/core';
 
-import { AgentProvider, useAgent } from './context';
-import { INLINE_APPROVAL, type OnApprovalRequired } from './approval';
+import { AgentProvider, useAgent } from './context.js';
+import { INLINE_APPROVAL, type OnApprovalRequired } from './approval.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react-ui/src/approval.ts
+++ b/packages/react-ui/src/approval.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Tool, ToolContext, ToolDefinition, ToolProvider } from '@mast-ai/core';
-import type { ToolCallStatus, ToolEventEntry } from './types';
+import type { ToolCallStatus, ToolEventEntry } from './types.js';
 
 /**
  * Sentinel value returned from {@link OnApprovalRequired} to defer the

--- a/packages/react-ui/src/components/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/AssistantMessage.tsx
@@ -4,12 +4,12 @@
 import { Fragment, Suspense, lazy } from 'react';
 import type { ReactNode } from 'react';
 
-import { useAgent } from '../context';
-import type { PendingApproval } from '../approval';
-import type { ConversationEntry, ToolEventEntry } from '../types';
-import { InlineApproval } from './InlineApproval';
-import { ThinkingBlock } from './ThinkingBlock';
-import { ToolCallBlock } from './ToolCallBlock';
+import { useAgent } from '../context.js';
+import type { PendingApproval } from '../approval.js';
+import type { ConversationEntry, ToolEventEntry } from '../types.js';
+import { InlineApproval } from './InlineApproval.js';
+import { ThinkingBlock } from './ThinkingBlock.js';
+import { ToolCallBlock } from './ToolCallBlock.js';
 
 /**
  * Props accepted by {@link AssistantMessage}.

--- a/packages/react-ui/src/components/ChatInput.test.tsx
+++ b/packages/react-ui/src/components/ChatInput.test.tsx
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
 
-import { AgentProvider } from '../context';
-import { ChatInput } from './ChatInput';
+import { AgentProvider } from '../context.js';
+import { ChatInput } from './ChatInput.js';
 
 // ---------------------------------------------------------------------------
 // Mock helpers

--- a/packages/react-ui/src/components/ChatInput.tsx
+++ b/packages/react-ui/src/components/ChatInput.tsx
@@ -4,11 +4,11 @@
 import { Fragment, useId, useState } from 'react';
 import type { KeyboardEvent, ReactNode } from 'react';
 
-import { useAgent } from '../context';
-import { useIcons } from '../icons';
-import { MentionPicker } from '../mentions/MentionPicker';
-import { useMentions } from '../mentions/useMentions';
-import type { MentionsConfig } from '../mentions/types';
+import { useAgent } from '../context.js';
+import { useIcons } from '../icons.js';
+import { MentionPicker } from '../mentions/MentionPicker.js';
+import { useMentions } from '../mentions/useMentions.js';
+import type { MentionsConfig } from '../mentions/types.js';
 
 /**
  * Props accepted by {@link ChatInput}.

--- a/packages/react-ui/src/components/ChatInputMentions.test.tsx
+++ b/packages/react-ui/src/components/ChatInputMentions.test.tsx
@@ -7,9 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
 
-import { AgentProvider, useAgent } from '../context';
-import { ChatInput } from './ChatInput';
-import type { MentionItem, MentionsConfig } from '../mentions/types';
+import { AgentProvider, useAgent } from '../context.js';
+import { ChatInput } from './ChatInput.js';
+import type { MentionItem, MentionsConfig } from '../mentions/types.js';
 
 /** Inline spy that surfaces user-bubble text to the DOM for assertions. */
 function MessagesSpy() {

--- a/packages/react-ui/src/components/ConversationPanel.tsx
+++ b/packages/react-ui/src/components/ConversationPanel.tsx
@@ -3,11 +3,11 @@
 
 import type { ReactNode } from 'react';
 
-import type { PendingApproval } from '../approval';
-import type { MentionsConfig } from '../mentions/types';
-import type { ToolEventEntry } from '../types';
-import { ChatInput } from './ChatInput';
-import { MessageList } from './MessageList';
+import type { PendingApproval } from '../approval.js';
+import type { MentionsConfig } from '../mentions/types.js';
+import type { ToolEventEntry } from '../types.js';
+import { ChatInput } from './ChatInput.js';
+import { MessageList } from './MessageList.js';
 
 /**
  * Props accepted by {@link ConversationPanel}.

--- a/packages/react-ui/src/components/InlineApproval.tsx
+++ b/packages/react-ui/src/components/InlineApproval.tsx
@@ -1,8 +1,8 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useIcons } from '../icons';
-import type { ToolEventEntry } from '../types';
+import { useIcons } from '../icons.js';
+import type { ToolEventEntry } from '../types.js';
 
 /**
  * Props passed to a custom `renderApproval` slot and accepted by the

--- a/packages/react-ui/src/components/MessageItem.tsx
+++ b/packages/react-ui/src/components/MessageItem.tsx
@@ -3,10 +3,10 @@
 
 import type { ReactNode } from 'react';
 
-import type { PendingApproval } from '../approval';
-import type { ConversationEntry, ToolEventEntry } from '../types';
-import { AssistantMessage } from './AssistantMessage';
-import { UserMessage } from './UserMessage';
+import type { PendingApproval } from '../approval.js';
+import type { ConversationEntry, ToolEventEntry } from '../types.js';
+import { AssistantMessage } from './AssistantMessage.js';
+import { UserMessage } from './UserMessage.js';
 
 /**
  * Props accepted by {@link MessageItem}.

--- a/packages/react-ui/src/components/MessageList.test.tsx
+++ b/packages/react-ui/src/components/MessageList.test.tsx
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
 
-import { AgentProvider, useAgent } from '../context';
-import { MessageList } from './MessageList';
+import { AgentProvider, useAgent } from '../context.js';
+import { MessageList } from './MessageList.js';
 
 // ---------------------------------------------------------------------------
 // jsdom shims for @tanstack/react-virtual

--- a/packages/react-ui/src/components/MessageList.tsx
+++ b/packages/react-ui/src/components/MessageList.tsx
@@ -5,10 +5,10 @@ import { useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
-import { useAgent } from '../context';
-import type { PendingApproval } from '../approval';
-import type { ToolEventEntry } from '../types';
-import { MessageItem } from './MessageItem';
+import { useAgent } from '../context.js';
+import type { PendingApproval } from '../approval.js';
+import type { ToolEventEntry } from '../types.js';
+import { MessageItem } from './MessageItem.js';
 
 /**
  * Props accepted by {@link MessageList}.

--- a/packages/react-ui/src/components/ThinkingBlock.test.tsx
+++ b/packages/react-ui/src/components/ThinkingBlock.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { ThinkingBlock } from './ThinkingBlock';
+import { ThinkingBlock } from './ThinkingBlock.js';
 
 describe('<ThinkingBlock>', () => {
   afterEach(() => {

--- a/packages/react-ui/src/components/ThinkingBlock.tsx
+++ b/packages/react-ui/src/components/ThinkingBlock.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useIcons } from '../icons';
+import { useIcons } from '../icons.js';
 
 /**
  * Props accepted by {@link ThinkingBlock}.

--- a/packages/react-ui/src/components/ToolCallBlock.test.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.test.tsx
@@ -5,8 +5,8 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { ToolEventEntry } from '../types';
-import { ToolCallBlock } from './ToolCallBlock';
+import type { ToolEventEntry } from '../types.js';
+import { ToolCallBlock } from './ToolCallBlock.js';
 
 function makeEntry(overrides: Partial<ToolEventEntry> = {}): ToolEventEntry {
   return {

--- a/packages/react-ui/src/components/ToolCallBlock.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.tsx
@@ -1,9 +1,9 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useIcons } from '../icons';
-import type { ToolEventEntry } from '../types';
-import { ThinkingBlock } from './ThinkingBlock';
+import { useIcons } from '../icons.js';
+import type { ToolEventEntry } from '../types.js';
+import { ThinkingBlock } from './ThinkingBlock.js';
 
 /**
  * Props accepted by {@link ToolCallBlock}.

--- a/packages/react-ui/src/components/UserMessage.tsx
+++ b/packages/react-ui/src/components/UserMessage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ConversationEntry } from '../types';
+import type { ConversationEntry } from '../types.js';
 
 /**
  * Props accepted by {@link UserMessage}.

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -6,9 +6,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ReactNode } from 'react';
 import type { AgentConfig, AgentEvent, AgentRunner, Conversation, Message } from '@mast-ai/core';
 
-import { AgentProvider, useAgent } from './context';
-import { defaultIcons, useIcons } from './icons';
-import type { ConversationEntry, IconMap } from './types';
+import { AgentProvider, useAgent } from './context.js';
+import { defaultIcons, useIcons } from './icons.js';
+import type { ConversationEntry, IconMap } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Mock helpers

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -6,15 +6,15 @@ import type { ReactNode } from 'react';
 import { AgentRunner } from '@mast-ai/core';
 import type { AgentConfig, Conversation, Message } from '@mast-ai/core';
 
-import { useAgentStream } from './hooks/useAgentStream';
-import { IconProvider } from './icons';
+import { useAgentStream } from './hooks/useAgentStream.js';
+import { IconProvider } from './icons.js';
 import {
   withApprovalProxy,
   type ApprovalProxyHooks,
   type OnApprovalRequired,
   type PendingApproval,
-} from './approval';
-import type { ConversationEntry, IconMap, ToolCallStatus } from './types';
+} from './approval.js';
+import type { ConversationEntry, IconMap, ToolCallStatus } from './types.js';
 
 /**
  * Props accepted by {@link AgentProvider}.
@@ -38,7 +38,7 @@ export interface AgentProviderProps {
    * evaluates to `true`. Resolve with `true` to proceed, `false` to cancel
    * (the runner receives a synthetic "user cancelled" result), a string to
    * short-circuit execution with that string as the tool result, or
-   * {@link import('./approval').INLINE_APPROVAL} to defer to the inline
+   * {@link import('./approval.js').INLINE_APPROVAL} to defer to the inline
    * approval queue exposed via `useAgent().pendingApprovals`.
    *
    * Not called when no tool requires approval, and not called when the prop

--- a/packages/react-ui/src/hooks/useAgentStream.test.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.test.ts
@@ -4,7 +4,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import type { AgentEvent, Conversation } from '@mast-ai/core';
-import { useAgentStream } from './useAgentStream';
+import { useAgentStream } from './useAgentStream.js';
 
 // ---------------------------------------------------------------------------
 // Mock helpers

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -4,7 +4,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { Conversation, Message } from '@mast-ai/core';
 import type { AgentEvent } from '@mast-ai/core';
-import type { ConversationEntry, ToolCallStatus, ToolEventEntry } from '../types';
+import type { ConversationEntry, ToolCallStatus, ToolEventEntry } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Private helpers

--- a/packages/react-ui/src/icons.tsx
+++ b/packages/react-ui/src/icons.tsx
@@ -4,7 +4,7 @@
 import { createContext, useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
 
-import type { IconMap } from './types';
+import type { IconMap } from './types.js';
 
 /**
  * Shared SVG attributes for the bundled defaults. Each icon is a 16x16

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -1,36 +1,36 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-export type { ConversationEntry, ToolEventEntry, ToolCallStatus, IconMap } from './types';
-export { useAgentStream } from './hooks/useAgentStream';
-export type { UseAgentStreamOptions, UseAgentStreamReturn } from './hooks/useAgentStream';
-export { AgentProvider, useAgent } from './context';
-export type { AgentProviderProps, UseAgentReturn } from './context';
-export { INLINE_APPROVAL } from './approval';
-export type { OnApprovalRequired, PendingApproval } from './approval';
-export { InlineApproval } from './components/InlineApproval';
-export type { InlineApprovalProps } from './components/InlineApproval';
-export { ThinkingBlock } from './components/ThinkingBlock';
-export type { ThinkingBlockProps } from './components/ThinkingBlock';
-export { ToolCallBlock } from './components/ToolCallBlock';
-export type { ToolCallBlockProps } from './components/ToolCallBlock';
-export { UserMessage } from './components/UserMessage';
-export type { UserMessageProps } from './components/UserMessage';
-export { AssistantMessage } from './components/AssistantMessage';
-export type { AssistantMessageProps } from './components/AssistantMessage';
-export { ChatInput } from './components/ChatInput';
-export type { ChatInputProps } from './components/ChatInput';
-export { MessageItem } from './components/MessageItem';
-export type { MessageItemProps } from './components/MessageItem';
-export { MessageList } from './components/MessageList';
-export type { MessageListProps } from './components/MessageList';
-export { ConversationPanel } from './components/ConversationPanel';
-export type { ConversationPanelProps } from './components/ConversationPanel';
-export { useMentions } from './mentions/useMentions';
-export type { UseMentionsReturn } from './mentions/useMentions';
+export type { ConversationEntry, ToolEventEntry, ToolCallStatus, IconMap } from './types.js';
+export { useAgentStream } from './hooks/useAgentStream.js';
+export type { UseAgentStreamOptions, UseAgentStreamReturn } from './hooks/useAgentStream.js';
+export { AgentProvider, useAgent } from './context.js';
+export type { AgentProviderProps, UseAgentReturn } from './context.js';
+export { INLINE_APPROVAL } from './approval.js';
+export type { OnApprovalRequired, PendingApproval } from './approval.js';
+export { InlineApproval } from './components/InlineApproval.js';
+export type { InlineApprovalProps } from './components/InlineApproval.js';
+export { ThinkingBlock } from './components/ThinkingBlock.js';
+export type { ThinkingBlockProps } from './components/ThinkingBlock.js';
+export { ToolCallBlock } from './components/ToolCallBlock.js';
+export type { ToolCallBlockProps } from './components/ToolCallBlock.js';
+export { UserMessage } from './components/UserMessage.js';
+export type { UserMessageProps } from './components/UserMessage.js';
+export { AssistantMessage } from './components/AssistantMessage.js';
+export type { AssistantMessageProps } from './components/AssistantMessage.js';
+export { ChatInput } from './components/ChatInput.js';
+export type { ChatInputProps } from './components/ChatInput.js';
+export { MessageItem } from './components/MessageItem.js';
+export type { MessageItemProps } from './components/MessageItem.js';
+export { MessageList } from './components/MessageList.js';
+export type { MessageListProps } from './components/MessageList.js';
+export { ConversationPanel } from './components/ConversationPanel.js';
+export type { ConversationPanelProps } from './components/ConversationPanel.js';
+export { useMentions } from './mentions/useMentions.js';
+export type { UseMentionsReturn } from './mentions/useMentions.js';
 export {
   buildInlineMentionPrompt,
   extractMentionQuery,
   removeMentionTrigger,
-} from './mentions/utils';
-export type { MentionItem, MentionSegment, MentionsConfig } from './mentions/types';
+} from './mentions/utils.js';
+export type { MentionItem, MentionSegment, MentionsConfig } from './mentions/types.js';

--- a/packages/react-ui/src/mentions/MentionPicker.tsx
+++ b/packages/react-ui/src/mentions/MentionPicker.tsx
@@ -3,7 +3,7 @@
 
 import type { ReactNode } from 'react';
 
-import type { MentionItem } from './types';
+import type { MentionItem } from './types.js';
 
 /**
  * Props accepted by {@link MentionPicker}. Exported for consumers building
@@ -27,7 +27,7 @@ export interface MentionPickerProps<T = unknown> {
 }
 
 /**
- * Floating popover rendered above {@link import('../components/ChatInput').ChatInput}
+ * Floating popover rendered above {@link import('../components/ChatInput.js').ChatInput}
  * when an in-progress mention has at least one filtered item.
  *
  * Uses `role="listbox"` with `role="option"` rows so screen readers announce

--- a/packages/react-ui/src/mentions/index.ts
+++ b/packages/react-ui/src/mentions/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-export type { MentionItem, MentionSegment, MentionsConfig } from './types';
-export { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils';
-export { useMentions } from './useMentions';
-export type { UseMentionsReturn } from './useMentions';
-export { MentionPicker } from './MentionPicker';
-export type { MentionPickerProps } from './MentionPicker';
+export type { MentionItem, MentionSegment, MentionsConfig } from './types.js';
+export { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils.js';
+export { useMentions } from './useMentions.js';
+export type { UseMentionsReturn } from './useMentions.js';
+export { MentionPicker } from './MentionPicker.js';
+export type { MentionPickerProps } from './MentionPicker.js';

--- a/packages/react-ui/src/mentions/useMentions.test.ts
+++ b/packages/react-ui/src/mentions/useMentions.test.ts
@@ -5,8 +5,8 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { StrictMode, type KeyboardEvent } from 'react';
 
-import { useMentions } from './useMentions';
-import type { MentionItem } from './types';
+import { useMentions } from './useMentions.js';
+import type { MentionItem } from './types.js';
 
 interface DocPayload {
   path: string;

--- a/packages/react-ui/src/mentions/useMentions.ts
+++ b/packages/react-ui/src/mentions/useMentions.ts
@@ -4,8 +4,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 
-import type { MentionItem, MentionSegment, MentionsConfig } from './types';
-import { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils';
+import type { MentionItem, MentionSegment, MentionsConfig } from './types.js';
+import { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils.js';
 
 /**
  * Return shape of {@link useMentions}.

--- a/packages/react-ui/src/mentions/utils.test.ts
+++ b/packages/react-ui/src/mentions/utils.test.ts
@@ -3,8 +3,8 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils';
-import type { MentionSegment } from './types';
+import { buildInlineMentionPrompt, extractMentionQuery, removeMentionTrigger } from './utils.js';
+import type { MentionSegment } from './types.js';
 
 describe('extractMentionQuery', () => {
   it('returns the query when the input ends with `@<chars>`', () => {

--- a/packages/react-ui/src/mentions/utils.ts
+++ b/packages/react-ui/src/mentions/utils.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import type { MentionSegment } from './types';
+import type { MentionSegment } from './types.js';
 
 const DEFAULT_TRIGGER = '@';
 


### PR DESCRIPTION
## Summary

- `@mast-ai/core` source used extensionless relative imports (`from './types'`). `tsconfig.json` uses `moduleResolution: \"bundler\"`, which compiles them as-is, but `package.json` declares `\"type\": \"module\"`, so Node's strict ESM loader requires explicit file extensions and was rejecting the compiled output with `ERR_MODULE_NOT_FOUND`. Bundlers like Vite were tolerating it; downstream Node-ESM consumers (e.g. vitest resolving `@mast-ai/core` through `node_modules/`) were not. This fix adds `.js` extensions to every relative `import`/`export ... from` in `core` source.
- `@mast-ai/react-ui` had the same source-level pattern but a different consequence. Its runtime ships as a single Vite-bundled `dist/index.js`, so Node never traverses the relative imports — but the extensionless paths leaked into the `tsc`-emitted `.d.ts` files, breaking TypeScript consumers using strict module resolution (`nodenext` / `node16`). Same mechanical fix applied here for consistency and to unblock those consumers.
- `@mast-ai/built-in-ai` and `@mast-ai/google-genai` already followed the `.js`-extension convention; verified clean.

## Notes for reviewers

- Mechanical change: 39 files, 138 swaps of `'./x'` → `'./x.js'`. No `tsconfig.json` change needed — `bundler` resolution accepts `.js` extensions, it just doesn't require them.
- The `.js` extension in `.ts` source is the conventional pattern for publishable Node-ESM packages: TypeScript treats it as a hint about the *runtime* file and resolves it back to the `.ts` source at compile time.
- This ships as part of an `0.1.1` patch release across all four `@mast-ai/*` packages — published `0.1.0` of `core` is broken for Node consumers.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build -w @mast-ai/core -w @mast-ai/google-genai -w @mast-ai/built-in-ai -w @mast-ai/react-ui` succeeds
- [x] `npm test --workspaces --if-present` — 249 tests pass (22 core + 67 built-in-ai + 11 google-genai + 149 react-ui)
- [x] Verified `packages/react-ui/dist/index.d.ts` now emits `from './types.js'` etc.
- [x] Verified the fix against the Node-loader path: rebuilt `dist/` copied into a downstream consumer (`agent-text-editor`)'s `node_modules/@mast-ai/core/dist/`, all 293 of its tests pass (previously broken)