### PR TITLE
docs(react-ui): theming integration guide and shadcn preset

### DIFF
--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -77,6 +77,10 @@ at any scope without `!important`.
   --mast-tool-bg: #f0fdf4;
   --mast-tool-fg: #166534;
   --mast-tool-pending: #f59e0b;
+  --mast-tool-error-bg: #fef2f2;
+  --mast-tool-error-fg: #991b1b;
+  --mast-tool-cancelled-bg: #f3f4f6;
+  --mast-tool-cancelled-fg: #4b5563;
   --mast-user-bubble: #dbeafe;
   --mast-user-fg: #1e3a8a;
 
@@ -106,6 +110,10 @@ at any scope without `!important`.
     --mast-tool-bg: #052e16;
     --mast-tool-fg: #86efac;
     --mast-tool-pending: #fbbf24;
+    --mast-tool-error-bg: #450a0a;
+    --mast-tool-error-fg: #fecaca;
+    --mast-tool-cancelled-bg: #1f2937;
+    --mast-tool-cancelled-fg: #d1d5db;
     --mast-user-bubble: #1e3a8a;
     --mast-user-fg: #bfdbfe;
   }
@@ -131,6 +139,22 @@ root element. `ConversationPanel` accepts a `theme` prop that sets this attribut
 
 All default classes use the `mast-` prefix (e.g. `mast-message`, `mast-thinking-block`).
 This avoids collisions with Tailwind utility classes and other CSS frameworks.
+
+### 2.4 Theme presets
+
+The package ships optional theme presets that remap every `--mast-*` token onto
+an existing design system in one import. Presets are plain CSS published under
+`@mast-ai/react-ui/themes/<name>.css`.
+
+| Preset                                         | Maps `--mast-*` onto                                                                           |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `@mast-ai/react-ui/themes/tailwind-shadcn.css` | shadcn HSL variables (`--background`, `--foreground`, `--primary`, `--muted`, `--destructive`) |
+
+Presets use a triple-selector rule (`[data-mast-root], [data-mast-root][data-mast-theme='dark'], [data-mast-root][data-mast-theme='light']`)
+to match the specificity of the library's own dark-theme block, so source order
+tie-breaks in favour of the preset when it is loaded after `styles.css`. See
+[`USAGE.md` §5](./USAGE.md#5-theming) for the full integration guide,
+including how to forward `data-mast-theme` for class-based dark-mode setups.
 
 ---
 
@@ -676,6 +700,8 @@ packages/react-ui/
 │       └── ChatInput.tsx
 ├── styles/
 │   └── default.css            — emitted as dist/styles.css
+├── themes/
+│   └── tailwind-shadcn.css    — emitted as dist/themes/tailwind-shadcn.css
 ├── package.json
 ├── tsconfig.json
 └── vite.config.ts             — library mode; externalises react, @mast-ai/core
@@ -704,7 +730,8 @@ export type { GetToolLabel } from './components/ToolLabelContext';
 ```
 
 CSS is a separate export path (`@mast-ai/react-ui/styles.css`) handled by the build
-output, not imported from `index.ts`.
+output, not imported from `index.ts`. Theme presets are published as additional CSS
+export paths under `@mast-ai/react-ui/themes/<name>.css` (see §2.4).
 
 ---
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -17,7 +17,7 @@ common use cases. The corresponding API reference lives in
 2. [Basic setup with `GoogleGenAIAdapter`](#2-basic-setup-with-googlegenaiadapter)
 3. [Registering tools](#3-registering-tools)
 4. [Custom icons (`lucide-react` example)](#4-custom-icons-lucide-react-example)
-5. [Dark mode and theming](#5-dark-mode-and-theming)
+5. [Theming](#5-theming)
 6. [Custom tool call rendering (`renderToolCall`)](#6-custom-tool-call-rendering-rendertoolcall)
 7. [Custom message rendering (`renderMessage`)](#7-custom-message-rendering-rendermessage)
 8. [Composing a custom layout with primitives](#8-composing-a-custom-layout-with-primitives)
@@ -209,7 +209,14 @@ defined in the default stylesheet and rotates the loader icon.
 
 ---
 
-## 5. Dark mode and theming
+## 5. Theming
+
+Every visual value in the default stylesheet is a CSS custom property scoped
+under `[data-mast-root]`, so consumers can override individual tokens, swap the
+whole palette, or remap every token onto an existing design system without
+`!important` and without forking the stylesheet.
+
+### 5.1 Dark mode
 
 The default stylesheet ships a light theme and an automatic dark theme that
 follows `prefers-color-scheme`. Apps that manage their own theme switching can
@@ -223,31 +230,198 @@ force a value with the `theme` prop on `<ConversationPanel>`:
 
 The prop sets `data-mast-theme` on the panel root. The default stylesheet
 selects on that attribute so OS preferences are overridden without
-`!important`.
+`!important`. When composing primitives directly (see §8), set
+`data-mast-theme={theme}` yourself on the element that carries `data-mast-root`.
 
-### Overriding individual tokens
+### 5.2 Token reference
 
-Every colour, font, and spacing value is a CSS custom property scoped under
-`[data-mast-root]`. Override at any level:
+Every token below is defined on `[data-mast-root]` in the default stylesheet
+and is safe to override at any scope.
+
+| Token                             | Used by                                                        |
+| --------------------------------- | -------------------------------------------------------------- |
+| `--mast-bg`                       | Panel background, args/result panes, mention picker background |
+| `--mast-bg-subtle`                | Message list background, code blocks, picker hover row         |
+| `--mast-fg`                       | Body text                                                      |
+| `--mast-fg-muted`                 | Secondary text (chevrons, "show args" labels, descriptions)    |
+| `--mast-border`                   | Panel border, code-block border, sub-agent indent rule         |
+| `--mast-accent`                   | Send button, primary approval action                           |
+| `--mast-accent-fg`                | Foreground on `--mast-accent`                                  |
+| `--mast-thinking-bg`              | `<ThinkingBlock>` background, inline approval card background  |
+| `--mast-thinking-fg`              | `<ThinkingBlock>` text, inline approval card text              |
+| `--mast-tool-bg`                  | `<ToolCallBlock>` background (success / running)               |
+| `--mast-tool-fg`                  | `<ToolCallBlock>` text (success / running)                     |
+| `--mast-tool-pending`             | Streaming spinner color, cancel button, approval card border   |
+| `--mast-tool-error-bg`            | `<ToolCallBlock>` background when `status: 'error'`            |
+| `--mast-tool-error-fg`            | `<ToolCallBlock>` text when `status: 'error'`                  |
+| `--mast-tool-cancelled-bg`        | `<ToolCallBlock>` background when `status: 'cancelled'`        |
+| `--mast-tool-cancelled-fg`        | `<ToolCallBlock>` text when `status: 'cancelled'`              |
+| `--mast-user-bubble`              | User message bubble background                                 |
+| `--mast-user-fg`                  | User message bubble text                                       |
+| `--mast-mention-chip-bg`          | `@`-mention chip background (input and user bubble)            |
+| `--mast-mention-chip-fg`          | `@`-mention chip text                                          |
+| `--mast-mention-picker-bg`        | Mention picker popover background (defaults to `--mast-bg`)    |
+| `--mast-mention-picker-active-bg` | Highlighted picker row (defaults to `--mast-bg-subtle`)        |
+| `--mast-mention-picker-shadow`    | Mention picker drop shadow                                     |
+| `--mast-font`                     | All UI text                                                    |
+| `--mast-font-mono`                | Code blocks, tool names, `<pre>` content                       |
+| `--mast-text-sm`                  | Secondary text size (sub-text, status labels, picker rows)     |
+| `--mast-text-base`                | Body text size                                                 |
+| `--mast-gap`                      | Vertical / horizontal gap inside the panel                     |
+| `--mast-radius`                   | Border radius for buttons, blocks, and the panel itself        |
+
+Tokens whose default is `var(--mast-bg)` or `var(--mast-bg-subtle)` inherit
+from the base color tokens automatically, so overriding `--mast-bg` once is
+usually enough.
+
+### 5.3 Overriding individual tokens
+
+Set whichever tokens you want to change on any selector that contains a
+`[data-mast-root]` element. The default stylesheet uses single-attribute
+selectors, so an unscoped override wins by source order if its CSS is loaded
+after `@mast-ai/react-ui/styles.css`.
 
 ```css
-/* App-wide brand accent */
+/* App-wide brand accent. */
 [data-mast-root] {
   --mast-accent: #ec4899;
   --mast-accent-fg: #ffffff;
   --mast-radius: 0.25rem;
 }
 
-/* Different palette inside a sidebar variant */
+/* Different palette inside a sidebar variant. */
 .app-sidebar [data-mast-root] {
   --mast-bg: #0f172a;
   --mast-fg: #e2e8f0;
 }
 ```
 
-The full token list lives in [`SPEC.md` §2.2](./SPEC.md#22-css-custom-properties).
-The mention picker adds a few extra tokens (`--mast-mention-chip-bg`,
-`--mast-mention-picker-bg`, …) documented in [§13.7](./SPEC.md#137-styling).
+### 5.4 Mapping onto an existing design system (Tailwind / shadcn)
+
+Apps with their own design tokens typically want library components to inherit
+the app theme rather than ship a parallel palette. The pattern is to remap
+every `--mast-*` token onto the consumer's variables in a single block. Two
+non-obvious things tripped up the first integration we did:
+
+**Specificity tie-break.** A bare `[data-mast-root]` selector loses to the
+library's own `[data-mast-root][data-mast-theme='dark']` block in dark mode,
+so the dark theme keeps the library's hardcoded colors. Listing all three
+selectors in one rule forces equal specificity and lets source order (the
+consumer's CSS loaded after the library's) tie-break in favor of the override.
+
+**App-driven dark mode.** Tailwind and shadcn use a `.dark` class on `<html>`
+to swap variables. The library's `data-mast-theme` attribute is independent
+and follows OS preference by default. Pass `data-mast-theme={theme}` from your
+theme state to keep the library in sync with the app theme, otherwise OS dark
+mode and an app forced to light (or vice versa) will mix.
+
+**`hsl(var(--*))` vs raw color literals.** shadcn projects scaffolded with
+`shadcn-ui add` store colors as raw HSL triples (`--background: 0 0% 100%`),
+so the consumer expression must wrap them in `hsl(...)`. Tailwind v4 / shadcn
+v4 setups instead store full color values (`--background: oklch(...)` or
+`hsl(0 0% 100%)`), in which case you drop the `hsl()` wrapper and reference
+the variable directly. Mixing the two forms produces invalid `color` values
+that browsers silently fall back from.
+
+Drop the following block into your global stylesheet, after the
+`@mast-ai/react-ui/styles.css` import:
+
+```css
+[data-mast-root],
+[data-mast-root][data-mast-theme='dark'],
+[data-mast-root][data-mast-theme='light'] {
+  --mast-bg: hsl(var(--background));
+  --mast-bg-subtle: hsl(var(--muted) / 0.2);
+  --mast-fg: hsl(var(--foreground));
+  --mast-fg-muted: hsl(var(--muted-foreground));
+  --mast-border: hsl(var(--border));
+  --mast-accent: hsl(var(--primary));
+  --mast-accent-fg: hsl(var(--primary-foreground));
+  --mast-thinking-bg: hsl(var(--muted));
+  --mast-thinking-fg: hsl(var(--muted-foreground));
+  --mast-tool-bg: hsl(var(--muted) / 0.4);
+  --mast-tool-fg: hsl(var(--muted-foreground));
+  --mast-tool-pending: hsl(var(--primary));
+  --mast-tool-error-bg: hsl(var(--destructive) / 0.1);
+  --mast-tool-error-fg: hsl(var(--destructive));
+  --mast-tool-cancelled-bg: hsl(var(--muted));
+  --mast-tool-cancelled-fg: hsl(var(--muted-foreground));
+  --mast-user-bubble: hsl(var(--primary));
+  --mast-user-fg: hsl(var(--primary-foreground));
+  --mast-mention-chip-bg: hsl(var(--primary) / 0.1);
+  --mast-mention-chip-fg: hsl(var(--primary));
+}
+```
+
+Then sync the library theme to your app theme on the panel root:
+
+```tsx
+import { ConversationPanel } from '@mast-ai/react-ui';
+import { useTheme } from 'next-themes'; // or your own theme provider
+
+function Chat() {
+  const { resolvedTheme } = useTheme(); // 'light' | 'dark'
+  return <ConversationPanel theme={resolvedTheme === 'dark' ? 'dark' : 'light'} />;
+}
+```
+
+If you compose primitives directly instead of using `<ConversationPanel>`,
+forward `data-mast-theme` onto the element that carries `data-mast-root`:
+
+```tsx
+<aside data-mast-root data-mast-theme={resolvedTheme}>
+  <MessageList />
+  <ChatInput />
+</aside>
+```
+
+### 5.5 Importing the bundled Tailwind / shadcn preset
+
+The preset above also ships as an importable stylesheet. Add it after the
+default styles import to skip writing the mapping yourself:
+
+```ts
+import '@mast-ai/react-ui/styles.css';
+import '@mast-ai/react-ui/themes/tailwind-shadcn.css';
+```
+
+The preset assumes the standard shadcn variables (`--background`,
+`--foreground`, `--primary`, `--primary-foreground`, `--muted`,
+`--muted-foreground`, `--border`, `--destructive`) are defined as raw HSL
+triples on `:root` and `.dark`, which is the default shadcn layout. Tailwind
+v4 / shadcn v4 projects that store full color values should copy the snippet
+in §5.4 and drop the `hsl()` wrapper instead.
+
+You still need to forward the app theme via `data-mast-theme` (§5.4) so the
+library's dark detection stays in sync with the `.dark` class.
+
+### 5.6 Plain CSS without a design system
+
+For apps that do not use Tailwind or shadcn, override the tokens directly in
+your global stylesheet. The library's automatic dark mode applies whenever
+`data-mast-theme` is unset, so you only need a second block for explicit
+themes:
+
+```css
+[data-mast-root] {
+  --mast-bg: #fafafa;
+  --mast-fg: #1c1917;
+  --mast-accent: #f97316;
+  --mast-accent-fg: #ffffff;
+  --mast-radius: 0.375rem;
+  --mast-font: 'Inter', system-ui, sans-serif;
+}
+
+[data-mast-root][data-mast-theme='dark'] {
+  --mast-bg: #1c1917;
+  --mast-fg: #fafafa;
+  --mast-accent: #fb923c;
+}
+```
+
+Set tokens to `inherit` (or a `var()` reference) to pull values from a parent
+element. Combined with `<ConversationPanel theme={theme}>`, this gives full
+control over the panel's appearance without touching the library bundle.
 
 ---
 

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -10,7 +10,8 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./themes/tailwind-shadcn.css": "./dist/themes/tailwind-shadcn.css"
   },
   "files": [
     "dist"

--- a/packages/react-ui/themes/tailwind-shadcn.css
+++ b/packages/react-ui/themes/tailwind-shadcn.css
@@ -1,0 +1,55 @@
+/*
+ * @mast-ai/react-ui — Tailwind / shadcn theme preset
+ *
+ * Maps every --mast-* token onto the standard shadcn HSL CSS variables
+ * (--background, --foreground, --primary, --muted, --border, --destructive,
+ * etc.) so library components inherit the consuming app's theme.
+ *
+ * Usage:
+ *   import '@mast-ai/react-ui/styles.css';
+ *   import '@mast-ai/react-ui/themes/tailwind-shadcn.css';
+ *
+ * The shadcn variables must be raw HSL triples (e.g. --background: 0 0% 100%)
+ * for hsl(var(--background)) to evaluate correctly. This is the default for
+ * shadcn projects scaffolded with `shadcn-ui add`. Tailwind v4 / shadcn v4
+ * setups that store full color() values should drop the hsl() wrapper.
+ *
+ * Two non-obvious tricks this preset relies on:
+ *
+ * 1. Listing all three selectors with equal specificity so source order
+ *    tie-breaks in the consumer's favor. A bare [data-mast-root] block loses
+ *    to the library's [data-mast-root][data-mast-theme='dark'] block in dark
+ *    mode and the dark theme would keep the library's hardcoded colors.
+ *
+ * 2. Setting data-mast-theme={theme} on the panel root in your app keeps the
+ *    library's dark detection in sync with shadcn's class-based dark mode
+ *    (.dark on <html>). Without it, the library follows OS preference and
+ *    can mismatch the app theme.
+ *
+ * See docs/react-ui/USAGE.md §5 for the full integration guide.
+ */
+
+[data-mast-root],
+[data-mast-root][data-mast-theme='dark'],
+[data-mast-root][data-mast-theme='light'] {
+  --mast-bg: hsl(var(--background));
+  --mast-bg-subtle: hsl(var(--muted) / 0.2);
+  --mast-fg: hsl(var(--foreground));
+  --mast-fg-muted: hsl(var(--muted-foreground));
+  --mast-border: hsl(var(--border));
+  --mast-accent: hsl(var(--primary));
+  --mast-accent-fg: hsl(var(--primary-foreground));
+  --mast-thinking-bg: hsl(var(--muted));
+  --mast-thinking-fg: hsl(var(--muted-foreground));
+  --mast-tool-bg: hsl(var(--muted) / 0.4);
+  --mast-tool-fg: hsl(var(--muted-foreground));
+  --mast-tool-pending: hsl(var(--primary));
+  --mast-tool-error-bg: hsl(var(--destructive) / 0.1);
+  --mast-tool-error-fg: hsl(var(--destructive));
+  --mast-tool-cancelled-bg: hsl(var(--muted));
+  --mast-tool-cancelled-fg: hsl(var(--muted-foreground));
+  --mast-user-bubble: hsl(var(--primary));
+  --mast-user-fg: hsl(var(--primary-foreground));
+  --mast-mention-chip-bg: hsl(var(--primary) / 0.1);
+  --mast-mention-chip-fg: hsl(var(--primary));
+}

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -4,26 +4,32 @@ import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
 /**
- * Emits `styles/default.css` into the build output as `styles.css` so the
- * `./styles.css` package export resolves to a published file inside `dist/`.
+ * Emits the default stylesheet and theme presets into the build output so
+ * each `./styles.css` / `./themes/*.css` package export resolves to a
+ * published file inside `dist/`.
  */
-function emitStylesheet(): Plugin {
+function emitStylesheets(): Plugin {
+  const assets: { source: string; fileName: string }[] = [
+    { source: 'styles/default.css', fileName: 'styles.css' },
+    { source: 'themes/tailwind-shadcn.css', fileName: 'themes/tailwind-shadcn.css' },
+  ];
   return {
-    name: 'mast-ai-emit-stylesheet',
+    name: 'mast-ai-emit-stylesheets',
     apply: 'build',
     generateBundle() {
-      const source = readFileSync(resolve(__dirname, 'styles/default.css'), 'utf8');
-      this.emitFile({
-        type: 'asset',
-        fileName: 'styles.css',
-        source,
-      });
+      for (const asset of assets) {
+        this.emitFile({
+          type: 'asset',
+          fileName: asset.fileName,
+          source: readFileSync(resolve(__dirname, asset.source), 'utf8'),
+        });
+      }
     },
   };
 }
 
 export default defineConfig({
-  plugins: [react(), emitStylesheet()],
+  plugins: [react(), emitStylesheets()],
   build: {
     lib: {
       entry: 'src/index.ts',

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -280,7 +280,16 @@ Override individual tokens by setting CSS custom properties under `[data-mast-ro
 }
 ```
 
-Mention picker tokens: `--mast-mention-chip-bg`, `--mast-mention-picker-bg`, etc. The full token list is in `docs/react-ui/SPEC.md` §2.2 and §13.7.
+For Tailwind / shadcn apps, import the bundled preset to remap every `--mast-*` token onto the standard shadcn HSL variables in one line:
+
+```ts
+import '@mast-ai/react-ui/styles.css';
+import '@mast-ai/react-ui/themes/tailwind-shadcn.css';
+```
+
+Two gotchas when writing the mapping by hand: list `[data-mast-root]`, `[data-mast-root][data-mast-theme='dark']`, and `[data-mast-root][data-mast-theme='light']` together so source order tie-breaks against the library's dark-mode block, and pass `data-mast-theme={theme}` on the panel root so the library tracks the app's class-based dark mode (`.dark` on `<html>`).
+
+The full token list, gotcha rationale, and a plain-CSS example are in `docs/react-ui/USAGE.md` §5.
 
 ## Icons
 


### PR DESCRIPTION
## Summary

- Adds a full **Theming** section to `docs/react-ui/USAGE.md` (§5): complete token reference table, Tailwind / shadcn worked example with the specificity / class-based-dark-mode / `hsl(var(--*))` gotchas called out explicitly, plain-CSS example, and a one-line preset import.
- Ships the mapping itself as `@mast-ai/react-ui/themes/tailwind-shadcn.css`, an importable preset that remaps every `--mast-*` token onto shadcn's standard HSL variables (`--background`, `--foreground`, `--primary`, `--muted`, `--destructive`, …) using the triple-selector rule so source order tie-breaks correctly against the library's own dark-theme block.
- Reconciles `docs/react-ui/SPEC.md` §2.2 with the current token list (the `--mast-tool-error-*` / `--mast-tool-cancelled-*` tokens were missing) and adds §2.4 documenting the preset export. Skill reference (`skills/mast-ai/references/react-ui.md`) gets the same pointer.

The preset content matches the mapping that was validated during the agent-text-editor migration referenced in the issue, so consumers get the same dark/light behaviour the maintainer has already shipped to production.

Closes #82.

## Test plan

- [x] `dist/themes/tailwind-shadcn.css` is emitted by `npm run build` in `packages/react-ui` (verified locally: 2.43 kB / gzip 0.94 kB).
- [x] `import '@mast-ai/react-ui/themes/tailwind-shadcn.css'` resolves via the new package export.
- [x] In a shadcn-scaffolded consumer, importing `styles.css` then `themes/tailwind-shadcn.css` and passing `theme={resolvedTheme}` on `<ConversationPanel>` produces a panel whose colors track the app theme through both OS and class-based (`.dark` on `<html>`) dark-mode toggles.
- [x] `docs/react-ui/USAGE.md` §5 renders correctly in the GitHub preview (token table, three subsection callouts, code blocks).