### PR TITLE
chore: release v0.2.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.1.2"
+    "@mast-ai/core": "^0.2.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.1.2"
+    "@mast-ai/core": "^0.2.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.1.2",
+    "@mast-ai/core": "^0.2.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
Bumps `@mast-ai/core`, `@mast-ai/google-genai`, `@mast-ai/built-in-ai`, and `@mast-ai/react-ui` from `0.1.2` to `0.2.0` in lockstep.

## Changes since v0.1.2

### `@mast-ai/core`

- `RunBuilder.forwardTo()` for sub-agent event forwarding (#88)

### `@mast-ai/react-ui`

- `renderApproval` slot for inline approval cards (#87)
- Per-tool display label slot for `ToolCallBlock` via `getToolLabel` (#89)
- Theming integration guide and shadcn preset (#90)
- `AgentProvider` auto-renders a `<div data-mast-root>` wrapper around children by default, with `disableRoot` opt-out (#91)
- `AgentProvider` accepts `runner={null}` for the "agent not yet configured" state; `useAgent()` exposes `isReady` (#93)

### `@mast-ai/google-genai`, `@mast-ai/built-in-ai`

No source changes; bumped in lockstep per the release policy.

## Why a minor (breaking) bump

On `0.x`, minor bumps mark the breaking-change line. `AgentProvider`'s auto-rendered `data-mast-root` wrapper changes the rendered DOM structure by default, which is an observable behaviour change consumers may depend on (e.g. when `<AgentProvider>` was a direct flex/grid child). Consumers who place `data-mast-root` themselves can opt out with `disableRoot`. Everything else is purely additive.

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present`
- [x] `npm run build`
- [ ] Tag `v0.2.0` after merge to trigger the publish workflow