### PR TITLE
feat(core): RunBuilder.forwardTo() for sub-agent event forwarding

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -242,6 +242,15 @@ export class RunBuilder {
    */
   onToolEvent(handler: (toolName: string, event: AgentEvent) => void): this;
 
+  /**
+   * Forwards every non-`done` event from this run to `parentContext.onEvent`.
+   * Intended for tools that internally run a sub-agent: chain this on the
+   * sub-agent's RunBuilder so the parent runner's UI receives child events
+   * without manual forwarding boilerplate. No-op if `parentContext.onEvent`
+   * is undefined.
+   */
+  forwardTo(parentContext: ToolContext): this;
+
   runStream(input: string): AsyncIterable<AgentEvent>;
   run(input: string): Promise<AgentResult>;
   runTyped<T>(input: string): Promise<T>;
@@ -342,8 +351,8 @@ export function createAgentTool(
 The returned tool's `call(args, context)`:
 
 1. Builds the child input via `options.buildInput(args)`.
-2. Calls `runner.runBuilder(agent).signal(context.signal).runStream(input)`.
-3. For every event whose type is not `done`, calls `context.onEvent?.(event)`.
+2. Calls `runner.runBuilder(agent).forwardTo(context).signal(context.signal).runStream(input)`.
+3. `forwardTo(context)` automatically forwards every non-`done` child event to `context.onEvent`.
 4. Returns the `done.output` string as the tool result.
 5. Throws `AgentError` if the stream ends without a `done` event.
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -768,6 +768,51 @@ Nesting is currently scoped to a single level (a sub-agent calling its own
 tools). Grandchild events route back to the outermost matching parent; deeper
 disambiguation is a future extension tracked in the SPEC.
 
+### 11.1 Custom sub-agent tools: use `forwardTo(context)`
+
+`createAgentTool` is the canonical wrapper, but some tools need custom logic
+around the sub-agent run (multi-step orchestration, conditional invocation,
+post-processing). Those tools should chain `forwardTo(context)` on the
+sub-agent's `RunBuilder` instead of hand-rolling the forwarding loop:
+
+```ts
+import type { Tool, ToolContext, AgentRunner, AgentConfig } from '@mast-ai/core';
+
+export function createInvokeWriterTool(runner: AgentRunner, agent: AgentConfig): Tool {
+  return {
+    definition: () => ({
+      name: 'invoke_writer',
+      description: 'Delegates a writing task to the writer agent.',
+      parameters: { type: 'object', properties: { task: { type: 'string' } } },
+      scope: 'write',
+    }),
+    async call(args, context: ToolContext): Promise<string> {
+      const { task } = args as { task: string };
+      const builder = runner.runBuilder(agent).forwardTo(context);
+      if (context.signal) builder.signal(context.signal);
+
+      for await (const event of builder.runStream(task)) {
+        if (event.type === 'done') return event.output;
+      }
+      throw new Error("Writer sub-agent ended without a 'done' event");
+    },
+  };
+}
+```
+
+`forwardTo(context)`:
+
+- Forwards every non-`done` child event to `context.onEvent`, populating
+  `subThinking` / `subText` / `nestedToolEvents` on the parent's tool entry.
+- Filters `done` events automatically (they carry the child's full history,
+  which must not leak to the parent runner's consumer).
+- Is a no-op when `context.onEvent` is undefined.
+- Composes with `history()`, `signal()`, and `onToolEvent()` in any order.
+
+Forgetting to call `forwardTo(context)` is a silent failure: the tool runs
+fine but the parent's tool block shows no streamed sub-output. Always
+chain it on any sub-agent `RunBuilder` invoked from a tool's `call`.
+
 ---
 
 ## 12. Mention pipeline (`@`-mentions)

--- a/docs/tool-event-streaming/PLAN.md
+++ b/docs/tool-event-streaming/PLAN.md
@@ -64,22 +64,32 @@ const result = await tool.call(call.args, {
 
 ### In the sub-agent tool (`delegate_to_skill`)
 
-Switch from `run()` to `runStream()` and forward non-`done` events:
+Chain `forwardTo(context)` on the sub-agent's `RunBuilder` to forward
+non-`done` events automatically:
 
 ```typescript
 async call(args: DelegateToSkillArgs, context: ToolContext): Promise<string> {
-  for await (const event of childRunner.runBuilder(skill).runStream(args.input)) {
-    if (event.type !== 'done') {
-      context.onEvent?.(event); // forward thinking / text_delta / tool_call_* only
-    } else {
-      return event.output;      // only the result goes back to the parent agent
+  const builder = childRunner.runBuilder(skill).forwardTo(context);
+  for await (const event of builder.runStream(args.input)) {
+    if (event.type === 'done') {
+      return event.output; // only the result goes back to the parent agent
     }
   }
   throw new Error('Child runner ended without a done event');
 }
 ```
 
-`done` must be filtered out. It carries `history: Message[]` — the child's full conversation history — which must not reach the parent's consumers. The parent agent's own context is unaffected (it only sees the tool result string), but UI consumers registered via `onToolEvent` would receive the history payload if `done` is forwarded.
+`forwardTo(context)` filters out `done` automatically. `done` must not be
+forwarded because it carries `history: Message[]` — the child's full
+conversation history — which must not reach the parent's consumers. The
+parent agent's own context is unaffected (it only sees the tool result
+string), but UI consumers registered via `onToolEvent` would receive the
+history payload if `done` is forwarded.
+
+Tools that wrap a sub-agent without custom logic should use
+`createAgentTool`, which encodes this contract once. `forwardTo(context)`
+exists for tools that need custom orchestration around the sub-agent run
+(multi-step delegation, conditional invocation, post-processing).
 
 ### At the parent run call site
 

--- a/packages/core/src/agentTool.ts
+++ b/packages/core/src/agentTool.ts
@@ -46,14 +46,13 @@ export function createAgentTool(
     definition: () => definition,
     async call(args: unknown, context: ToolContext): Promise<string> {
       const input = options.buildInput(args);
-      const builder = runner.runBuilder(agent);
+      const builder = runner.runBuilder(agent).forwardTo(context);
       if (context.signal) builder.signal(context.signal);
 
       for await (const event of builder.runStream(input)) {
         if (event.type === 'done') {
           return event.output;
         }
-        context.onEvent?.(event);
       }
 
       throw new AgentError(`Sub-agent '${agent.name}' stream ended without a 'done' event.`);

--- a/packages/core/src/runner.test.ts
+++ b/packages/core/src/runner.test.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { AgentRunner } from './runner.js';
+import { AgentError } from './error.js';
+import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index.js';
+import type { AgentConfig, AgentEvent } from './types.js';
+import type { ToolContext } from './tool.js';
+
+function streamingAdapter(chunks: AdapterStreamChunk[]): LlmAdapter {
+  return {
+    generate: vi.fn(),
+    generateStream: (_request: AdapterRequest) =>
+      (async function* () {
+        for (const chunk of chunks) yield chunk;
+      })(),
+  };
+}
+
+const agent: AgentConfig = {
+  name: 'Child',
+  instructions: 'Be a child agent.',
+};
+
+describe('RunBuilder.forwardTo', () => {
+  it('forwards every non-done event to parentContext.onEvent in order', async () => {
+    const runner = new AgentRunner(
+      streamingAdapter([
+        { type: 'thinking', delta: 'pondering' },
+        { type: 'text_delta', delta: 'Hello ' },
+        { type: 'text_delta', delta: 'world' },
+      ]),
+    );
+
+    const forwarded: AgentEvent[] = [];
+    const yielded: AgentEvent[] = [];
+    const context: ToolContext = { onEvent: (e) => forwarded.push(e) };
+
+    for await (const event of runner.runBuilder(agent).forwardTo(context).runStream('hi')) {
+      yielded.push(event);
+    }
+
+    expect(forwarded.map((e) => e.type)).toEqual(['thinking', 'text_delta', 'text_delta']);
+    expect(forwarded.some((e) => e.type === 'done')).toBe(false);
+
+    // The stream itself still yields every event including done.
+    expect(yielded.map((e) => e.type)).toEqual(['thinking', 'text_delta', 'text_delta', 'done']);
+  });
+
+  it('is a no-op when parentContext.onEvent is undefined', async () => {
+    const runner = new AgentRunner(streamingAdapter([{ type: 'text_delta', delta: 'ok' }]));
+
+    const yielded: AgentEvent[] = [];
+    for await (const event of runner.runBuilder(agent).forwardTo({}).runStream('hi')) {
+      yielded.push(event);
+    }
+
+    // Stream still yields normally; nothing to assert beyond not throwing.
+    expect(yielded.map((e) => e.type)).toEqual(['text_delta', 'done']);
+  });
+
+  it('is chainable with history(), signal(), and onToolEvent()', async () => {
+    const runner = new AgentRunner(streamingAdapter([{ type: 'text_delta', delta: 'ok' }]));
+    const controller = new AbortController();
+    const onToolEvent = vi.fn();
+    const onEvent = vi.fn();
+
+    const builder = runner
+      .runBuilder(agent)
+      .history([])
+      .signal(controller.signal)
+      .forwardTo({ onEvent })
+      .onToolEvent(onToolEvent);
+
+    const events: AgentEvent[] = [];
+    for await (const event of builder.runStream('hi')) {
+      events.push(event);
+    }
+
+    expect(events.map((e) => e.type)).toEqual(['text_delta', 'done']);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({ type: 'text_delta', delta: 'ok' });
+  });
+
+  it('still propagates an aborted signal through the run', async () => {
+    const controller = new AbortController();
+    controller.abort('test reason');
+
+    const runner = new AgentRunner(streamingAdapter([{ type: 'text_delta', delta: 'x' }]));
+
+    await expect(
+      (async () => {
+        for await (const _event of runner
+          .runBuilder(agent)
+          .signal(controller.signal)
+          .forwardTo({ onEvent: vi.fn() })
+          .runStream('hi')) {
+          // drain
+        }
+      })(),
+    ).rejects.toBeInstanceOf(AgentError);
+  });
+});

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -3,7 +3,7 @@
 
 import type { AgentConfig, AgentEvent, AgentResult, Message, ToolCall } from './types.js';
 import type { LlmAdapter, AdapterRequest } from './adapter/index.js';
-import { type ToolProvider, ToolRegistry } from './tool.js';
+import { type ToolContext, type ToolProvider, ToolRegistry } from './tool.js';
 import { AgentError } from './error.js';
 import { Conversation } from './conversation.js';
 
@@ -24,6 +24,7 @@ export class RunBuilder {
   private _history: Message[] = [];
   private _signal?: AbortSignal;
   private _onToolEvent?: (toolName: string, event: AgentEvent) => void;
+  private _forwardContext?: ToolContext;
 
   constructor(
     private readonly agent: AgentConfig,
@@ -53,9 +54,33 @@ export class RunBuilder {
     return this;
   }
 
+  /**
+   * Forwards every non-`done` event yielded by this run to
+   * `parentContext.onEvent`. Intended for tools that internally run a
+   * sub-agent: chain this so the parent runner's UI can populate
+   * `subThinking` / `subText` / `nestedToolEvents` on the parent's tool
+   * entry without manual forwarding boilerplate.
+   *
+   * `done` events are filtered out to avoid leaking child conversation
+   * history to the parent's consumers. If `parentContext.onEvent` is
+   * undefined, this is a no-op.
+   */
+  forwardTo(parentContext: ToolContext): this {
+    this._forwardContext = parentContext;
+    return this;
+  }
+
   /** Executes the run and returns a stream of {@link AgentEvent} objects. */
   runStream(input: string): AsyncIterable<AgentEvent> {
-    return this.execute(input, this._history, this._signal, this._onToolEvent);
+    const stream = this.execute(input, this._history, this._signal, this._onToolEvent);
+    const onEvent = this._forwardContext?.onEvent;
+    if (!onEvent) return stream;
+    return (async function* () {
+      for await (const event of stream) {
+        if (event.type !== 'done') onEvent(event);
+        yield event;
+      }
+    })();
   }
 
   /** Executes the run and returns the final text output. */

--- a/skills/mast-ai/references/core-api.md
+++ b/skills/mast-ai/references/core-api.md
@@ -84,6 +84,14 @@ export class RunBuilder {
    */
   onToolEvent(handler: (toolName: string, event: AgentEvent) => void): this;
 
+  /**
+   * For tools that internally run a sub-agent: chain this on the sub-agent's
+   * RunBuilder to forward every non-`done` event to parentContext.onEvent.
+   * Filters `done` (which carries child history) automatically. No-op when
+   * parentContext.onEvent is undefined.
+   */
+  forwardTo(parentContext: ToolContext): this;
+
   runStream(input: string): AsyncIterable<AgentEvent>;
   run(input: string): Promise<AgentResult>;
   runTyped<T>(input: string): Promise<T>;
@@ -96,6 +104,15 @@ runner
     if (event.type === 'text_delta') updateSkillPanel(toolName, event.delta);
   })
   .runStream(input);
+
+// Usage — inside a custom tool that wraps a sub-agent
+async call(args, context: ToolContext): Promise<string> {
+  const builder = childRunner.runBuilder(childAgent).forwardTo(context);
+  for await (const event of builder.runStream(input)) {
+    if (event.type === 'done') return event.output;
+  }
+  throw new Error('child stream ended without done');
+}
 ```
 
 ## Conversation

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -172,6 +172,8 @@ Three rendering entry points:
 
 Tools built with `createAgentTool` from `@mast-ai/core` automatically forward their child tool events. `useAgentStream` routes child `tool_call_started` / `tool_call_completed` into `ToolEventEntry.nestedToolEvents`, and `<ToolCallBlock>` renders them recursively. No extra wiring is needed in the consumer.
 
+For custom tools that wrap a sub-agent (where `createAgentTool` is too prescriptive), chain `RunBuilder.forwardTo(context)` on the sub-agent run so the parent's `subThinking` / `subText` / `nestedToolEvents` populate without manual forwarding boilerplate. Forgetting to forward is a silent UX failure.
+
 Currently scoped to a single level: grandchild events route back to the outermost matching parent.
 
 ## Collapsible `<ToolCallBlock>`


### PR DESCRIPTION
## Summary

- Adds `RunBuilder.forwardTo(parentContext)` — a chainable helper that forwards every non-`done` event from a run to `parentContext.onEvent`. Filters `done` (which carries child history); no-op when `onEvent` is undefined; composes with `history()` / `signal()` / `onToolEvent()` in any order.
- Refactors `createAgentTool` to use the new helper internally (one line of duplicated boilerplate gone).
- Updates `docs/SPEC.md`, `docs/react-ui/USAGE.md` (new §11.1), `docs/tool-event-streaming/PLAN.md`, and the `skills/mast-ai` reference docs to mark `forwardTo(context)` as the canonical pattern for custom sub-agent tools where `createAgentTool` is too prescriptive.

## Why

Tools that wrap a sub-agent had to hand-roll a `for await` loop calling `context.onEvent?.(event)` for every non-`done` event. Forgetting it is a silent UX failure (parent tool block shows no streamed sub-output) — caught only by manual UI testing. Issue #80 cites four real cases of this in `agent-text-editor`'s `invoke_*` delegation tools. `createAgentTool` already covers the simple "just delegate" case, but tools with custom orchestration around the sub-agent run can't use it; `forwardTo()` is the composable equivalent.

## Test plan

- [x] `npm test --workspaces --if-present` — 263 tests pass (26 core including 4 new runner tests, 11 google-genai, 67 built-in-ai, 159 react-ui).
- [x] `npm run lint`, `npm run format`, `npm run build` — all clean.
- [x] New unit tests cover: events forwarded in order, `done` filtered, no-op when `context.onEvent` is missing, chainability with `history()`/`signal()`/`onToolEvent()`, abort signal still propagates.
- [x] Manual demo verification: no demo code changed; `apps/demo-react-ui`'s `summarize_documents` (built via `createAgentTool`) continues to render nested tool calls + sub-output under the parent block via the helper's new internal use of `forwardTo`.

Closes #80