### PR TITLE
ci: bump checkout and setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` and `actions/setup-node` from `v4` to `v5` in both `ci.yml` and `publish.yml`.
- v5 of these actions runs on Node.js 24, resolving the deprecation warning surfaced on the v0.2.0 publish run (Node.js 20 is being removed from runners on 2026-09-16).

## Test plan

- [x] CI workflow on this PR runs green (validates the new action versions on the standard build/test pipeline).
- [x] No changes needed to `publish.yml` validation since publishing is only exercised on tag pushes — re-validate on the next release tag.