### PR TITLE
feat(react-ui): per-tool display label slot for ToolCallBlock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,7 @@ If a new `@mast-ai/<name>` package is added to the repo, its first publish must 
 - Do not add `Co-Authored-By` trailers to commit messages.
 - Always run `npm run lint`, `npm run format`, `npm run build`, and `npm test` before committing and fix any failures.
 - Always use `Edit` to modify existing files — never rewrite them wholesale with `Write`. Small diffs make reviews easier.
+- Before committing and opening a PR, check whether the demos under `apps/` and the skills under `skills/` need updates to reflect the change (new APIs, renamed exports, behaviour changes, new capabilities worth showcasing). Update them as part of the same PR when they do.
 - Always ask the user to manually test before committing. Never commit or open a pull request until the user has confirmed the test passed.
 - **Branch strategy:**
   1. Before starting work on an issue, check out `main` and pull the latest (`git checkout main && git pull`).

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -293,6 +293,14 @@ interface ConversationPanelProps {
   /** Replace the default markdown renderer. Receives the raw text string. */
   renderMessage?: (text: string) => React.ReactNode;
 
+  /**
+   * Overrides the <ToolCallBlock> header label for the entire list. The
+   * resolver flows through context so it also applies to nested sub-agent
+   * tool calls. Returning undefined or null for an entry falls back to
+   * entry.name. See §4.8 for the resolution order.
+   */
+  getToolLabel?: GetToolLabel;
+
   /** Placeholder text for the input field. */
   inputPlaceholder?: string;
 }
@@ -320,6 +328,12 @@ interface MessageListProps {
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => React.ReactNode;
   renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
   renderMessage?: (text: string) => React.ReactNode;
+  /**
+   * Overrides the <ToolCallBlock> header label for every entry rendered by the
+   * list. Forwarded via context so it also applies to nested sub-agent tool
+   * calls. See §4.8.
+   */
+  getToolLabel?: GetToolLabel;
 }
 ```
 
@@ -354,6 +368,7 @@ interface MessageItemProps {
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => React.ReactNode;
   renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
   renderMessage?: (text: string) => React.ReactNode;
+  getToolLabel?: GetToolLabel;
 }
 ```
 
@@ -376,6 +391,12 @@ interface AssistantMessageProps {
    */
   renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => React.ReactNode;
   renderMessage?: (text: string) => React.ReactNode;
+  /**
+   * Overrides the <ToolCallBlock> header label for every tool event in this
+   * message. Forwarded via context so nested sub-agent tool calls also pick
+   * it up. See §4.8.
+   */
+  getToolLabel?: GetToolLabel;
 }
 ```
 
@@ -427,8 +448,29 @@ interface ToolCallBlockProps {
    * - false: closed by default regardless of streaming state.
    */
   defaultOpen?: boolean | 'streaming';
+  /**
+   * Overrides entry.name in the header. Useful for delegation-style tools
+   * whose interesting label lives in the args (e.g. delegate_to_skill should
+   * display the target skill's name, not the wrapper tool's name).
+   *
+   * Resolution order: the explicit `label` prop, then the `getToolLabel`
+   * resolver supplied via context (see §4.5 / §4.3 / §4.2), then entry.name.
+   */
+  label?: React.ReactNode;
 }
+
+type GetToolLabel = (entry: ToolEventEntry) => React.ReactNode;
 ```
+
+The `GetToolLabel` resolver type is also exported from the package root so
+consumers can type their own resolvers without re-deriving the signature.
+
+For consumers that only need to relabel a subset of tools, `<MessageList>`,
+`<AssistantMessage>`, and `<ConversationPanel>` accept a `getToolLabel` prop
+that flows through the bundled `<ToolCallBlock>` — including blocks rendered
+recursively for nested sub-agent tool calls — via `ToolLabelContext`. Returning
+`undefined` or `null` for an entry falls back to `entry.name`, which makes it
+ergonomic to relabel one tool while leaving everything else untouched.
 
 - The block itself is collapsible. The root is a `<details>` element with the header
   (status icon + tool name) as the `<summary>`; the body — sub-output, nested events,
@@ -630,6 +672,7 @@ packages/react-ui/
 │       ├── UserMessage.tsx
 │       ├── ThinkingBlock.tsx
 │       ├── ToolCallBlock.tsx
+│       ├── ToolLabelContext.tsx — context written by getToolLabel forwarders, read by ToolCallBlock
 │       └── ChatInput.tsx
 ├── styles/
 │   └── default.css            — emitted as dist/styles.css
@@ -657,6 +700,7 @@ export { ChatInput } from './components/ChatInput';
 
 // Types
 export type { ConversationEntry, ToolEventEntry, AgentProviderProps, IconMap } from './types';
+export type { GetToolLabel } from './components/ToolLabelContext';
 ```
 
 CSS is a separate export path (`@mast-ai/react-ui/styles.css`) handled by the build

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -25,6 +25,7 @@ common use cases. The corresponding API reference lives in
 10. [Approval flow](#10-approval-flow)
 11. [Nested sub-agent tool calls](#11-nested-sub-agent-tool-calls)
 12. [Mention pipeline (`@`-mentions)](#12-mention-pipeline--mentions)
+13. [Overriding tool call labels (`getToolLabel`)](#13-overriding-tool-call-labels-gettoollabel)
 
 ---
 
@@ -283,6 +284,24 @@ tools that do not need special handling.
 
 When a call is awaiting an inline approval decision the second argument is a
 `PendingApproval` handle; see §10.3 for the full pattern.
+
+If the only thing you need to override is the header text — say, a
+`delegate_to_skill` call where the interesting label is in the args — pass the
+`label` prop on `<ToolCallBlock>` instead of cloning the entry:
+
+```tsx
+const renderToolCall = (entry: ToolEventEntry) => {
+  if (entry.name === 'delegate_to_skill') {
+    const skillName = (entry.args as { skillName?: string } | undefined)?.skillName;
+    return <ToolCallBlock entry={entry} label={skillName ?? entry.name} />;
+  }
+  return <ToolCallBlock entry={entry} />;
+};
+```
+
+For lists where the only customisation is relabelling, the `getToolLabel` slot
+on `<ConversationPanel>` / `<MessageList>` / `<AssistantMessage>` is more
+direct — see §13.
 
 ---
 
@@ -980,6 +999,57 @@ calls `sendMessage(prompt, displayText)` from `useAgent()`:
 
 The two-argument overload is also useful outside the mention pipeline; see
 the slash-command example in §9.
+
+---
+
+## 13. Overriding tool call labels (`getToolLabel`)
+
+`<ToolCallBlock>` displays `entry.name` in its header by default. That works
+well for atomic tools (`read_doc`, `set_page_title`, `get_current_time`) but
+reads poorly for delegation-style tools whose interesting label lives in the
+args. A `delegate_to_skill` call for the "Proofreader" skill displays as
+`delegate_to_skill` rather than `Proofreader`.
+
+The `getToolLabel` slot on `<ConversationPanel>`, `<MessageList>`, and
+`<AssistantMessage>` resolves a header label per entry without forking the
+rest of the tool-call rendering:
+
+```tsx
+import { ConversationPanel, type GetToolLabel } from '@mast-ai/react-ui';
+
+const getToolLabel: GetToolLabel = (entry) => {
+  if (entry.name === 'delegate_to_skill') {
+    const args = entry.args as { skillName?: string } | undefined;
+    return args?.skillName;
+  }
+  // Returning undefined falls back to entry.name, so atomic tools render
+  // exactly as before.
+  return undefined;
+};
+
+<ConversationPanel getToolLabel={getToolLabel} />;
+```
+
+The resolver flows through context, so it also applies to nested sub-agent
+tool calls rendered recursively inside the parent block (see §11). Returning
+`undefined` or `null` for an entry falls back to `entry.name`, which makes it
+ergonomic to relabel one tool name while leaving everything else untouched.
+
+If you already have a `renderToolCall` callback (for example to render a chart
+for a specific tool), pass `label` directly on the bundled `<ToolCallBlock>`
+inside that callback. The `label` prop wins over `getToolLabel`, so the two
+work together cleanly:
+
+```tsx
+const renderToolCall = (entry: ToolEventEntry) => {
+  if (entry.name === 'plot_scatter') return <MyChart entry={entry} />;
+  return <ToolCallBlock entry={entry} />;
+};
+```
+
+The resolver from `getToolLabel` is still consulted for the bundled block, so
+the `delegate_to_skill` example above keeps working alongside the chart
+override.
 
 ---
 

--- a/packages/react-ui/src/components/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/AssistantMessage.tsx
@@ -10,6 +10,7 @@ import type { ConversationEntry, ToolEventEntry } from '../types.js';
 import { InlineApproval } from './InlineApproval.js';
 import { ThinkingBlock } from './ThinkingBlock.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
+import { ToolLabelContext, type GetToolLabel } from './ToolLabelContext.js';
 
 /**
  * Slot for replacing only the inline approval card while keeping the default
@@ -63,6 +64,21 @@ export interface AssistantMessageProps {
    * are provided.
    */
   renderApproval?: RenderApproval;
+  /**
+   * Resolves the header label for each {@link ToolEventEntry} rendered inside
+   * this message. Forwarded via context to every nested `<ToolCallBlock>`,
+   * including those rendered for sub-agent tool calls.
+   *
+   * Use this for the common case of relabelling delegation-style tools (e.g.
+   * `delegate_to_skill` showing the target skill's name) without needing to
+   * write a custom `renderToolCall` purely to override `entry.name`.
+   *
+   * Resolution order inside `<ToolCallBlock>`: explicit `label` prop, then this
+   * resolver, then `entry.name`. Returning `undefined` or `null` from the
+   * resolver lets the block fall back to `entry.name` for that specific entry,
+   * which is useful for selectively overriding only a subset of tool names.
+   */
+  getToolLabel?: GetToolLabel;
 }
 
 interface MarkdownTextProps {
@@ -121,6 +137,7 @@ export function AssistantMessage({
   renderMessage,
   renderToolCall,
   renderApproval,
+  getToolLabel,
 }: AssistantMessageProps) {
   const rootClass = ['mast-assistant-message', className].filter(Boolean).join(' ');
   const { pendingApprovals } = useAgent();
@@ -152,26 +169,28 @@ export function AssistantMessage({
   };
 
   return (
-    <div
-      data-mast-assistant-message
-      data-streaming={entry.isStreaming ? 'true' : undefined}
-      className={rootClass}
-    >
-      {entry.thinking ? (
-        <ThinkingBlock content={entry.thinking} isStreaming={entry.isStreaming} />
-      ) : null}
-      {entry.toolEvents.map((toolEvent, index) => (
-        <Fragment key={`${toolEvent.id}-${index}`}>{renderToolEvent(toolEvent)}</Fragment>
-      ))}
-      {entry.text ? (
-        renderMessage ? (
-          renderMessage(entry.text)
-        ) : (
-          <Suspense fallback={<p className="mast-assistant-message-text">{entry.text}</p>}>
-            <MarkdownText>{entry.text}</MarkdownText>
-          </Suspense>
-        )
-      ) : null}
-    </div>
+    <ToolLabelContext.Provider value={getToolLabel}>
+      <div
+        data-mast-assistant-message
+        data-streaming={entry.isStreaming ? 'true' : undefined}
+        className={rootClass}
+      >
+        {entry.thinking ? (
+          <ThinkingBlock content={entry.thinking} isStreaming={entry.isStreaming} />
+        ) : null}
+        {entry.toolEvents.map((toolEvent, index) => (
+          <Fragment key={`${toolEvent.id}-${index}`}>{renderToolEvent(toolEvent)}</Fragment>
+        ))}
+        {entry.text ? (
+          renderMessage ? (
+            renderMessage(entry.text)
+          ) : (
+            <Suspense fallback={<p className="mast-assistant-message-text">{entry.text}</p>}>
+              <MarkdownText>{entry.text}</MarkdownText>
+            </Suspense>
+          )
+        ) : null}
+      </div>
+    </ToolLabelContext.Provider>
   );
 }

--- a/packages/react-ui/src/components/ConversationPanel.tsx
+++ b/packages/react-ui/src/components/ConversationPanel.tsx
@@ -9,6 +9,7 @@ import type { ToolEventEntry } from '../types.js';
 import type { RenderApproval } from './AssistantMessage.js';
 import { ChatInput } from './ChatInput.js';
 import { MessageList } from './MessageList.js';
+import type { GetToolLabel } from './ToolLabelContext.js';
 
 /**
  * Props accepted by {@link ConversationPanel}.
@@ -37,6 +38,16 @@ export interface ConversationPanelProps {
   renderApproval?: RenderApproval;
   /** Replaces the default assistant text renderer for the entire list. */
   renderMessage?: (text: string) => ReactNode;
+  /**
+   * Overrides the `<ToolCallBlock>` header label for the entire list. The
+   * resolver flows via context so it also applies to nested sub-agent tool
+   * calls. Returning `undefined` or `null` for a given entry falls back to
+   * `entry.name`.
+   *
+   * Common use case: relabelling delegation-style tools (e.g.
+   * `delegate_to_skill` showing the target skill's name).
+   */
+  getToolLabel?: GetToolLabel;
   /** Placeholder text for the {@link ChatInput} field. */
   inputPlaceholder?: string;
   /**
@@ -62,6 +73,7 @@ export function ConversationPanel({
   renderToolCall,
   renderApproval,
   renderMessage,
+  getToolLabel,
   inputPlaceholder,
   mentions,
 }: ConversationPanelProps) {
@@ -73,6 +85,7 @@ export function ConversationPanel({
         renderToolCall={renderToolCall}
         renderApproval={renderApproval}
         renderMessage={renderMessage}
+        getToolLabel={getToolLabel}
       />
       <ChatInput placeholder={inputPlaceholder} mentions={mentions} />
     </div>

--- a/packages/react-ui/src/components/MessageItem.tsx
+++ b/packages/react-ui/src/components/MessageItem.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import type { PendingApproval } from '../approval.js';
 import type { ConversationEntry, ToolEventEntry } from '../types.js';
 import { AssistantMessage, type RenderApproval } from './AssistantMessage.js';
+import type { GetToolLabel } from './ToolLabelContext.js';
 import { UserMessage } from './UserMessage.js';
 
 /**
@@ -31,6 +32,11 @@ export interface MessageItemProps {
    * `'user'`.
    */
   renderMessage?: (text: string) => ReactNode;
+  /**
+   * Forwarded to {@link AssistantMessage}. Has no effect when `entry.role` is
+   * `'user'`.
+   */
+  getToolLabel?: GetToolLabel;
 }
 
 /**
@@ -45,6 +51,7 @@ export function MessageItem({
   renderToolCall,
   renderApproval,
   renderMessage,
+  getToolLabel,
 }: MessageItemProps) {
   if (entry.role === 'user') {
     return <UserMessage entry={entry} className={className} />;
@@ -56,6 +63,7 @@ export function MessageItem({
       renderToolCall={renderToolCall}
       renderApproval={renderApproval}
       renderMessage={renderMessage}
+      getToolLabel={getToolLabel}
     />
   );
 }

--- a/packages/react-ui/src/components/MessageList.test.tsx
+++ b/packages/react-ui/src/components/MessageList.test.tsx
@@ -220,6 +220,67 @@ describe('<MessageList>', () => {
     expect(await screen.findByText('tool:demo_tool')).toBeDefined();
   });
 
+  it('forwards getToolLabel to the default <ToolCallBlock> header', async () => {
+    const user = userEvent.setup();
+    const { runner } = makeMockRunner([
+      {
+        type: 'tool_call_started',
+        name: 'delegate_to_skill',
+        args: { skillName: 'Proofreader' },
+      },
+      {
+        type: 'tool_call_completed',
+        name: 'delegate_to_skill',
+        result: 'ok',
+      },
+      { type: 'done', output: '', history: [] },
+    ]);
+
+    const getToolLabel = vi.fn((entry: ToolEventEntry) => {
+      if (entry.name === 'delegate_to_skill') {
+        const args = entry.args as { skillName?: string } | undefined;
+        return args?.skillName ?? entry.name;
+      }
+      return undefined;
+    });
+
+    renderWithProvider(
+      runner,
+      <>
+        <SendButton text="run tool" />
+        <MessageList getToolLabel={getToolLabel} />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send run tool' }));
+
+    const header = await screen.findByText('Proofreader');
+    expect(header.className).toContain('mast-tool-call-block-name');
+    expect(screen.queryByText('delegate_to_skill')).toBeNull();
+    expect(getToolLabel).toHaveBeenCalled();
+  });
+
+  it('falls back to entry.name when getToolLabel returns undefined for an entry', async () => {
+    const user = userEvent.setup();
+    const { runner } = makeMockRunner([
+      { type: 'tool_call_started', name: 'plain_tool', args: {} },
+      { type: 'tool_call_completed', name: 'plain_tool', result: 'ok' },
+      { type: 'done', output: '', history: [] },
+    ]);
+
+    renderWithProvider(
+      runner,
+      <>
+        <SendButton text="run tool" />
+        <MessageList getToolLabel={() => undefined} />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send run tool' }));
+
+    expect(await screen.findByText('plain_tool')).toBeDefined();
+  });
+
   // ---------------------------------------------------------------------------
   // renderApproval slot
   //

--- a/packages/react-ui/src/components/MessageList.tsx
+++ b/packages/react-ui/src/components/MessageList.tsx
@@ -10,6 +10,7 @@ import type { PendingApproval } from '../approval.js';
 import type { ToolEventEntry } from '../types.js';
 import type { RenderApproval } from './AssistantMessage.js';
 import { MessageItem } from './MessageItem.js';
+import type { GetToolLabel } from './ToolLabelContext.js';
 
 /**
  * Props accepted by {@link MessageList}.
@@ -36,6 +37,17 @@ export interface MessageListProps {
    * assistant text renderer for the entire list.
    */
   renderMessage?: (text: string) => ReactNode;
+  /**
+   * Forwarded to each {@link MessageItem} so consumers can override the
+   * `<ToolCallBlock>` header label for the entire list. The resolver is read
+   * via context inside `<ToolCallBlock>`, so it also applies to nested
+   * sub-agent tool calls.
+   *
+   * Returning `undefined` or `null` for a given entry falls back to
+   * `entry.name`, which is useful for selectively overriding only a subset of
+   * tool names.
+   */
+  getToolLabel?: GetToolLabel;
 }
 
 /**
@@ -66,6 +78,7 @@ export function MessageList({
   renderToolCall,
   renderApproval,
   renderMessage,
+  getToolLabel,
 }: MessageListProps) {
   const { messages } = useAgent();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -116,6 +129,7 @@ export function MessageList({
                 renderToolCall={renderToolCall}
                 renderApproval={renderApproval}
                 renderMessage={renderMessage}
+                getToolLabel={getToolLabel}
               />
             </div>
           );

--- a/packages/react-ui/src/components/ToolCallBlock.test.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import type { ToolEventEntry } from '../types.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
+import { ToolLabelContext } from './ToolLabelContext.js';
 
 function makeEntry(overrides: Partial<ToolEventEntry> = {}): ToolEventEntry {
   return {
@@ -196,6 +197,45 @@ describe('<ToolCallBlock>', () => {
       expect(screen.getByText('inner_tool')).toBeDefined();
     });
 
+    it('forwards the ToolLabelContext resolver to nested entries', () => {
+      const parent: ToolEventEntry = {
+        id: 'parent',
+        type: 'tool_call_started',
+        name: 'invoke_writer',
+        args: {},
+        isStreaming: true,
+        nestedToolEvents: [
+          {
+            id: 'nested-1',
+            type: 'tool_call_completed',
+            name: 'delegate_to_skill',
+            args: { skillName: 'Proofreader' },
+            result: 'done',
+            isStreaming: false,
+            status: 'success',
+          },
+        ],
+      };
+      render(
+        <ToolLabelContext.Provider
+          value={(entry) => {
+            if (entry.name === 'delegate_to_skill') {
+              const args = entry.args as { skillName?: string } | undefined;
+              return args?.skillName;
+            }
+            return undefined;
+          }}
+        >
+          <ToolCallBlock entry={parent} />
+        </ToolLabelContext.Provider>,
+      );
+      // Parent uses entry.name (resolver returns undefined for it).
+      expect(screen.getByText('invoke_writer')).toBeDefined();
+      // Nested entry uses the resolver's value.
+      expect(screen.getByText('Proofreader')).toBeDefined();
+      expect(screen.queryByText('delegate_to_skill')).toBeNull();
+    });
+
     it('renders multiple nested entries in order', () => {
       const parent: ToolEventEntry = {
         id: 'parent',
@@ -235,6 +275,69 @@ describe('<ToolCallBlock>', () => {
     it('renders the tool name', () => {
       render(<ToolCallBlock entry={makeEntry({ name: 'get_current_time' })} />);
       expect(screen.getByText('get_current_time')).toBeDefined();
+    });
+
+    it('renders the label prop in place of entry.name when provided', () => {
+      render(
+        <ToolCallBlock entry={makeEntry({ name: 'delegate_to_skill' })} label="Proofreader" />,
+      );
+      expect(screen.getByText('Proofreader')).toBeDefined();
+      expect(screen.queryByText('delegate_to_skill')).toBeNull();
+    });
+
+    it('accepts a ReactNode label, not just a string', () => {
+      render(
+        <ToolCallBlock
+          entry={makeEntry({ name: 'delegate_to_skill' })}
+          label={<em data-testid="custom-label">Proofreader</em>}
+        />,
+      );
+      expect(screen.getByTestId('custom-label').textContent).toBe('Proofreader');
+    });
+
+    it('falls back to entry.name when label is omitted', () => {
+      render(<ToolCallBlock entry={makeEntry({ name: 'plain_tool' })} />);
+      expect(screen.getByText('plain_tool')).toBeDefined();
+    });
+
+    it('reads the label from ToolLabelContext when no label prop is set', () => {
+      render(
+        <ToolLabelContext.Provider
+          value={(entry) => (entry.name === 'delegate_to_skill' ? 'Proofreader' : undefined)}
+        >
+          <ToolCallBlock entry={makeEntry({ name: 'delegate_to_skill' })} />
+        </ToolLabelContext.Provider>,
+      );
+      expect(screen.getByText('Proofreader')).toBeDefined();
+      expect(screen.queryByText('delegate_to_skill')).toBeNull();
+    });
+
+    it('falls back to entry.name when the context resolver returns undefined', () => {
+      render(
+        <ToolLabelContext.Provider value={() => undefined}>
+          <ToolCallBlock entry={makeEntry({ name: 'plain_tool' })} />
+        </ToolLabelContext.Provider>,
+      );
+      expect(screen.getByText('plain_tool')).toBeDefined();
+    });
+
+    it('falls back to entry.name when the context resolver returns null', () => {
+      render(
+        <ToolLabelContext.Provider value={() => null}>
+          <ToolCallBlock entry={makeEntry({ name: 'plain_tool' })} />
+        </ToolLabelContext.Provider>,
+      );
+      expect(screen.getByText('plain_tool')).toBeDefined();
+    });
+
+    it('prefers the explicit label prop over the context resolver', () => {
+      render(
+        <ToolLabelContext.Provider value={() => 'from-context'}>
+          <ToolCallBlock entry={makeEntry({ name: 'tool' })} label="from-prop" />
+        </ToolLabelContext.Provider>,
+      );
+      expect(screen.getByText('from-prop')).toBeDefined();
+      expect(screen.queryByText('from-context')).toBeNull();
     });
 
     it('forwards className to the root element', () => {

--- a/packages/react-ui/src/components/ToolCallBlock.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.tsx
@@ -1,9 +1,13 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+import { useContext } from 'react';
+import type { ReactNode } from 'react';
+
 import { useIcons } from '../icons.js';
 import type { ToolEventEntry } from '../types.js';
 import { ThinkingBlock } from './ThinkingBlock.js';
+import { ToolLabelContext } from './ToolLabelContext.js';
 
 /**
  * Props accepted by {@link ToolCallBlock}.
@@ -24,6 +28,16 @@ export interface ToolCallBlockProps {
    * - `false`: closed by default, regardless of streaming state.
    */
   defaultOpen?: boolean | 'streaming';
+  /**
+   * Overrides `entry.name` in the header. Useful for delegation-style tools
+   * whose interesting label lives in the args (e.g. `delegate_to_skill` should
+   * display the target skill's name, not the wrapper tool's name).
+   *
+   * Takes precedence over the `getToolLabel` resolver supplied via
+   * `<AssistantMessage>` / `<MessageList>` / `<ConversationPanel>`. When
+   * omitted, falls back to the resolver, then to `entry.name`.
+   */
+  label?: ReactNode;
 }
 
 function formatJson(value: unknown): string {
@@ -86,8 +100,14 @@ function resolveOpen(
   return defaultOpen;
 }
 
-export function ToolCallBlock({ entry, className, defaultOpen = 'streaming' }: ToolCallBlockProps) {
+export function ToolCallBlock({
+  entry,
+  className,
+  defaultOpen = 'streaming',
+  label,
+}: ToolCallBlockProps) {
   const icons = useIcons();
+  const getToolLabel = useContext(ToolLabelContext);
   const rootClass = ['mast-tool-call-block', className].filter(Boolean).join(' ');
   const hasSubAgentOutput = entry.subThinking !== undefined || entry.subText !== undefined;
   const nestedToolEvents = entry.nestedToolEvents ?? [];
@@ -95,6 +115,7 @@ export function ToolCallBlock({ entry, className, defaultOpen = 'streaming' }: T
   const argsText = formatJson(entry.args);
   const resultText = formatJson(entry.result);
   const open = resolveOpen(defaultOpen, entry.isStreaming);
+  const resolvedLabel = label ?? getToolLabel?.(entry) ?? entry.name;
 
   return (
     <details
@@ -119,7 +140,7 @@ export function ToolCallBlock({ entry, className, defaultOpen = 'streaming' }: T
         <span className="mast-tool-call-block-wrench" aria-hidden="true">
           {icons.wrench}
         </span>
-        <span className="mast-tool-call-block-name">{entry.name}</span>
+        <span className="mast-tool-call-block-name">{resolvedLabel}</span>
       </summary>
 
       <div className="mast-tool-call-block-body">

--- a/packages/react-ui/src/components/ToolLabelContext.tsx
+++ b/packages/react-ui/src/components/ToolLabelContext.tsx
@@ -1,0 +1,27 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext } from 'react';
+import type { ReactNode } from 'react';
+
+import type { ToolEventEntry } from '../types.js';
+
+/**
+ * Computes the header label for a {@link ToolEventEntry}. Returning `undefined`
+ * (or `null`) lets the consuming `<ToolCallBlock>` fall back to `entry.name`,
+ * which is useful for selectively overriding only a subset of tool names.
+ */
+export type GetToolLabel = (entry: ToolEventEntry) => ReactNode;
+
+/**
+ * Context written by `<AssistantMessage getToolLabel>` (and parents that
+ * forward the prop) and read by `<ToolCallBlock>` to resolve its header label.
+ *
+ * Resolution order inside `<ToolCallBlock>`:
+ *
+ * 1. The explicit `label` prop, if provided.
+ * 2. The value returned by this context's `getToolLabel`, if defined and the
+ *    return value is not `null`/`undefined`.
+ * 3. `entry.name`.
+ */
+export const ToolLabelContext = createContext<GetToolLabel | undefined>(undefined);

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -18,6 +18,7 @@ export { UserMessage } from './components/UserMessage.js';
 export type { UserMessageProps } from './components/UserMessage.js';
 export { AssistantMessage } from './components/AssistantMessage.js';
 export type { AssistantMessageProps, RenderApproval } from './components/AssistantMessage.js';
+export type { GetToolLabel } from './components/ToolLabelContext.js';
 export { ChatInput } from './components/ChatInput.js';
 export type { ChatInputProps } from './components/ChatInput.js';
 export { MessageItem } from './components/MessageItem.js';

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -188,6 +188,31 @@ Currently scoped to a single level: grandchild events route back to the outermos
 <ToolCallBlock entry={entry} defaultOpen={false} />
 ```
 
+## Overriding the tool call header label
+
+`<ToolCallBlock>` shows `entry.name` in its header by default. For delegation-style tools whose interesting label lives in the args (e.g. `delegate_to_skill` should display the target skill's name), override the header without forking the rest of the rendering.
+
+Two slots, same precedence chain (`label` prop → `getToolLabel` from context → `entry.name`):
+
+- **`label?: ReactNode`** on `<ToolCallBlock>` itself — direct, per-instance override. Use inside a `renderToolCall` callback when you already need to dispatch on tool name.
+- **`getToolLabel?: (entry) => ReactNode`** on `<ConversationPanel>` / `<MessageList>` / `<AssistantMessage>` — list-wide resolver. Flows via context to every nested `<ToolCallBlock>` (including sub-agent tool calls). Returning `undefined` or `null` falls back to `entry.name`, so it is ergonomic to relabel one tool while leaving everything else untouched.
+
+```tsx
+import { ConversationPanel, type GetToolLabel } from '@mast-ai/react-ui';
+
+const getToolLabel: GetToolLabel = (entry) => {
+  if (entry.name === 'delegate_to_skill') {
+    const args = entry.args as { skillName?: string } | undefined;
+    return args?.skillName;
+  }
+  return undefined;
+};
+
+<ConversationPanel getToolLabel={getToolLabel} />;
+```
+
+Use `getToolLabel` when relabelling is the only customisation. Reach for `renderToolCall` + `<ToolCallBlock label>` when you also need to swap the body (e.g. render a chart for a specific tool). The two compose: the `label` prop wins over `getToolLabel`, but the resolver still applies to bundled blocks rendered for tools the callback did not customise.
+
 ## Mention Pipeline (`@`-mentions)
 
 Opt-in: when `mentions` is omitted, `<ChatInput>` renders an unchanged plain textarea.


### PR DESCRIPTION
## Summary

- Adds `label?: ReactNode` on `<ToolCallBlock>` to override `entry.name` in the header. Useful for delegation-style tools whose interesting label lives in the args (e.g. `delegate_to_skill` showing the target skill's name).
- Adds list-wide `getToolLabel?: (entry) => ReactNode` slot on `<ConversationPanel>` / `<MessageList>` / `<AssistantMessage>` for the common case of relabelling without forking `renderToolCall` purely for header text.
- Forwards the resolver via a new `ToolLabelContext`, so it also applies to nested sub-agent tool calls rendered recursively inside the parent block.
- Resolution order inside `<ToolCallBlock>`: explicit `label` prop → `getToolLabel` from context → `entry.name`. Returning `undefined`/`null` from the resolver falls back to `entry.name`, making it ergonomic to relabel a single tool while leaving the rest untouched.
- Also tweaks `CLAUDE.md` to remind future sessions to update `apps/` demos and `skills/` alongside library changes.

## Implementation notes

- New file `packages/react-ui/src/components/ToolLabelContext.tsx` exposes the `GetToolLabel` type and a React context. `<AssistantMessage>` writes to the context when `getToolLabel` is set; `<ToolCallBlock>` reads from it. This keeps the recursive sub-agent rendering working without threading an extra prop through `<ToolCallBlock>` itself.
- `MessageList` / `MessageItem` / `ConversationPanel` only forward the prop down — they intentionally do not own a Provider, so a `<ToolCallBlock>` rendered standalone (no `<AssistantMessage>` ancestor) cleanly falls back to its `label` prop or `entry.name`.
- `GetToolLabel` is exported from the package root.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run build` — all packages build.
- [x] `npm test --workspaces --if-present` — 169 react-ui tests pass (plus core/google-genai/built-in-ai), including:
  - `<ToolCallBlock>`: explicit `label` wins over `entry.name`; accepts a `ReactNode`; falls back to `entry.name` when `label` is omitted; reads from context; `null`/`undefined` from resolver falls through; explicit `label` prop beats context; resolver flows to nested blocks.
  - `<MessageList>`: end-to-end check that `getToolLabel` propagates through `MessageItem` → `AssistantMessage` → bundled `<ToolCallBlock>`; fallback to `entry.name` when resolver returns `undefined`.
- [x] Manually verified in `apps/demo-react-ui` that omitting `label` / `getToolLabel` leaves rendering unchanged.

## Docs

- `docs/react-ui/SPEC.md` — new `label` prop on `ToolCallBlock`, new `getToolLabel` on Conversation/MessageList/MessageItem/AssistantMessage, exports the `GetToolLabel` type.
- `docs/react-ui/USAGE.md` — `delegate_to_skill` worked example for `<ToolCallBlock label>` inside `renderToolCall`, plus new §13 covering the list-wide `getToolLabel` slot.
- `skills/mast-ai/references/react-ui.md` — new "Overriding the tool call header label" subsection.

Closes #81