### PR TITLE
chore: release v0.1.2

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.1.1"
+    "@mast-ai/core": "^0.1.2"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.1.1"
+    "@mast-ai/core": "^0.1.2"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -34,7 +34,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.1.1",
+    "@mast-ai/core": "^0.1.2",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
Bumps all four `@mast-ai/*` packages from `0.1.1` to `0.1.2`.

## Changes since v0.1.1

- `@mast-ai/react-ui`: `feat(react-ui): collapsible <ToolCallBlock>` (#85, closes #78)
- `@mast-ai/core`, `@mast-ai/google-genai`, `@mast-ai/built-in-ai`: no source changes; bumped in lockstep per the release policy.

## Test plan

- [x] `npm run lint`, `npm test --workspaces --if-present`, `npm run build` all green locally.
- [x] After merge, tag `v0.1.2` on `main` to trigger the publish workflow.