### PR TITLE
feat(react-ui): renderApproval slot for inline approval cards

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -10,13 +10,13 @@ import {
   ConversationPanel,
   INLINE_APPROVAL,
   InlineApproval,
-  ToolCallBlock,
   useAgent,
   type ConversationEntry,
   type IconMap,
   type MentionsConfig,
   type OnApprovalRequired,
   type PendingApproval,
+  type RenderApproval,
   type ToolEventEntry,
 } from '@mast-ai/react-ui';
 import {
@@ -286,8 +286,10 @@ const onApprovalRequired: OnApprovalRequired = async (toolCall) => {
 
 /**
  * Custom Apply/Discard card for `set_page_title` that previews the proposed
- * title. Demonstrates option (a): full layout control via `renderToolCall`,
- * with `approve()` / `reject()` plumbed through the second arg.
+ * title instead of dumping the raw arg JSON. Wired through the
+ * `renderApproval` slot, which only fires for tool events with a pending
+ * approval handle and leaves the rest of the tool-call rendering to the
+ * default `<ToolCallBlock>`.
  */
 function SetPageTitleApproval({
   entry,
@@ -325,29 +327,23 @@ function SetPageTitleApproval({
 }
 
 /**
- * Single render function dispatches across all states:
- *
- * - `set_page_title` awaiting approval → custom card (option a).
- * - any other tool awaiting approval → bundled `<InlineApproval>` (option b).
- * - everything else → `<ToolCallBlock>` (collapses on completion via its
- *   built-in `defaultOpen='streaming'` behaviour, so the conversation stays
- *   scannable).
+ * Dispatches the inline approval card by tool name. `set_page_title` gets a
+ * bespoke preview; every other approval-required tool falls back to the
+ * bundled `<InlineApproval>`. Non-approval tool events are not handled here
+ * at all — they fall through to the default `<ToolCallBlock>` rendering.
  */
-const renderToolCall = (entry: ToolEventEntry, approval?: PendingApproval) => {
-  if (approval) {
-    if (entry.name === 'set_page_title') {
-      return <SetPageTitleApproval entry={entry} approval={approval} />;
-    }
-    return (
-      <InlineApproval
-        entry={entry}
-        approve={approval.approve}
-        reject={approval.reject}
-        respondWith={approval.respondWith}
-      />
-    );
+const renderApproval: RenderApproval = (entry, approval) => {
+  if (entry.name === 'set_page_title') {
+    return <SetPageTitleApproval entry={entry} approval={approval} />;
   }
-  return <ToolCallBlock entry={entry} />;
+  return (
+    <InlineApproval
+      entry={entry}
+      approve={approval.approve}
+      reject={approval.reject}
+      respondWith={approval.respondWith}
+    />
+  );
 };
 
 /** Header indicator that demonstrates reading `pendingApprovals` via `useAgent`. */
@@ -616,7 +612,7 @@ export default function App() {
             </div>
             <ConversationPanel
               theme={panelTheme}
-              renderToolCall={renderToolCall}
+              renderApproval={renderApproval}
               mentions={mentionsConfig as MentionsConfig}
               inputPlaceholder="Type @ to reference a doc, then press Enter."
             />

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -277,6 +277,19 @@ interface ConversationPanelProps {
    */
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => React.ReactNode;
 
+  /**
+   * Replace only the inline approval card. Called once per tool event whose
+   * call is awaiting an inline approval decision; non-approval tool events
+   * fall through to renderToolCall (or the default <ToolCallBlock>).
+   *
+   * Use this slot to customise the approval prompt (e.g. render
+   * "Rename document 'Old' to 'New'?" instead of the raw arg JSON) without
+   * forking the rest of the tool-call rendering. Takes precedence over
+   * renderToolCall for entries with a pending approval handle when both
+   * are provided.
+   */
+  renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
+
   /** Replace the default markdown renderer. Receives the raw text string. */
   renderMessage?: (text: string) => React.ReactNode;
 
@@ -304,7 +317,8 @@ entry (currently streaming) changes size.
 ```tsx
 interface MessageListProps {
   className?: string;
-  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+  renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => React.ReactNode;
+  renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
   renderMessage?: (text: string) => React.ReactNode;
 }
 ```
@@ -337,7 +351,8 @@ Renders a single `ConversationEntry`. Delegates to `<UserMessage>` or
 interface MessageItemProps {
   entry: ConversationEntry;
   className?: string;
-  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+  renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => React.ReactNode;
+  renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
   renderMessage?: (text: string) => React.ReactNode;
 }
 ```
@@ -352,7 +367,14 @@ Renders an assistant turn: optional `<ThinkingBlock>`, zero or more
 interface AssistantMessageProps {
   entry: ConversationEntry;
   className?: string;
-  renderToolCall?: (entry: ToolEventEntry) => React.ReactNode;
+  renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => React.ReactNode;
+  /**
+   * Replace only the inline approval card. Called once per tool event with a
+   * pending approval handle; non-approval events fall through to
+   * renderToolCall (or the default <ToolCallBlock>). Takes precedence over
+   * renderToolCall for awaiting entries when both are provided.
+   */
+  renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
   renderMessage?: (text: string) => React.ReactNode;
 }
 ```
@@ -737,17 +759,28 @@ interface PendingApproval {
 ```
 
 The library handles promise-resolver plumbing — consumers never call `new Promise`
-themselves. Two ergonomic entry points use this queue:
+themselves. Three ergonomic entry points use this queue:
 
-**(a) Custom rendering via `renderToolCall`.** The single `renderToolCall` prop on
-`<ConversationPanel>` / `<MessageList>` receives `(entry, approval?)`; when `approval`
-is present the consumer can render any UI they like and wire the buttons directly to
-`approval.approve()` / `approval.reject()`.
+**(a) Approval-only slot via `renderApproval`.** The `renderApproval` prop on
+`<ConversationPanel>` / `<MessageList>` / `<MessageItem>` / `<AssistantMessage>`
+is called once per tool event with a pending approval handle; non-approval events
+fall through to `renderToolCall` or the default `<ToolCallBlock>`. Use this when
+you only want to customise the approval card (e.g. render a friendly summary
+instead of the raw arg JSON) without rebuilding the rest of the tool-call
+rendering. Takes precedence over `renderToolCall` for awaiting entries when both
+are provided.
 
-**(b) Built-in `<InlineApproval>` component.** Exported as a stand-alone component
-that renders a default approve/reject card. Compose it inside `renderToolCall` for
-tools that should use the default skin, or omit `renderToolCall` entirely — the
-library uses it as the default for any awaiting entry with a handle.
+**(b) Full tool-call rendering via `renderToolCall`.** The `renderToolCall` prop
+receives `(entry, approval?)`; when `approval` is present the consumer can render
+any UI they like and wire the buttons directly to `approval.approve()` /
+`approval.reject()`. Use this when the approval card and the rest of the
+tool-call rendering should both be customised together.
+
+**(c) Built-in `<InlineApproval>` component.** Exported as a stand-alone component
+that renders a default approve/reject card. Compose it inside `renderToolCall`
+or `renderApproval` for tools that should use the default skin, or omit both
+slots entirely — the library uses it as the default for any awaiting entry with
+a handle.
 
 When `reset()` is called while approvals are pending, the library calls `reject()`
 on each so their proxies finish and the run terminates cleanly.

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -612,6 +612,89 @@ The library handles all promise-resolver plumbing; consumers never call
 `useAgent().pendingApprovals` so app chrome (e.g. a header badge) can show how
 many tools are paused.
 
+#### Customising only the approval card with `renderApproval`
+
+The default `<InlineApproval>` shows the tool name and the raw args JSON. For a
+tool whose args are opaque internal fields (ids, flags), that is a poor prompt:
+`rename_document({ id: '44c2…', title: 'New' })` reads as a UUID and a string
+when what the user wants to see is `Rename "Old" to "New"?`.
+
+The `renderToolCall` callback can intercept this case, but doing so means
+rebuilding the layout, buttons, and styling of every other tool call too. The
+narrower `renderApproval` slot replaces only the approval card and lets the
+default `<ToolCallBlock>` keep rendering everything else:
+
+```tsx
+import { ConversationPanel, InlineApproval, type RenderApproval } from '@mast-ai/react-ui';
+
+const renderApproval: RenderApproval = (entry, approval) => {
+  switch (entry.name) {
+    case 'rename_document': {
+      const args = entry.args as { id: string; title: string };
+      return (
+        <ApprovalCard
+          summary={`Rename document to "${args.title}"?`}
+          onApprove={approval.approve}
+          onReject={approval.reject}
+        />
+      );
+    }
+    case 'delete_document': {
+      const args = entry.args as { id: string; title: string };
+      return (
+        <ApprovalCard
+          summary={`Delete "${args.title}"?`}
+          danger
+          onApprove={approval.approve}
+          onReject={approval.reject}
+        />
+      );
+    }
+    default:
+      // Fall back to the bundled card for tools without bespoke copy.
+      return (
+        <InlineApproval
+          entry={entry}
+          approve={approval.approve}
+          reject={approval.reject}
+          respondWith={approval.respondWith}
+        />
+      );
+  }
+};
+
+function ApprovalCard({
+  summary,
+  danger,
+  onApprove,
+  onReject,
+}: {
+  summary: string;
+  danger?: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}) {
+  return (
+    <div className={danger ? 'my-approval danger' : 'my-approval'}>
+      <p>{summary}</p>
+      <button type="button" onClick={onApprove}>
+        Approve
+      </button>
+      <button type="button" onClick={onReject}>
+        Reject
+      </button>
+    </div>
+  );
+}
+
+<ConversationPanel renderApproval={renderApproval} />;
+```
+
+When both `renderApproval` and `renderToolCall` are provided, `renderApproval`
+wins for entries with a pending approval handle and `renderToolCall` continues
+to handle every other tool event. Compose `<InlineApproval>` (or `<ToolCallBlock>`)
+inside either slot as the fallback for tools you have not customised.
+
 ### 10.4 Runtime overrides
 
 `approvalOverride` adjusts the policy without touching tool definitions:

--- a/packages/react-ui/src/components/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/AssistantMessage.tsx
@@ -12,6 +12,14 @@ import { ThinkingBlock } from './ThinkingBlock.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
 
 /**
+ * Slot for replacing only the inline approval card while keeping the default
+ * `<ToolCallBlock>` rendering for non-approval tool events. Receives the
+ * matching {@link ToolEventEntry} and the live {@link PendingApproval} handle
+ * exposing `approve()`, `reject()`, and `respondWith()`.
+ */
+export type RenderApproval = (entry: ToolEventEntry, approval: PendingApproval) => ReactNode;
+
+/**
  * Props accepted by {@link AssistantMessage}.
  */
 export interface AssistantMessageProps {
@@ -38,8 +46,23 @@ export interface AssistantMessageProps {
    * When this prop is omitted, the library defaults to rendering
    * `<InlineApproval>` for tool events with a pending approval handle and
    * `<ToolCallBlock>` otherwise.
+   *
+   * Takes a back seat to {@link AssistantMessageProps.renderApproval} when
+   * both are provided and the entry has a pending approval handle.
    */
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => ReactNode;
+  /**
+   * Replaces only the inline approval card. Called once per tool event whose
+   * call is awaiting an inline approval decision (i.e. has a matching
+   * {@link PendingApproval} handle); non-approval tool events fall through to
+   * `renderToolCall` or the default `<ToolCallBlock>`.
+   *
+   * Use this slot to customise the approval prompt without rebuilding the
+   * tool-call rendering for every other event. Takes precedence over
+   * `renderToolCall` for entries with a pending approval handle when both
+   * are provided.
+   */
+  renderApproval?: RenderApproval;
 }
 
 interface MarkdownTextProps {
@@ -97,6 +120,7 @@ export function AssistantMessage({
   className,
   renderMessage,
   renderToolCall,
+  renderApproval,
 }: AssistantMessageProps) {
   const rootClass = ['mast-assistant-message', className].filter(Boolean).join(' ');
   const { pendingApprovals } = useAgent();
@@ -111,6 +135,7 @@ export function AssistantMessage({
       ? pendingApprovals.find((p) => p.toolName === toolEvent.name)
       : undefined;
 
+    if (approval && renderApproval) return renderApproval(toolEvent, approval);
     if (renderToolCall) return renderToolCall(toolEvent, approval);
 
     if (approval) {

--- a/packages/react-ui/src/components/ConversationPanel.tsx
+++ b/packages/react-ui/src/components/ConversationPanel.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import type { PendingApproval } from '../approval.js';
 import type { MentionsConfig } from '../mentions/types.js';
 import type { ToolEventEntry } from '../types.js';
+import type { RenderApproval } from './AssistantMessage.js';
 import { ChatInput } from './ChatInput.js';
 import { MessageList } from './MessageList.js';
 
@@ -27,6 +28,13 @@ export interface ConversationPanelProps {
    * awaiting an inline approval decision.
    */
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => ReactNode;
+  /**
+   * Replaces only the inline approval card. Use this slot to customise the
+   * approval prompt without rebuilding the rest of the tool-call rendering.
+   * Takes precedence over `renderToolCall` for entries with a pending
+   * approval handle when both are provided.
+   */
+  renderApproval?: RenderApproval;
   /** Replaces the default assistant text renderer for the entire list. */
   renderMessage?: (text: string) => ReactNode;
   /** Placeholder text for the {@link ChatInput} field. */
@@ -52,6 +60,7 @@ export function ConversationPanel({
   theme,
   className,
   renderToolCall,
+  renderApproval,
   renderMessage,
   inputPlaceholder,
   mentions,
@@ -60,7 +69,11 @@ export function ConversationPanel({
 
   return (
     <div data-mast-root data-mast-theme={theme} className={rootClass}>
-      <MessageList renderToolCall={renderToolCall} renderMessage={renderMessage} />
+      <MessageList
+        renderToolCall={renderToolCall}
+        renderApproval={renderApproval}
+        renderMessage={renderMessage}
+      />
       <ChatInput placeholder={inputPlaceholder} mentions={mentions} />
     </div>
   );

--- a/packages/react-ui/src/components/MessageItem.tsx
+++ b/packages/react-ui/src/components/MessageItem.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 
 import type { PendingApproval } from '../approval.js';
 import type { ConversationEntry, ToolEventEntry } from '../types.js';
-import { AssistantMessage } from './AssistantMessage.js';
+import { AssistantMessage, type RenderApproval } from './AssistantMessage.js';
 import { UserMessage } from './UserMessage.js';
 
 /**
@@ -25,6 +25,11 @@ export interface MessageItemProps {
    * Forwarded to {@link AssistantMessage}. Has no effect when `entry.role` is
    * `'user'`.
    */
+  renderApproval?: RenderApproval;
+  /**
+   * Forwarded to {@link AssistantMessage}. Has no effect when `entry.role` is
+   * `'user'`.
+   */
   renderMessage?: (text: string) => ReactNode;
 }
 
@@ -34,7 +39,13 @@ export interface MessageItemProps {
  *
  * Used by {@link MessageList} to render each virtualised row.
  */
-export function MessageItem({ entry, className, renderToolCall, renderMessage }: MessageItemProps) {
+export function MessageItem({
+  entry,
+  className,
+  renderToolCall,
+  renderApproval,
+  renderMessage,
+}: MessageItemProps) {
   if (entry.role === 'user') {
     return <UserMessage entry={entry} className={className} />;
   }
@@ -43,6 +54,7 @@ export function MessageItem({ entry, className, renderToolCall, renderMessage }:
       entry={entry}
       className={className}
       renderToolCall={renderToolCall}
+      renderApproval={renderApproval}
       renderMessage={renderMessage}
     />
   );

--- a/packages/react-ui/src/components/MessageList.test.tsx
+++ b/packages/react-ui/src/components/MessageList.test.tsx
@@ -1,13 +1,27 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
-import type { AgentConfig, AgentEvent, AgentRunner, Conversation } from '@mast-ai/core';
+import {
+  AgentRunner,
+  ToolRegistry,
+  type AdapterRequest,
+  type AdapterStreamChunk,
+  type AgentConfig,
+  type AgentEvent,
+  type Conversation,
+  type LlmAdapter,
+  type Tool,
+  type ToolContext,
+  type ToolDefinition,
+} from '@mast-ai/core';
 
 import { AgentProvider, useAgent } from '../context.js';
+import { INLINE_APPROVAL, type PendingApproval } from '../approval.js';
+import type { ToolEventEntry } from '../types.js';
 import { MessageList } from './MessageList.js';
 
 // ---------------------------------------------------------------------------
@@ -204,5 +218,157 @@ describe('<MessageList>', () => {
     await user.click(screen.getByRole('button', { name: 'send run tool' }));
 
     expect(await screen.findByText('tool:demo_tool')).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // renderApproval slot
+  //
+  // Exercises the full forwarding chain (MessageList → MessageItem →
+  // AssistantMessage) plus the approval proxy. The approval flow only fires
+  // through the real `AgentRunner`, so these tests build one with a scripted
+  // `LlmAdapter` rather than the bare-Conversation mock used above.
+  // ---------------------------------------------------------------------------
+
+  function scriptedAdapter(scripts: AdapterStreamChunk[][]): LlmAdapter {
+    let i = 0;
+    return {
+      generate: vi.fn(),
+      generateStream: (_request: AdapterRequest) => {
+        const script = scripts[i++] ?? [];
+        return (async function* () {
+          for (const chunk of script) yield chunk;
+        })();
+      },
+    };
+  }
+
+  const SENSITIVE_DEF: ToolDefinition = {
+    name: 'sensitive',
+    description: 'A sensitive tool that requires approval.',
+    parameters: { type: 'object', properties: {}, required: [] },
+    scope: 'write',
+    requiresApproval: true,
+  };
+
+  class StubTool implements Tool {
+    constructor(
+      private readonly _definition: ToolDefinition,
+      private readonly _result: unknown = 'stub-result',
+    ) {}
+    definition(): ToolDefinition {
+      return this._definition;
+    }
+    async call(_args: unknown, _ctx: ToolContext): Promise<unknown> {
+      return this._result;
+    }
+  }
+
+  function makeApprovalRunner(): AgentRunner {
+    const registry = new ToolRegistry().register(new StubTool(SENSITIVE_DEF));
+    const adapter = scriptedAdapter([
+      [{ type: 'tool_call', toolCall: { id: '1', name: 'sensitive', args: { foo: 'bar' } } }],
+      [{ type: 'text_delta', delta: 'done' }],
+    ]);
+    return new AgentRunner(adapter, registry);
+  }
+
+  it('renders renderApproval for entries with a pending approval handle', async () => {
+    const user = userEvent.setup();
+    const runner = makeApprovalRunner();
+    const renderApproval = vi.fn(
+      (entry: ToolEventEntry, approval: PendingApproval): ReactNode => (
+        <div data-testid="custom-approval">
+          Approve {entry.name} args={JSON.stringify(entry.args)}
+          <button type="button" onClick={approval.approve}>
+            Yes
+          </button>
+        </div>
+      ),
+    );
+
+    render(
+      <AgentProvider
+        runner={runner}
+        agent={agentConfig}
+        onApprovalRequired={async () => INLINE_APPROVAL}
+      >
+        <SendButton text="go" />
+        <MessageList renderApproval={renderApproval} />
+      </AgentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send go' }));
+
+    const card = await screen.findByTestId('custom-approval');
+    expect(card.textContent).toContain('Approve sensitive');
+    expect(card.textContent).toContain('{"foo":"bar"}');
+
+    // The bundled InlineApproval must not render alongside the custom slot.
+    expect(document.querySelector('[data-mast-inline-approval]')).toBeNull();
+
+    // The slot received the live PendingApproval handle.
+    const lastCall = renderApproval.mock.calls.at(-1)!;
+    expect(lastCall[0]).toMatchObject({ name: 'sensitive', args: { foo: 'bar' } });
+    expect(lastCall[1]).toMatchObject({
+      toolName: 'sensitive',
+      args: { foo: 'bar' },
+      approve: expect.any(Function),
+      reject: expect.any(Function),
+      respondWith: expect.any(Function),
+    });
+  });
+
+  it('falls back to <InlineApproval> when renderApproval is omitted', async () => {
+    const user = userEvent.setup();
+    const runner = makeApprovalRunner();
+
+    render(
+      <AgentProvider
+        runner={runner}
+        agent={agentConfig}
+        onApprovalRequired={async () => INLINE_APPROVAL}
+      >
+        <SendButton text="go" />
+        <MessageList />
+      </AgentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send go' }));
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-mast-inline-approval]')).not.toBeNull();
+    });
+  });
+
+  it('renderApproval takes precedence over renderToolCall for awaiting entries', async () => {
+    const user = userEvent.setup();
+    const runner = makeApprovalRunner();
+    const renderApproval = vi.fn(
+      (_entry: ToolEventEntry, _approval: PendingApproval): ReactNode => (
+        <div data-testid="approval-slot">approval slot</div>
+      ),
+    );
+    const renderToolCall = vi.fn(
+      (entry: ToolEventEntry, _approval?: PendingApproval): ReactNode => (
+        <div data-testid="tool-slot">tool slot {entry.name}</div>
+      ),
+    );
+
+    render(
+      <AgentProvider
+        runner={runner}
+        agent={agentConfig}
+        onApprovalRequired={async () => INLINE_APPROVAL}
+      >
+        <SendButton text="go" />
+        <MessageList renderApproval={renderApproval} renderToolCall={renderToolCall} />
+      </AgentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send go' }));
+
+    expect(await screen.findByTestId('approval-slot')).toBeDefined();
+    expect(screen.queryByTestId('tool-slot')).toBeNull();
+    expect(renderApproval).toHaveBeenCalled();
   });
 });

--- a/packages/react-ui/src/components/MessageList.tsx
+++ b/packages/react-ui/src/components/MessageList.tsx
@@ -8,6 +8,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { useAgent } from '../context.js';
 import type { PendingApproval } from '../approval.js';
 import type { ToolEventEntry } from '../types.js';
+import type { RenderApproval } from './AssistantMessage.js';
 import { MessageItem } from './MessageItem.js';
 
 /**
@@ -23,6 +24,13 @@ export interface MessageListProps {
    * decision.
    */
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => ReactNode;
+  /**
+   * Forwarded to each {@link MessageItem} so consumers can replace only the
+   * inline approval card without overriding the rest of the tool-call
+   * rendering. Takes precedence over `renderToolCall` for entries with a
+   * pending approval handle when both are provided.
+   */
+  renderApproval?: RenderApproval;
   /**
    * Forwarded to each {@link MessageItem} so consumers can replace the default
    * assistant text renderer for the entire list.
@@ -53,7 +61,12 @@ const DEFAULT_ESTIMATED_ITEM_HEIGHT = 80;
  * Reads `messages` from `useAgent()`, so this component must be rendered
  * inside an `<AgentProvider>`.
  */
-export function MessageList({ className, renderToolCall, renderMessage }: MessageListProps) {
+export function MessageList({
+  className,
+  renderToolCall,
+  renderApproval,
+  renderMessage,
+}: MessageListProps) {
   const { messages } = useAgent();
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -101,6 +114,7 @@ export function MessageList({ className, renderToolCall, renderMessage }: Messag
               <MessageItem
                 entry={entry}
                 renderToolCall={renderToolCall}
+                renderApproval={renderApproval}
                 renderMessage={renderMessage}
               />
             </div>

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -17,7 +17,7 @@ export type { ToolCallBlockProps } from './components/ToolCallBlock.js';
 export { UserMessage } from './components/UserMessage.js';
 export type { UserMessageProps } from './components/UserMessage.js';
 export { AssistantMessage } from './components/AssistantMessage.js';
-export type { AssistantMessageProps } from './components/AssistantMessage.js';
+export type { AssistantMessageProps, RenderApproval } from './components/AssistantMessage.js';
 export { ChatInput } from './components/ChatInput.js';
 export type { ChatInputProps } from './components/ChatInput.js';
 export { MessageItem } from './components/MessageItem.js';

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -71,6 +71,7 @@ interface ConversationPanelProps {
   theme?: 'light' | 'dark'; // omit to follow prefers-color-scheme
   className?: string;
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => ReactNode;
+  renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => ReactNode;
   renderMessage?: (text: string) => ReactNode;
   inputPlaceholder?: string;
   mentions?: MentionsConfig;
@@ -147,7 +148,7 @@ Return values:
 
 ### Inline approvals
 
-When `onApprovalRequired` returns `INLINE_APPROVAL`, a `PendingApproval` is added to `useAgent().pendingApprovals` and the runner pauses. `<ConversationPanel renderToolCall>` receives the handle as the second arg:
+When `onApprovalRequired` returns `INLINE_APPROVAL`, a `PendingApproval` is added to `useAgent().pendingApprovals` and the runner pauses:
 
 ```typescript
 interface PendingApproval {
@@ -159,7 +160,13 @@ interface PendingApproval {
 }
 ```
 
-Either compose the bundled `<InlineApproval entry approve reject respondWith />` inside `renderToolCall`, or render a custom card. The library handles all promise plumbing, so consumers never call `new Promise`.
+Three rendering entry points:
+
+- **`renderApproval`** (narrow): replaces only the approval card. Called once per tool event with a pending approval handle; non-approval events fall through to `renderToolCall` or the default `<ToolCallBlock>`. Use this when you only want to customise the approval prompt (e.g. render `Rename "Old" to "New"?` instead of the raw arg JSON). Compose `<InlineApproval entry approve reject respondWith />` inside the slot as the fallback for tools you have not customised.
+- **`renderToolCall`** (full): receives `(entry, approval?)` for every tool event. Use this when the approval card and the rest of the tool-call rendering should both be customised together.
+- **`<InlineApproval>`** (default): used automatically for any awaiting entry when neither slot is provided.
+
+`renderApproval` takes precedence over `renderToolCall` for awaiting entries when both are provided. The library handles all promise plumbing, so consumers never call `new Promise`.
 
 ## Nested Sub-Agent Tool Calls
 


### PR DESCRIPTION
## Summary

- Adds a `renderApproval` slot, parallel to `renderToolCall`, on `<ConversationPanel>`, `<MessageList>`, `<MessageItem>`, and `<AssistantMessage>`. The slot replaces only the inline approval card and leaves non-approval tool events to the default `<ToolCallBlock>` (or `renderToolCall` if also provided).
- `renderApproval` takes precedence over `renderToolCall` for entries with a pending approval handle when both are provided. When neither slot is set, the library still falls back to the bundled `<InlineApproval>` — no behavior change for existing consumers.
- Migrates the demo's `set_page_title` custom card from `renderToolCall` to the new slot to show the tighter integration point.
- Updates `docs/react-ui/SPEC.md` (prop tables + §9.3 entry-points list), `docs/react-ui/USAGE.md` (new "Customising only the approval card" subsection with a `switch (entry.name)` example), and `skills/mast-ai/references/react-ui.md`.

Closes #79

## Test plan

- [x] `npm run lint`, `npm run build`, `npm run format`, `npm test --workspaces --if-present` all pass (259 tests across 4 packages).
- [x] New unit tests in `packages/react-ui/src/components/MessageList.test.tsx`: slot is called with the right `(entry, approval)` and bundled `<InlineApproval>` is not rendered; default `<InlineApproval>` still renders when slot is omitted; `renderApproval` wins over `renderToolCall` for awaiting entries.
- [x] Manual test in the demo: approval-required `set_page_title` and `get_page_title` flows still render correctly; non-approval tools fall through to `<ToolCallBlock>` unchanged.