### PR TITLE
fix(react-ui): invert AgentProvider's disableRoot default to true

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -606,7 +606,6 @@ export default function App() {
             initialHistory={active?.history}
             initialEntries={active?.entries}
             onConversationChange={handleConversationChange}
-            theme={panelTheme}
           >
             <div className="demo-main-header">
               <PendingApprovalsBadge />

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -280,33 +280,53 @@ interface AgentProviderProps {
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
 
   /**
-   * Forces a theme on the auto-rendered [data-mast-root] wrapper. When
-   * omitted, the panel follows the OS preference via the default stylesheet's
-   * prefers-color-scheme media query. Ignored when disableRoot is true.
+   * Forces a theme on the auto-rendered [data-mast-root] wrapper. Only
+   * meaningful when disableRoot is explicitly false (so the provider actually
+   * renders the wrapper). When omitted or true, the prop has no effect and
+   * consumers should set data-mast-theme themselves on whatever element
+   * carries data-mast-root.
    */
   theme?: 'light' | 'dark';
 
   /**
-   * Disable the auto-rendered <div data-mast-root> wrapper around children.
-   * Use this when placing data-mast-root somewhere else in the tree yourself
-   * (e.g. on a chat sidebar's outer container so additional non-library UI
-   * inside also picks up the library's CSS variables). Default: false.
+   * Controls whether the provider renders an auto wrapper <div data-mast-root>
+   * around children.
+   *
+   * Default: true — the provider is transparent in the DOM and consumers are
+   * responsible for placing data-mast-root themselves (typically on the
+   * outermost container, or implicitly via <ConversationPanel> which carries
+   * its own data-mast-root). This avoids the auto wrapper's panel chrome
+   * (border, padding, height: 100%) leaking onto whatever subtree the provider
+   * wraps, including app-root mounts.
+   *
+   * Set to false to opt back into the auto wrapper for zero-config setups
+   * that compose primitives directly without their own root container.
    */
   disableRoot?: boolean;
 }
 ```
 
-Renders (default — `disableRoot` omitted or `false`):
+Renders (default — `disableRoot` omitted or `true`):
+
+```html
+{children}
+```
+
+Consumers place `data-mast-root` on whatever element should anchor the
+library's CSS custom properties. `<ConversationPanel>` does this on its
+panel root, so the default + `<ConversationPanel>` combination needs no
+extra setup. When composing primitives directly, place `data-mast-root` on
+the outermost container so non-library UI in the same subtree also inherits
+the variables.
+
+When `disableRoot` is `false`, the provider renders an auto wrapper:
 
 ```html
 <div data-mast-root data-mast-theme="{theme}">{children}</div>
 ```
 
-When `disableRoot` is `true`, `children` are rendered directly without a
-wrapper element — the consumer is responsible for placing `data-mast-root`
-on the appropriate element themselves. `<ConversationPanel>` already places
-its own `data-mast-root` on the panel root, so the default and `disableRoot`
-modes both work with it; the default leaves a redundant outer wrapper.
+This is the opt-in zero-config mode for layouts that do not have their own
+container element.
 
 **Internal state managed by `AgentProvider`:**
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -107,11 +107,16 @@ with the agent runner, and exposes the streaming state to descendants through
 `useAgent()`. `<ConversationPanel>` renders a complete chat UI and must be
 nested inside the provider.
 
-By default `<AgentProvider>` also renders a `<div data-mast-root>` wrapper
-around its children so the library's CSS variables are in scope without any
-extra setup. Pass `theme="light" | "dark"` to force a value (the default
-follows OS preference), or `disableRoot` to opt out — see §8 for the
-opt-out pattern.
+`<AgentProvider>` is transparent in the DOM by default: it does not render
+its own wrapper around `children`. `<ConversationPanel>` carries its own
+`data-mast-root` so the snippet above works with no extra setup. When
+composing primitives directly, place `data-mast-root` on whichever element
+should anchor the library's CSS variables (typically the outermost
+container) — see §8.
+
+Pass `disableRoot={false}` to opt back into a zero-config wrapper when you
+have nowhere else to put `data-mast-root`; in that mode the provider also
+forwards `theme="light" | "dark"` onto the wrapper as `data-mast-theme`.
 
 > Do not bake the API key into a public bundle. The reference demo
 > (`apps/demo-react-ui`) prompts for the key at runtime and stores it in
@@ -227,25 +232,25 @@ whole palette, or remap every token onto an existing design system without
 
 The default stylesheet ships a light theme and an automatic dark theme that
 follows `prefers-color-scheme`. Apps that manage their own theme switching can
-force a value via the `theme` prop on either `<AgentProvider>` (which sets it
-on the auto-rendered `data-mast-root` wrapper) or `<ConversationPanel>` (which
-sets it on the panel root):
+force a value via the `theme` prop on `<ConversationPanel>` (which sets it on
+the panel root). When opted into the auto wrapper via `disableRoot={false}`,
+the same prop on `<AgentProvider>` forwards it onto the wrapper.
 
 ```tsx
-<AgentProvider runner={runner} agent={agent} theme="dark">
-  <ConversationPanel />
-</AgentProvider>
-
 <ConversationPanel theme="dark" />   // force dark
 <ConversationPanel theme="light" />  // force light
 <ConversationPanel />                // follow OS (default)
+
+<AgentProvider runner={runner} agent={agent} disableRoot={false} theme="dark">
+  <ConversationPanel />
+</AgentProvider>
 ```
 
 The prop sets `data-mast-theme` on the matching root. The default stylesheet
 selects on that attribute so OS preferences are overridden without
-`!important`. When composing primitives directly with `disableRoot` (see §8),
-set `data-mast-theme={theme}` yourself on the element that carries
-`data-mast-root`.
+`!important`. When composing primitives directly (see §8) the provider is
+already transparent in the DOM by default, so set `data-mast-theme={theme}`
+yourself on the element that carries `data-mast-root`.
 
 ### 5.2 Token reference
 
@@ -517,11 +522,11 @@ highlighter, or escape every character because your domain is plain text.
 
 `<ConversationPanel>` is a thin wrapper around `<MessageList>` and
 `<ChatInput>`. For a sidebar, a docked panel, or any non-default layout, drop
-those primitives directly into your own JSX. Pass `disableRoot` on
-`<AgentProvider>` so it does not emit its own `data-mast-root` wrapper, and
-place the attribute on whichever element should anchor the CSS custom
-properties — typically the outermost container so non-library UI inside (a
-header, badges, surrounding chrome) also picks up the variables:
+those primitives directly into your own JSX. `<AgentProvider>` is transparent
+in the DOM by default, so place `data-mast-root` on whichever element should
+anchor the CSS custom properties (typically the outermost container, so
+non-library UI inside such as a header, badges, or surrounding chrome also
+picks up the variables):
 
 ```tsx
 import { AgentProvider, MessageList, ChatInput } from '@mast-ai/react-ui';
@@ -539,21 +544,26 @@ function AgentSidebar() {
   );
 }
 
-<AgentProvider runner={runner} agent={agent} disableRoot>
+<AgentProvider runner={runner} agent={agent}>
   <AgentSidebar />
 </AgentProvider>;
 ```
 
-If you skip `disableRoot`, the provider still renders its default
-`<div data-mast-root>` around your subtree — the inner `data-mast-root` on the
-sidebar wins for CSS scoping, but the wrapper is wasted. Set `disableRoot`
-whenever you place `data-mast-root` somewhere else yourself.
+For zero-config setups that have no natural outer container, set
+`disableRoot={false}` to opt back into the provider's auto wrapper:
 
-Also use `disableRoot` when you want the library's CSS variables to extend
-to non-library UI rendered alongside the chat (e.g. a settings dialog
-button or a status badge in the chat sidebar's header). The auto-rendered
-wrapper sits inside the provider and only covers `children`; placing
-`data-mast-root` on your own outer container keeps everything in scope.
+```tsx
+<AgentProvider runner={runner} agent={agent} disableRoot={false}>
+  <MessageList />
+  <ChatInput />
+</AgentProvider>
+```
+
+The auto wrapper carries panel chrome (border, padding, `height: 100%`),
+which is appropriate when it actually wraps a chat panel but surprises apps
+that mount `<AgentProvider>` near the React tree root. The default
+(`disableRoot` omitted or `true`) keeps the provider transparent so the
+chrome only appears where you ask for it.
 
 Other primitives exported for compositional use: `<MessageItem>`,
 `<UserMessage>`, `<AssistantMessage>`, `<ThinkingBlock>`, `<ToolCallBlock>`,

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -389,10 +389,22 @@ describe('useAgent', () => {
   // Auto-rendered [data-mast-root] wrapper
   // -------------------------------------------------------------------------
 
-  it('renders a [data-mast-root] wrapper around children by default', () => {
+  it('does not render a [data-mast-root] wrapper around children by default', () => {
     const { runner } = makeMockRunner();
     const { container } = render(
       <AgentProvider runner={runner} agent={agentConfig}>
+        <span data-testid="child">child</span>
+      </AgentProvider>,
+    );
+
+    expect(container.querySelector('[data-mast-root]')).toBeNull();
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
+  });
+
+  it('renders the [data-mast-root] wrapper when disableRoot={false} opts in', () => {
+    const { runner } = makeMockRunner();
+    const { container } = render(
+      <AgentProvider runner={runner} agent={agentConfig} disableRoot={false}>
         <span data-testid="child">child</span>
       </AgentProvider>,
     );
@@ -406,10 +418,10 @@ describe('useAgent', () => {
     expect(root!.hasAttribute('data-mast-theme')).toBe(false);
   });
 
-  it('forwards the `theme` prop onto the auto-rendered wrapper as data-mast-theme', () => {
+  it('forwards the `theme` prop onto the opted-in wrapper as data-mast-theme', () => {
     const { runner } = makeMockRunner();
     const { container } = render(
-      <AgentProvider runner={runner} agent={agentConfig} theme="dark">
+      <AgentProvider runner={runner} agent={agentConfig} disableRoot={false} theme="dark">
         <span>child</span>
       </AgentProvider>,
     );
@@ -419,7 +431,7 @@ describe('useAgent', () => {
     expect(root!.getAttribute('data-mast-theme')).toBe('dark');
   });
 
-  it('omits the wrapper entirely when disableRoot is true', () => {
+  it('omits the wrapper when disableRoot is true', () => {
     const { runner } = makeMockRunner();
     const { container } = render(
       <AgentProvider runner={runner} agent={agentConfig} disableRoot>
@@ -543,16 +555,15 @@ describe('useAgent', () => {
       expect(result.current.isReady).toBe(false);
     });
 
-    it('renders the [data-mast-root] wrapper even with a null runner', () => {
+    it('does not render the [data-mast-root] wrapper with a null runner by default', () => {
       const { container } = render(
         <AgentProvider runner={null} agent={agentConfig}>
           <span data-testid="child">child</span>
         </AgentProvider>,
       );
 
-      const root = container.querySelector('[data-mast-root]');
-      expect(root).not.toBeNull();
-      expect(root!.querySelector('[data-testid="child"]')).not.toBeNull();
+      expect(container.querySelector('[data-mast-root]')).toBeNull();
+      expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
     });
 
     it('switches to a real runner without remounting and starts a fresh conversation', async () => {

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -87,18 +87,28 @@ export interface AgentProviderProps {
    */
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
   /**
-   * Forces a theme on the auto-rendered `[data-mast-root]` wrapper. When
-   * omitted, the panel follows the OS preference via the default stylesheet's
-   * `prefers-color-scheme` media query. Ignored when `disableRoot` is `true`.
+   * Forces a theme on the auto-rendered `[data-mast-root]` wrapper. Only
+   * meaningful when `disableRoot` is explicitly `false` (so the provider
+   * actually renders the wrapper); when omitted or `true`, this prop has no
+   * effect and consumers should set `data-mast-theme` themselves on whatever
+   * element carries `data-mast-root`. When the wrapper is rendered without a
+   * theme set, the panel follows OS preference via the default stylesheet's
+   * `prefers-color-scheme` media query.
    */
   theme?: 'light' | 'dark';
   /**
-   * Disable the auto-rendered `<div data-mast-root>` wrapper around `children`.
-   * Use this when you want to place `data-mast-root` somewhere else in the
-   * tree yourself, e.g. on a chat sidebar's outer container so additional
-   * non-library UI inside also picks up the library's CSS variables.
+   * Controls whether the provider renders an auto wrapper `<div data-mast-root>`
+   * around `children`.
    *
-   * Default: `false` (the wrapper is rendered).
+   * Default: `true` — the provider is transparent in the DOM and consumers
+   * are responsible for placing `data-mast-root` themselves (typically on the
+   * outermost container, or implicitly via `<ConversationPanel>` which carries
+   * its own `data-mast-root`). This avoids the auto wrapper's panel chrome
+   * (border, padding, `height: 100%`) leaking onto whatever subtree the
+   * provider wraps, including app-root mounts.
+   *
+   * Set to `false` to opt back into the auto wrapper for zero-config setups
+   * that compose primitives directly without their own root container.
    */
   disableRoot?: boolean;
 }
@@ -309,13 +319,14 @@ export function AgentProvider({
     [entries, history, sendMessage, cancel, isRunning, reset, pendingApprovals, isReady],
   );
 
-  const wrappedChildren = disableRoot ? (
-    children
-  ) : (
-    <div data-mast-root data-mast-theme={theme}>
-      {children}
-    </div>
-  );
+  const wrappedChildren =
+    disableRoot === false ? (
+      <div data-mast-root data-mast-theme={theme}>
+        {children}
+      </div>
+    ) : (
+      children
+    );
 
   return (
     <AgentContext.Provider value={value}>

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -35,8 +35,8 @@ interface AgentProviderProps {
   initialHistory?: Message[]; // read once on mount
   initialEntries?: ConversationEntry[]; // read once on mount
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
-  theme?: 'light' | 'dark'; // forwarded to the auto-rendered [data-mast-root] wrapper
-  disableRoot?: boolean; // omit the auto-rendered <div data-mast-root> wrapper
+  theme?: 'light' | 'dark'; // forwarded to the auto wrapper when disableRoot={false}
+  disableRoot?: boolean; // default true; pass false to opt into the auto <div data-mast-root> wrapper
 }
 ```
 
@@ -44,7 +44,7 @@ Internally creates a `Conversation` via `runner.conversation(agent)`. To switch 
 
 `runner={null}` is the "agent not yet configured" state for chat UIs that mount before the user has supplied an API key, signed in, etc. `useAgent()` returns disabled-state defaults (`isReady: false`, empty messages/history, no-op `sendMessage` with a console warning), and `<ChatInput>` greys out automatically. Switching `null` → real runner does not require remounting; the conversation starts fresh on the next `sendMessage` (and picks up `initialHistory` if provided). Prefer this over constructing a stub runner whose adapter throws.
 
-By default, renders a `<div data-mast-root data-mast-theme={theme}>` around `children` so the library's CSS variables are scoped without extra setup. Pass `disableRoot` when placing `data-mast-root` somewhere else yourself (e.g. on a chat sidebar's outer container so non-library UI inside also picks up the variables).
+By default, the provider is transparent in the DOM. Place `data-mast-root` on whichever element should anchor the library's CSS variables (typically the outermost container, or implicitly via `<ConversationPanel>` which carries its own). Pass `disableRoot={false}` to opt into a zero-config `<div data-mast-root data-mast-theme={theme}>` wrapper for layouts that have no natural outer container.
 
 ## useAgent
 
@@ -87,7 +87,7 @@ interface ConversationPanelProps {
 
 ## Primitives
 
-For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. Pass `disableRoot` on `<AgentProvider>` so it does not emit its own wrapper, and add `data-mast-root` to whatever element should anchor the CSS custom properties.
+For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. `<AgentProvider>` is already transparent by default, so just add `data-mast-root` to whatever element should anchor the CSS custom properties. (Use `disableRoot={false}` when you want the provider to render its own zero-config wrapper instead.)
 
 ```typescript
 import {
@@ -275,7 +275,7 @@ const {
 
 ## Theming
 
-The default stylesheet ships a light theme and an automatic dark theme that follows `prefers-color-scheme`. Apps that manage their own theme can force a value with `theme="light" | "dark"` on either `<AgentProvider>` (forwarded to the auto-rendered wrapper) or `<ConversationPanel>` — both set `data-mast-theme`.
+The default stylesheet ships a light theme and an automatic dark theme that follows `prefers-color-scheme`. Apps that manage their own theme can force a value with `theme="light" | "dark"` on `<ConversationPanel>` (or, when opted in via `disableRoot={false}`, on `<AgentProvider>` so it's forwarded onto the auto wrapper). Both set `data-mast-theme`.
 
 Override individual tokens by setting CSS custom properties under `[data-mast-root]`:
 


### PR DESCRIPTION
## Summary

- Inverts the `disableRoot` default so `<AgentProvider>` is transparent in the DOM by default. The auto `<div data-mast-root>` wrapper is now opt-in via `disableRoot={false}`.
- This is a breaking change for apps that upgraded to 0.2.0 and relied on the auto wrapper. Pre-0.2.0 there was no wrapper, so this restores the prior behaviour.
- Updates `theme` prop docs to note it only takes effect when the wrapper is opted in. The same prop on `<ConversationPanel>` (which carries its own `data-mast-root`) is unchanged.

## Why

In 0.2.0 the auto wrapper carried opinionated panel chrome (`border`, `padding: 0.75rem`, `height: 100%`, `box-sizing: border-box`). Two surprises followed:

1. `<AgentProvider>`-at-app-root layouts got a 1px border + 0.75rem padding around the entire app, producing page-level scroll when a child sized `h-screen w-screen` ran into `box-sizing: border-box`. The fix (`disableRoot`) was correct but undiscoverable.
2. Apps following USAGE.md §8 (placing `data-mast-root` on a sidebar's outer container) ended up with two nested `data-mast-root` elements, both with chrome.

Provider components are typically transparent; opt-in chrome is more predictable and forces consumers to think about where `data-mast-root` should live, which they need to do anyway to match §8.

## Changes

- `packages/react-ui/src/context.tsx` — Wrapper only renders when `disableRoot === false`. JSDoc updated for `disableRoot` and `theme`.
- `packages/react-ui/src/context.test.tsx` — Flipped wrapper-presence assertions; added an opt-in test for `disableRoot={false}`.
- `apps/demo-react-ui/src/App.tsx` — Removed the now-no-op `theme={panelTheme}` prop on `<AgentProvider>` (the prop still works on `<ConversationPanel>`).
- `docs/react-ui/SPEC.md` §4.1, `docs/react-ui/USAGE.md` §2 / §5.1 / §8, `skills/mast-ai/references/react-ui.md` — Reframed the default as transparent and documented `disableRoot={false}` as the zero-config opt-in.

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present` (180 react-ui tests pass)
- [x] `npm run build`
- [x] Manual smoke test in `apps/demo-react-ui`: no extra outer wrapper, no page-level scroll, tool calls / approvals / theming still work.

Closes #96