### PR TITLE
feat(react-ui): auto-render data-mast-root wrapper on AgentProvider

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -606,6 +606,7 @@ export default function App() {
             initialHistory={active?.history}
             initialEntries={active?.entries}
             onConversationChange={handleConversationChange}
+            theme={panelTheme}
           >
             <div className="demo-main-header">
               <PendingApprovalsBadge />

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -270,8 +270,35 @@ interface AgentProviderProps {
    * Not called when a run is cancelled or errors before completion.
    */
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
+
+  /**
+   * Forces a theme on the auto-rendered [data-mast-root] wrapper. When
+   * omitted, the panel follows the OS preference via the default stylesheet's
+   * prefers-color-scheme media query. Ignored when disableRoot is true.
+   */
+  theme?: 'light' | 'dark';
+
+  /**
+   * Disable the auto-rendered <div data-mast-root> wrapper around children.
+   * Use this when placing data-mast-root somewhere else in the tree yourself
+   * (e.g. on a chat sidebar's outer container so additional non-library UI
+   * inside also picks up the library's CSS variables). Default: false.
+   */
+  disableRoot?: boolean;
 }
 ```
+
+Renders (default — `disableRoot` omitted or `false`):
+
+```html
+<div data-mast-root data-mast-theme="{theme}">{children}</div>
+```
+
+When `disableRoot` is `true`, `children` are rendered directly without a
+wrapper element — the consumer is responsible for placing `data-mast-root`
+on the appropriate element themselves. `<ConversationPanel>` already places
+its own `data-mast-root` on the panel root, so the default and `disableRoot`
+modes both work with it; the default leaves a redundant outer wrapper.
 
 **Internal state managed by `AgentProvider`:**
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -106,6 +106,12 @@ with the agent runner, and exposes the streaming state to descendants through
 `useAgent()`. `<ConversationPanel>` renders a complete chat UI and must be
 nested inside the provider.
 
+By default `<AgentProvider>` also renders a `<div data-mast-root>` wrapper
+around its children so the library's CSS variables are in scope without any
+extra setup. Pass `theme="light" | "dark"` to force a value (the default
+follows OS preference), or `disableRoot` to opt out — see §8 for the
+opt-out pattern.
+
 > Do not bake the API key into a public bundle. The reference demo
 > (`apps/demo-react-ui`) prompts for the key at runtime and stores it in
 > `localStorage`; production apps should fetch a short-lived token from a
@@ -220,18 +226,25 @@ whole palette, or remap every token onto an existing design system without
 
 The default stylesheet ships a light theme and an automatic dark theme that
 follows `prefers-color-scheme`. Apps that manage their own theme switching can
-force a value with the `theme` prop on `<ConversationPanel>`:
+force a value via the `theme` prop on either `<AgentProvider>` (which sets it
+on the auto-rendered `data-mast-root` wrapper) or `<ConversationPanel>` (which
+sets it on the panel root):
 
 ```tsx
+<AgentProvider runner={runner} agent={agent} theme="dark">
+  <ConversationPanel />
+</AgentProvider>
+
 <ConversationPanel theme="dark" />   // force dark
 <ConversationPanel theme="light" />  // force light
 <ConversationPanel />                // follow OS (default)
 ```
 
-The prop sets `data-mast-theme` on the panel root. The default stylesheet
+The prop sets `data-mast-theme` on the matching root. The default stylesheet
 selects on that attribute so OS preferences are overridden without
-`!important`. When composing primitives directly (see §8), set
-`data-mast-theme={theme}` yourself on the element that carries `data-mast-root`.
+`!important`. When composing primitives directly with `disableRoot` (see §8),
+set `data-mast-theme={theme}` yourself on the element that carries
+`data-mast-root`.
 
 ### 5.2 Token reference
 
@@ -503,14 +516,18 @@ highlighter, or escape every character because your domain is plain text.
 
 `<ConversationPanel>` is a thin wrapper around `<MessageList>` and
 `<ChatInput>`. For a sidebar, a docked panel, or any non-default layout, drop
-those primitives directly into your own JSX:
+those primitives directly into your own JSX. Pass `disableRoot` on
+`<AgentProvider>` so it does not emit its own `data-mast-root` wrapper, and
+place the attribute on whichever element should anchor the CSS custom
+properties — typically the outermost container so non-library UI inside (a
+header, badges, surrounding chrome) also picks up the variables:
 
 ```tsx
 import { AgentProvider, MessageList, ChatInput } from '@mast-ai/react-ui';
 
 function AgentSidebar() {
   return (
-    <aside className="my-sidebar" data-mast-root>
+    <aside className="my-sidebar" data-mast-root data-mast-theme={theme}>
       <header className="my-sidebar-header">
         <h2>Assistant</h2>
         <button onClick={closeSidebar}>×</button>
@@ -521,14 +538,21 @@ function AgentSidebar() {
   );
 }
 
-<AgentProvider runner={runner} agent={agent}>
+<AgentProvider runner={runner} agent={agent} disableRoot>
   <AgentSidebar />
 </AgentProvider>;
 ```
 
-Add `data-mast-root` to whichever element should anchor the CSS custom
-properties. `<ConversationPanel>` does this for you; bespoke wrappers must do
-it themselves.
+If you skip `disableRoot`, the provider still renders its default
+`<div data-mast-root>` around your subtree — the inner `data-mast-root` on the
+sidebar wins for CSS scoping, but the wrapper is wasted. Set `disableRoot`
+whenever you place `data-mast-root` somewhere else yourself.
+
+Also use `disableRoot` when you want the library's CSS variables to extend
+to non-library UI rendered alongside the chat (e.g. a settings dialog
+button or a status badge in the chat sidebar's header). The auto-rendered
+wrapper sits inside the provider and only covers `children`; placing
+`data-mast-root` on your own outer container keeps everything in scope.
 
 Other primitives exported for compositional use: `<MessageItem>`,
 `<UserMessage>`, `<AssistantMessage>`, `<ThinkingBlock>`, `<ToolCallBlock>`,

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -384,6 +384,52 @@ describe('useAgent', () => {
     expect(result.current.history).toEqual([]);
   });
 
+  // -------------------------------------------------------------------------
+  // Auto-rendered [data-mast-root] wrapper
+  // -------------------------------------------------------------------------
+
+  it('renders a [data-mast-root] wrapper around children by default', () => {
+    const { runner } = makeMockRunner();
+    const { container } = render(
+      <AgentProvider runner={runner} agent={agentConfig}>
+        <span data-testid="child">child</span>
+      </AgentProvider>,
+    );
+
+    const root = container.querySelector('[data-mast-root]');
+    expect(root).not.toBeNull();
+    expect(root!.tagName).toBe('DIV');
+    expect(root!.querySelector('[data-testid="child"]')).not.toBeNull();
+    // No `data-mast-theme` is set when the prop is omitted, so the default
+    // stylesheet's `prefers-color-scheme` media query takes over.
+    expect(root!.hasAttribute('data-mast-theme')).toBe(false);
+  });
+
+  it('forwards the `theme` prop onto the auto-rendered wrapper as data-mast-theme', () => {
+    const { runner } = makeMockRunner();
+    const { container } = render(
+      <AgentProvider runner={runner} agent={agentConfig} theme="dark">
+        <span>child</span>
+      </AgentProvider>,
+    );
+
+    const root = container.querySelector('[data-mast-root]');
+    expect(root).not.toBeNull();
+    expect(root!.getAttribute('data-mast-theme')).toBe('dark');
+  });
+
+  it('omits the wrapper entirely when disableRoot is true', () => {
+    const { runner } = makeMockRunner();
+    const { container } = render(
+      <AgentProvider runner={runner} agent={agentConfig} disableRoot>
+        <span data-testid="child">child</span>
+      </AgentProvider>,
+    );
+
+    expect(container.querySelector('[data-mast-root]')).toBeNull();
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
+  });
+
   it('useAgent().history reflects the latest core history after each turn', async () => {
     const firstHistory: Message[] = [userMessage('one'), assistantMessage('first')];
     const secondHistory: Message[] = [

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -71,6 +71,21 @@ export interface AgentProviderProps {
    * a run is cancelled or errors before completion.
    */
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
+  /**
+   * Forces a theme on the auto-rendered `[data-mast-root]` wrapper. When
+   * omitted, the panel follows the OS preference via the default stylesheet's
+   * `prefers-color-scheme` media query. Ignored when `disableRoot` is `true`.
+   */
+  theme?: 'light' | 'dark';
+  /**
+   * Disable the auto-rendered `<div data-mast-root>` wrapper around `children`.
+   * Use this when you want to place `data-mast-root` somewhere else in the
+   * tree yourself, e.g. on a chat sidebar's outer container so additional
+   * non-library UI inside also picks up the library's CSS variables.
+   *
+   * Default: `false` (the wrapper is rendered).
+   */
+  disableRoot?: boolean;
 }
 
 /**
@@ -130,6 +145,8 @@ export function AgentProvider({
   initialHistory,
   initialEntries,
   onConversationChange,
+  theme,
+  disableRoot,
 }: AgentProviderProps) {
   const onConversationChangeRef = useRef(onConversationChange);
   onConversationChangeRef.current = onConversationChange;
@@ -248,9 +265,17 @@ export function AgentProvider({
     [entries, history, sendMessage, cancel, isRunning, reset, pendingApprovals],
   );
 
+  const wrappedChildren = disableRoot ? (
+    children
+  ) : (
+    <div data-mast-root data-mast-theme={theme}>
+      {children}
+    </div>
+  );
+
   return (
     <AgentContext.Provider value={value}>
-      <IconProvider icons={icons}>{children}</IconProvider>
+      <IconProvider icons={icons}>{wrappedChildren}</IconProvider>
     </AgentContext.Provider>
   );
 }

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -35,10 +35,14 @@ interface AgentProviderProps {
   initialHistory?: Message[]; // read once on mount
   initialEntries?: ConversationEntry[]; // read once on mount
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
+  theme?: 'light' | 'dark'; // forwarded to the auto-rendered [data-mast-root] wrapper
+  disableRoot?: boolean; // omit the auto-rendered <div data-mast-root> wrapper
 }
 ```
 
 Internally creates a `Conversation` via `runner.conversation(agent)`. To switch conversations at runtime, remount with a React `key` and seed via `initialHistory` / `initialEntries`. `onConversationChange` fires only after a successful `done` event (not on cancel or error).
+
+By default, renders a `<div data-mast-root data-mast-theme={theme}>` around `children` so the library's CSS variables are scoped without extra setup. Pass `disableRoot` when placing `data-mast-root` somewhere else yourself (e.g. on a chat sidebar's outer container so non-library UI inside also picks up the variables).
 
 ## useAgent
 
@@ -80,7 +84,7 @@ interface ConversationPanelProps {
 
 ## Primitives
 
-For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. Add `data-mast-root` to whatever element should anchor the CSS custom properties.
+For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. Pass `disableRoot` on `<AgentProvider>` so it does not emit its own wrapper, and add `data-mast-root` to whatever element should anchor the CSS custom properties.
 
 ```typescript
 import {
@@ -268,7 +272,7 @@ const {
 
 ## Theming
 
-The default stylesheet ships a light theme and an automatic dark theme that follows `prefers-color-scheme`. Apps that manage their own theme can force a value with `theme="light" | "dark"` on `<ConversationPanel>` (sets `data-mast-theme`).
+The default stylesheet ships a light theme and an automatic dark theme that follows `prefers-color-scheme`. Apps that manage their own theme can force a value with `theme="light" | "dark"` on either `<AgentProvider>` (forwarded to the auto-rendered wrapper) or `<ConversationPanel>` — both set `data-mast-theme`.
 
 Override individual tokens by setting CSS custom properties under `[data-mast-root]`:
 


### PR DESCRIPTION
## Summary

- `<AgentProvider>` now wraps its `children` in `<div data-mast-root data-mast-theme={theme}>` by default, eliminating the silent unstyled-component failure when consumers forget to add `data-mast-root` themselves.
- New optional props: `theme?: 'light' | 'dark'` (forwarded to the wrapper) and `disableRoot?: boolean` (opt out when placing `data-mast-root` somewhere else yourself, e.g. on a chat sidebar's outer container so non-library UI inside also picks up the variables).
- `<ConversationPanel>` continues to work unchanged with its own `data-mast-root` root; nesting works correctly. Demo updated to forward `theme` to `<AgentProvider>` so the `PendingApprovalsBadge` sibling tracks the explicit theme too.

Closes #83

## Test plan

- [x] `npm run lint`, `npm test --workspaces --if-present`, `npm run build` all clean.
- [x] Three new unit tests cover the default wrapper, `theme` forwarding, and `disableRoot` opt-out.
- [x] Manual: ran `apps/demo-react-ui` and confirmed default chat still renders fully styled and the theme toggle still themes the panel + badge correctly.