### PR TITLE
fix(ci): build before test in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,11 @@ jobs:
 
       - run: npm run lint
 
-      - run: npm test --workspaces --if-present
-
+      # Build before tests so workspace packages that depend on
+      # @mast-ai/core can resolve its `dist/index.js` entry.
       - run: npm run build -w @mast-ai/core -w @mast-ai/google-genai -w @mast-ai/built-in-ai -w @mast-ai/react-ui
+
+      - run: npm test --workspaces --if-present
 
       - name: Publish @mast-ai/core
         run: npm publish --provenance -w @mast-ai/core


### PR DESCRIPTION
## Summary

The `v0.1.1` publish run failed with `Failed to resolve entry for package \"@mast-ai/core\"`. Tests in `@mast-ai/built-in-ai` and `@mast-ai/react-ui` import from `@mast-ai/core`, whose `package.json` points `main`/`exports` at `./dist/index.js`. The publish workflow runs tests **before** build, so on a fresh CI checkout `dist/` doesn't exist yet and Vite fails to resolve the entry.

Swapping the two steps fixes it. `ci.yml` already runs build before test, which is why this didn't show up on PR CI.

Nothing was published — the failure happened before the publish steps. npm registry still only has `0.1.0` for all four packages.

## Notes for reviewers

- After this merges, re-trigger the publish workflow for `v0.1.1` via `workflow_dispatch` from the Actions tab (input: `v0.1.1`). The workflow definition is loaded from `main` (with this fix), the checkout step pulls source from the `v0.1.1` tag — no retag needed.

## Test plan

- [x] Diff is a 2-line swap in `.github/workflows/publish.yml` plus a comment.
- [ ] Real validation: re-run `Publish` workflow against `v0.1.1` after merge.