### PR TITLE
chore: release v0.1.1

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.1.0"
+    "@mast-ai/core": "^0.1.1"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.1.0"
+    "@mast-ai/core": "^0.1.1"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -34,7 +34,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.1.0",
+    "@mast-ai/core": "^0.1.1",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -43,9 +43,9 @@ for (const { pkg, previous, next } of updated) {
 
 console.log(`
 Next steps:
-  npm install                         # refresh package-lock
+  npm install                         # refresh node_modules
   npm run format                      # normalise package.json formatting
-  git add packages/*/package.json package-lock.json
+  git add packages/*/package.json
   git commit -m "chore: release v${newVersion}"
   git tag v${newVersion}
   git push origin <branch> --tags


### PR DESCRIPTION
## Summary

- Lockstep bump of all four `@mast-ai/*` packages from `0.1.0` to `0.1.1`, plus updating `@mast-ai/core` peer/dep references in `react-ui` etc. to `^0.1.1`.
- Patch release. Picks up the relative-import `.js`-extension fix from #75 — published `0.1.0` of `@mast-ai/core` is broken for Node-ESM consumers, and `react-ui`'s `.d.ts` files had the same hazard for strict-TS consumers.
- Drive-by: drops the now-stale `package-lock.json` reference from `scripts/bump-version.mjs`'s "Next steps" output (lockfile was gitignored in #74).

## Notes for reviewers

- Once this merges, tagging `v0.1.1` on `main` triggers `.github/workflows/publish.yml`, which lints, tests, builds, and publishes all four packages to npm via OIDC.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build -w @mast-ai/core -w @mast-ai/google-genai -w @mast-ai/built-in-ai -w @mast-ai/react-ui` succeeds
- [x] `npm test --workspaces --if-present` — 249 tests pass (22 core + 67 built-in-ai + 11 google-genai + 149 react-ui) at 0.1.1