### PR TITLE
feat(react-ui): allow nullable runner on AgentProvider for disabled state

### DIFF
--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -222,7 +222,15 @@ Wraps a subtree with agent context. Manages a `Conversation` instance from
 
 ```tsx
 interface AgentProviderProps {
-  runner: AgentRunner;
+  /**
+   * Drives every agent run. Pass `null` for the "agent not yet configured"
+   * state (no API key yet, signed-out, etc.): the provider mounts cleanly,
+   * `useAgent()` returns disabled-state defaults, and `<ChatInput>` greys
+   * out automatically. Switching from `null` to a real runner does not
+   * require remounting; the conversation starts fresh on the next
+   * `sendMessage`.
+   */
+  runner: AgentRunner | null;
   agent: AgentConfig;
   children: React.ReactNode;
   icons?: IconMap;
@@ -588,6 +596,9 @@ interface UseAgentReturn {
    * Send a user message and start a new turn. The first argument is the prompt
    * delivered to the LLM. The optional second argument overrides what is
    * rendered in the user bubble; when omitted, the prompt is shown.
+   *
+   * No-op (with a console warning) when the provider was mounted with
+   * `runner={null}`.
    */
   sendMessage: (text: string, displayText?: string) => void;
   cancel: () => void;
@@ -600,6 +611,13 @@ interface UseAgentReturn {
    * until one is called.
    */
   pendingApprovals: PendingApproval[];
+  /**
+   * `true` when an `AgentRunner` is configured. `false` when the provider
+   * was mounted with `runner={null}`. `<ChatInput>` reads this to disable
+   * its textarea and Send button; custom inputs built via `useAgent()`
+   * should do the same.
+   */
+  isReady: boolean;
 }
 
 interface PendingApproval {

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -26,6 +26,7 @@ common use cases. The corresponding API reference lives in
 11. [Nested sub-agent tool calls](#11-nested-sub-agent-tool-calls)
 12. [Mention pipeline (`@`-mentions)](#12-mention-pipeline--mentions)
 13. [Overriding tool call labels (`getToolLabel`)](#13-overriding-tool-call-labels-gettoollabel)
+14. [Agent not yet configured (`runner={null}`)](#14-agent-not-yet-configured-runnernull)
 
 ---
 
@@ -1248,6 +1249,65 @@ const renderToolCall = (entry: ToolEventEntry) => {
 The resolver from `getToolLabel` is still consulted for the bundled block, so
 the `delegate_to_skill` example above keeps working alongside the chart
 override.
+
+---
+
+## 14. Agent not yet configured (`runner={null}`)
+
+`<AgentProvider runner={null}>` mounts cleanly without an `AgentRunner`. Use it
+for the "agent not yet configured" state: before the user has supplied an API
+key, signed in, or selected a provider. The provider exposes disabled-state
+defaults via `useAgent()` and `<ChatInput>` greys out automatically, so the
+chat UI can sit inside a fixed shell that mounts before the runner exists.
+
+```tsx
+import { useMemo, useState } from 'react';
+import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+import { AgentProvider, ConversationPanel } from '@mast-ai/react-ui';
+
+function App() {
+  const [apiKey, setApiKey] = useState<string | null>(() => localStorage.getItem('gemini-key'));
+
+  const runner = useMemo(() => {
+    if (!apiKey) return null;
+    return new AgentRunner(new GoogleGenAIAdapter(apiKey), new ToolRegistry());
+  }, [apiKey]);
+
+  const agent = createAgent({ name: 'Assistant', instructions: '…' });
+
+  return (
+    <AppShell onSubmitKey={setApiKey}>
+      <AgentProvider runner={runner} agent={agent}>
+        <ConversationPanel />
+      </AgentProvider>
+    </AppShell>
+  );
+}
+```
+
+When `runner` is `null`:
+
+- `useAgent().isReady` is `false`. Use this to grey out custom inputs the same
+  way the bundled `<ChatInput>` does.
+- `useAgent().messages`, `history`, and `pendingApprovals` are empty.
+- `useAgent().isRunning` is always `false`.
+- `useAgent().sendMessage(…)` is a no-op and logs a console warning so silent
+  drops are easy to spot during development.
+- `cancel()` and `reset()` are safe no-ops.
+- `<ChatInput>` disables its textarea and Send button.
+- `<MessageList>` renders the empty list.
+
+When `runner` switches from `null` to a real value the provider materialises a
+fresh `Conversation` automatically; the next `sendMessage` starts a new turn.
+No remount is required, but anything streamed before the runner existed is
+discarded (there was nothing to stream).
+
+This is the recommended pattern for "agent not yet configured" UI. Avoid the
+older workaround of constructing a stub `AgentRunner` whose adapter throws on
+call: it forces consumers to gate the input separately, and the stub's
+`generate()` will fire if any code path slips past the gate. `runner={null}`
+makes the disabled state explicit and uniformly handled by the library.
 
 ---
 

--- a/packages/react-ui/src/components/ChatInput.test.tsx
+++ b/packages/react-ui/src/components/ChatInput.test.tsx
@@ -209,4 +209,18 @@ describe('<ChatInput>', () => {
     expect(root!.className).toContain('mast-chat-input');
     expect(root!.className).toContain('custom-class');
   });
+
+  it('disables the textarea and Send button when the provider has runner={null}', () => {
+    render(
+      <AgentProvider runner={null} agent={agentConfig}>
+        <ChatInput />
+      </AgentProvider>,
+    );
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(true);
+
+    const sendButton = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    expect(sendButton.disabled).toBe(true);
+  });
 });

--- a/packages/react-ui/src/components/ChatInput.tsx
+++ b/packages/react-ui/src/components/ChatInput.tsx
@@ -100,13 +100,14 @@ interface PlainChatInputProps {
 }
 
 function PlainChatInput({ className, placeholder, sendLabel, cancelLabel }: PlainChatInputProps) {
-  const { sendMessage, cancel, isRunning } = useAgent();
+  const { sendMessage, cancel, isRunning, isReady } = useAgent();
   const icons = useIcons();
   const [value, setValue] = useState('');
 
   const rootClass = ['mast-chat-input', className].filter(Boolean).join(' ');
   const trimmed = value.trim();
-  const canSend = !isRunning && trimmed.length > 0;
+  const canSend = isReady && !isRunning && trimmed.length > 0;
+  const disabled = !isReady || isRunning;
 
   const submit = () => {
     if (!canSend) return;
@@ -139,7 +140,7 @@ function PlainChatInput({ className, placeholder, sendLabel, cancelLabel }: Plai
         value={value}
         placeholder={placeholder}
         rows={rowsForText(value)}
-        disabled={isRunning}
+        disabled={disabled}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
       />
@@ -188,7 +189,7 @@ function MentionsChatInput({
   cancelLabel,
   mentions,
 }: MentionsChatInputProps) {
-  const { sendMessage, cancel, isRunning } = useAgent();
+  const { sendMessage, cancel, isRunning, isReady } = useAgent();
   const icons = useIcons();
   const pickerIdPrefix = useId();
   const {
@@ -207,7 +208,8 @@ function MentionsChatInput({
 
   const rootClass = ['mast-chat-input', 'mast-mention-input', className].filter(Boolean).join(' ');
   const hasContent = segments.length > 0 || trailingInput.trim().length > 0;
-  const canSend = !isRunning && hasContent;
+  const canSend = isReady && !isRunning && hasContent;
+  const disabled = !isReady || isRunning;
   const pickerOpen = mentionQuery !== null && filteredItems.length > 0;
   const activeId = pickerOpen ? `${pickerIdPrefix}-${pickerIndex}` : undefined;
 
@@ -276,7 +278,7 @@ function MentionsChatInput({
             value={trailingInput}
             placeholder={segments.length === 0 ? placeholder : ''}
             rows={rowsForText(trailingInput)}
-            disabled={isRunning}
+            disabled={disabled}
             onChange={(event) => setTrailingInput(event.target.value)}
             onKeyDown={handleKeyDown}
             role="combobox"

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -95,6 +95,7 @@ describe('useAgent', () => {
     expect(typeof result.current.cancel).toBe('function');
     expect(typeof result.current.reset).toBe('function');
     expect(result.current.isRunning).toBe(false);
+    expect(result.current.isReady).toBe(true);
   });
 
   it('sendMessage appends entries that are exposed via messages', async () => {
@@ -469,5 +470,160 @@ describe('useAgent', () => {
       result.current.sendMessage('two');
     });
     expect(result.current.history).toEqual(secondHistory);
+  });
+
+  // -------------------------------------------------------------------------
+  // Nullable runner ("agent not yet configured" state)
+  // -------------------------------------------------------------------------
+
+  describe('with runner={null}', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('mounts cleanly and exposes disabled-state defaults', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <AgentProvider runner={null} agent={agentConfig}>
+          {children}
+        </AgentProvider>
+      );
+      const { result } = renderHook(() => useAgent(), { wrapper });
+
+      expect(result.current.isReady).toBe(false);
+      expect(result.current.isRunning).toBe(false);
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.history).toEqual([]);
+      expect(result.current.pendingApprovals).toEqual([]);
+      expect(typeof result.current.sendMessage).toBe('function');
+      expect(typeof result.current.cancel).toBe('function');
+      expect(typeof result.current.reset).toBe('function');
+    });
+
+    it('sendMessage is a no-op (and warns) when no runner is configured', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <AgentProvider runner={null} agent={agentConfig}>
+          {children}
+        </AgentProvider>
+      );
+      const { result } = renderHook(() => useAgent(), { wrapper });
+
+      act(() => {
+        result.current.sendMessage('hello');
+      });
+
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.isRunning).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect((warnSpy.mock.calls[0][0] as string) ?? '').toMatch(/no AgentRunner is configured/);
+    });
+
+    it('cancel and reset are safe when no runner is configured', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <AgentProvider runner={null} agent={agentConfig}>
+          {children}
+        </AgentProvider>
+      );
+      const { result } = renderHook(() => useAgent(), { wrapper });
+
+      expect(() =>
+        act(() => {
+          result.current.cancel();
+          result.current.reset();
+        }),
+      ).not.toThrow();
+
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.history).toEqual([]);
+      expect(result.current.isReady).toBe(false);
+    });
+
+    it('renders the [data-mast-root] wrapper even with a null runner', () => {
+      const { container } = render(
+        <AgentProvider runner={null} agent={agentConfig}>
+          <span data-testid="child">child</span>
+        </AgentProvider>,
+      );
+
+      const root = container.querySelector('[data-mast-root]');
+      expect(root).not.toBeNull();
+      expect(root!.querySelector('[data-testid="child"]')).not.toBeNull();
+    });
+
+    it('switches to a real runner without remounting and starts a fresh conversation', async () => {
+      const finalHistory: Message[] = [userMessage('hi'), assistantMessage('Hi back')];
+      const { runner, runStreamSpy } = makeMockRunner([
+        { type: 'text_delta', delta: 'Hi back' },
+        { type: 'done', output: 'Hi back', history: finalHistory },
+      ]);
+
+      const probeRef: { current: ReturnType<typeof useAgent> | null } = { current: null };
+      function Probe() {
+        probeRef.current = useAgent();
+        return null;
+      }
+      const App = ({ runner: r }: { runner: AgentRunner | null }) => (
+        <AgentProvider runner={r} agent={agentConfig}>
+          <Probe />
+        </AgentProvider>
+      );
+
+      const { rerender } = render(<App runner={null} />);
+      expect(probeRef.current!.isReady).toBe(false);
+
+      // Swap in a real runner and let the materialise effect run.
+      await act(async () => {
+        rerender(<App runner={runner} />);
+      });
+
+      expect(probeRef.current!.isReady).toBe(true);
+      expect(runner.conversation).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        probeRef.current!.sendMessage('hi');
+      });
+
+      expect(runStreamSpy).toHaveBeenCalledTimes(1);
+      expect(probeRef.current!.messages).toHaveLength(2);
+      expect(probeRef.current!.history).toEqual(finalHistory);
+    });
+
+    it('seeds initialHistory once a real runner becomes available', async () => {
+      const seeded: Message[] = [
+        userMessage('previous question'),
+        assistantMessage('prior answer'),
+      ];
+      const { runner, created } = makeMockRunner([
+        { type: 'done', output: 'next', history: [...seeded] },
+      ]);
+
+      const probeRef: { current: ReturnType<typeof useAgent> | null } = { current: null };
+      function Probe() {
+        probeRef.current = useAgent();
+        return null;
+      }
+      const App = ({ runner: r }: { runner: AgentRunner | null }) => (
+        <AgentProvider runner={r} agent={agentConfig} initialHistory={seeded}>
+          <Probe />
+        </AgentProvider>
+      );
+
+      const { rerender } = render(<App runner={null} />);
+      // No conversation yet, so initialHistory is not surfaced via useAgent().history.
+      expect(probeRef.current!.history).toEqual([]);
+
+      await act(async () => {
+        rerender(<App runner={runner} />);
+      });
+
+      expect(created).toHaveLength(1);
+      expect(created[0].history).toEqual(seeded);
+      expect(probeRef.current!.history).toEqual(seeded);
+    });
   });
 });

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -1,7 +1,15 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
 import { AgentRunner } from '@mast-ai/core';
 import type { AgentConfig, Conversation, Message } from '@mast-ai/core';
@@ -20,8 +28,15 @@ import type { ConversationEntry, IconMap, ToolCallStatus } from './types.js';
  * Props accepted by {@link AgentProvider}.
  */
 export interface AgentProviderProps {
-  /** The {@link AgentRunner} that will execute agent runs. */
-  runner: AgentRunner;
+  /**
+   * The {@link AgentRunner} that will execute agent runs. Pass `null` for the
+   * "agent not yet configured" state (e.g. before the user has supplied an
+   * API key, signed in, or selected a provider): the provider mounts cleanly,
+   * `useAgent()` returns disabled-state defaults, and `<ChatInput>` greys out
+   * automatically. Switching from `null` to a real runner does not require
+   * remounting; the conversation starts fresh on the next `sendMessage`.
+   */
+  runner: AgentRunner | null;
   /** The agent configuration used for every turn. */
   agent: AgentConfig;
   /** The subtree that should have access to {@link useAgent}. */
@@ -124,6 +139,15 @@ export interface UseAgentReturn {
    * called.
    */
   pendingApprovals: PendingApproval[];
+  /**
+   * `true` when an `AgentRunner` is configured. `false` when `<AgentProvider>`
+   * was mounted with `runner={null}` (the "agent not yet configured" state).
+   * `<ChatInput>` reads this to disable its textarea and Send button; custom
+   * inputs built via `useAgent()` should do the same.
+   *
+   * When `false`, `sendMessage` is a no-op (it logs a development warning).
+   */
+  isReady: boolean;
 }
 
 const AgentContext = createContext<UseAgentReturn | null>(null);
@@ -172,6 +196,7 @@ export function AgentProvider({
   >(null);
 
   const wrappedRunner = useMemo(() => {
+    if (runner === null) return null;
     const hasApproval = onApprovalRequired !== undefined;
     const hasOverride = approvalOverride !== undefined && approvalOverride.length > 0;
     if (!hasApproval && !hasOverride) return runner;
@@ -190,13 +215,30 @@ export function AgentProvider({
     return new AgentRunner(runner.adapter, provider);
   }, [runner, onApprovalRequired, approvalOverride]);
 
-  const [conversation, setConversation] = useState<Conversation>(() => {
+  const [conversation, setConversation] = useState<Conversation | null>(() => {
+    if (wrappedRunner === null) return null;
     const conv = wrappedRunner.conversation(agent);
     if (initialHistoryRef.current && initialHistoryRef.current.length > 0) {
       conv.history = [...initialHistoryRef.current];
     }
     return conv;
   });
+
+  // Materialise a Conversation when the runner transitions from null to a
+  // real value, so consumers can swap in a runner after the app finishes
+  // configuring it (sign-in, API key entry, etc.) without remounting the
+  // provider. We deliberately do not tear down or replace an existing
+  // conversation when the runner reference changes — that case is out of
+  // scope and consumers should call `reset()` to start a fresh conversation.
+  useEffect(() => {
+    if (wrappedRunner !== null && conversation === null) {
+      const conv = wrappedRunner.conversation(agent);
+      if (initialHistoryRef.current && initialHistoryRef.current.length > 0) {
+        conv.history = [...initialHistoryRef.current];
+      }
+      setConversation(conv);
+    }
+  }, [wrappedRunner, conversation, agent]);
 
   const onTurnComplete = useCallback(
     (committedEntries: ConversationEntry[], committedHistory: Message[]) => {
@@ -249,9 +291,10 @@ export function AgentProvider({
     // proxy translates into the synthetic cancelled result.
     pendingApprovalsRef.current.forEach((p) => p.reject());
     resetStream();
-    setConversation(wrappedRunner.conversation(agent));
+    setConversation(wrappedRunner === null ? null : wrappedRunner.conversation(agent));
   }, [resetStream, wrappedRunner, agent]);
 
+  const isReady = wrappedRunner !== null;
   const value = useMemo<UseAgentReturn>(
     () => ({
       messages: entries,
@@ -261,8 +304,9 @@ export function AgentProvider({
       isRunning,
       reset,
       pendingApprovals,
+      isReady,
     }),
-    [entries, history, sendMessage, cancel, isRunning, reset, pendingApprovals],
+    [entries, history, sendMessage, cancel, isRunning, reset, pendingApprovals, isReady],
   );
 
   const wrappedChildren = disableRoot ? (

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -193,6 +193,12 @@ export interface UseAgentStreamReturn {
  * of the conversation. Sub-agent events are captured via `onToolEvent` and
  * routed to the matching `ToolEventEntry` by tool name.
  *
+ * Pass `null` for `conversation` to model the "agent not yet configured"
+ * state — `sendMessage` becomes a no-op (with a development warning),
+ * `history` is empty, and `isRunning` is always `false`. The hook switches
+ * back to live behaviour once a non-null `conversation` is supplied on a
+ * later render.
+ *
  * This hook is consumed by `<AgentProvider>` and is not part of the public API.
  * It is exported so that it can be used independently in advanced scenarios.
  *
@@ -223,12 +229,23 @@ export interface UseAgentStreamReturn {
  * ```
  */
 export function useAgentStream(
-  conversation: Conversation,
+  conversation: Conversation | null,
   options?: UseAgentStreamOptions,
 ): UseAgentStreamReturn {
   const [entries, setEntries] = useState<ConversationEntry[]>(() => options?.initialEntries ?? []);
-  const [history, setHistory] = useState<Message[]>(() => [...conversation.history]);
+  const [history, setHistory] = useState<Message[]>(() =>
+    conversation ? [...conversation.history] : [],
+  );
   const [isRunning, setIsRunning] = useState(false);
+
+  // When the provider materialises a Conversation after mount (e.g. the
+  // runner went from null to a real value), pick up its seeded history so
+  // the live `history` value reflects what the LLM will actually see.
+  useEffect(() => {
+    if (conversation) {
+      setHistory([...conversation.history]);
+    }
+  }, [conversation]);
   // Bumped after every `done` event to trigger the onTurnComplete effect once
   // the new entries and history have been committed by React.
   const [completedTurnId, setCompletedTurnId] = useState(0);
@@ -275,6 +292,15 @@ export function useAgentStream(
   const sendMessage = useCallback(
     (text: string, displayText?: string) => {
       if (isRunning) return;
+      if (conversation === null) {
+        // Surface accidental drops so consumers do not silently swallow user
+        // input when their gating around the runner-null state slips.
+        console.warn(
+          'useAgent().sendMessage was called while no AgentRunner is configured. ' +
+            'Pass a non-null `runner` to <AgentProvider> to enable the agent.',
+        );
+        return;
+      }
 
       // `??` (not `||`) so an explicit empty-string displayText is respected as
       // a deliberate override rather than collapsing back to `text`.

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -26,7 +26,7 @@ Wraps a subtree with agent context. Must be rendered around any component that c
 import { AgentProvider } from '@mast-ai/react-ui';
 
 interface AgentProviderProps {
-  runner: AgentRunner;
+  runner: AgentRunner | null; // null = "agent not yet configured" (no key, signed-out)
   agent: AgentConfig;
   children: ReactNode;
   icons?: IconMap;
@@ -41,6 +41,8 @@ interface AgentProviderProps {
 ```
 
 Internally creates a `Conversation` via `runner.conversation(agent)`. To switch conversations at runtime, remount with a React `key` and seed via `initialHistory` / `initialEntries`. `onConversationChange` fires only after a successful `done` event (not on cancel or error).
+
+`runner={null}` is the "agent not yet configured" state for chat UIs that mount before the user has supplied an API key, signed in, etc. `useAgent()` returns disabled-state defaults (`isReady: false`, empty messages/history, no-op `sendMessage` with a console warning), and `<ChatInput>` greys out automatically. Switching `null` → real runner does not require remounting; the conversation starts fresh on the next `sendMessage` (and picks up `initialHistory` if provided). Prefer this over constructing a stub runner whose adapter throws.
 
 By default, renders a `<div data-mast-root data-mast-theme={theme}>` around `children` so the library's CSS variables are scoped without extra setup. Pass `disableRoot` when placing `data-mast-root` somewhere else yourself (e.g. on a chat sidebar's outer container so non-library UI inside also picks up the variables).
 
@@ -59,6 +61,7 @@ interface UseAgentReturn {
   isRunning: boolean;
   reset: () => void;
   pendingApprovals: PendingApproval[];
+  isReady: boolean; // false when <AgentProvider> was mounted with runner={null}
 }
 ```
 


### PR DESCRIPTION
## Summary

- `<AgentProvider runner={null}>` mounts cleanly for the "agent not yet configured" case (no API key yet, signed-out, no provider selected). `useAgent()` returns disabled-state defaults: `isReady: false`, empty `messages` / `history` / `pendingApprovals`, `isRunning: false`, no-op `sendMessage` (with a console warning so accidentally-dropped input is easy to spot), safe `cancel` / `reset`.
- `<ChatInput>` (both plain and mention variants) reads `isReady` and disables the textarea + Send button automatically, matching how it greys out during `isRunning`.
- Switching `runner` from `null` to a real value does not require remounting — an effect materialises a fresh `Conversation` (seeding `initialHistory` if provided) and the next `sendMessage` starts a new turn. Existing non-null usage is unchanged; no breaking changes.
- Replaces the older workaround of constructing a stub `AgentRunner` whose adapter throws on call. `USAGE.md` adds §14 explicitly steering consumers toward `runner={null}` instead.

## Test plan

- [x] `npm run lint` (workspace root)
- [x] `npm run format`
- [x] `npm run build`
- [x] `npm test --workspaces` (179 react-ui tests pass, including 6 new cases for nullable runner: disabled-state defaults, no-op + warning on `sendMessage`, safe `cancel`/`reset`, `[data-mast-root]` still rendered, runner swap without remount, `initialHistory` seeded after the runner appears, and 1 new `<ChatInput>` test asserting both controls disable)
- [x] Manually tested in the demo

Closes #84