### PR TITLE
fix(react-ui): default approval UI to inline queue when callback is omitted

### DIFF
--- a/docs/react-ui/PLAN.md
+++ b/docs/react-ui/PLAN.md
@@ -260,9 +260,9 @@ needsApproval = (def.requiresApproval || overrideSet.has(name)) && !suppressSet.
 
 **`src/approval.test.tsx`**
 
-- All six scenarios from SPEC §11.2: `requiresApproval: true` triggers callback;
+- All scenarios from SPEC §11.2: `requiresApproval: true` triggers callback;
   callback returns `false` / `string` / `true`; `approvalOverride` adds and suppresses;
-  no callback → silent execution.
+  no callback → defaults to the inline approval queue.
 
 **`apps/demo-react-ui`**
 

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -1009,19 +1009,19 @@ to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequen
 
 **Approval flow**
 
-| Scenario                                    | What is verified                                                                                                      |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Tool with `requiresApproval: true`          | `onApprovalRequired` is called before tool executes                                                                   |
-| Callback returns `false`                    | Tool call is cancelled; runner receives synthetic "user cancelled" result                                             |
-| Callback returns a string                   | Injected as the tool result; tool does not execute                                                                    |
-| `approvalOverride` adds a name              | Unlisted tool triggers approval                                                                                       |
-| `approvalOverride` suppresses with `!`      | Tool with `requiresApproval: true` executes without prompting                                                         |
+| Scenario                                    | What is verified                                                                                                           |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Tool with `requiresApproval: true`          | `onApprovalRequired` is called before tool executes                                                                        |
+| Callback returns `false`                    | Tool call is cancelled; runner receives synthetic "user cancelled" result                                                  |
+| Callback returns a string                   | Injected as the tool result; tool does not execute                                                                         |
+| `approvalOverride` adds a name              | Unlisted tool triggers approval                                                                                            |
+| `approvalOverride` suppresses with `!`      | Tool with `requiresApproval: true` executes without prompting                                                              |
 | No `onApprovalRequired` provided            | Tools with `requiresApproval: true` enqueue an inline approval handle on `useAgent().pendingApprovals` (default behaviour) |
-| `awaitingApproval` flag                     | Set while the callback is pending; cleared on resolve, reject, or throw                                               |
-| `INLINE_APPROVAL` exposes `PendingApproval` | Handle appears on `useAgent().pendingApprovals` while waiting                                                         |
-| `approve()` / `reject()` / `respondWith()`  | Resolve the proxy and remove the handle from the queue                                                                |
-| `reset()` while pending                     | Rejects in-flight approvals so the run terminates                                                                     |
-| Tool call status                            | `'success'` on normal return; `'error'` when `tool_call_completed.error` is true; `'cancelled'` when the user rejects |
+| `awaitingApproval` flag                     | Set while the callback is pending; cleared on resolve, reject, or throw                                                    |
+| `INLINE_APPROVAL` exposes `PendingApproval` | Handle appears on `useAgent().pendingApprovals` while waiting                                                              |
+| `approve()` / `reject()` / `respondWith()`  | Resolve the proxy and remove the handle from the queue                                                                     |
+| `reset()` while pending                     | Rejects in-flight approvals so the run terminates                                                                          |
+| Tool call status                            | `'success'` on normal return; `'error'` when `tool_call_completed.error` is true; `'cancelled'` when the user rejects      |
 
 **Conversation persistence**
 

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -242,9 +242,13 @@ interface AgentProviderProps {
    * defer to the inline approval queue surfaced via useAgent().pendingApprovals.
    *
    * Also called for any tool whose name appears in approvalOverride, regardless
-   * of the tool's own requiresApproval flag — allowing context-specific policy
+   * of the tool's own requiresApproval flag, allowing context-specific policy
    * (e.g. a sandbox environment that auto-approves everything, or a production
    * deployment that adds approval to a third-party tool it did not define).
+   *
+   * Defaults to a callback that returns INLINE_APPROVAL for every call when
+   * omitted, so tools marked requiresApproval: true always pause for user
+   * confirmation by default.
    */
   onApprovalRequired?: (
     toolCall: ToolEventEntry,
@@ -946,9 +950,14 @@ suppressSet = new Set(approvalOverride.filter(s => s.startsWith('!')).map(s => s
 needsApproval = (toolDef.requiresApproval || overrideSet.has(name)) && !suppressSet.has(name)
 ```
 
-`onApprovalRequired` is not called when `needsApproval` is false, or when
-`onApprovalRequired` is not provided (in which case tools with `requiresApproval: true`
-execute without pausing — the callback is the opt-in).
+`onApprovalRequired` is not called when `needsApproval` is false. When the prop
+is omitted entirely, the library substitutes a default callback that returns
+`INLINE_APPROVAL` for every call, so tools with `requiresApproval: true` always
+pause for user confirmation by default. Apps that already render `<InlineApproval>`
+(or read `useAgent().pendingApprovals`) get a working approval flow with no
+additional wiring; provide a custom callback to plug in a different confirmation
+UI, auto-approve specific tools, inject canned results, or short-circuit
+cancellations.
 
 ---
 
@@ -1007,7 +1016,7 @@ to verify manually. Tests use a mock `AgentRunner` that yields a scripted sequen
 | Callback returns a string                   | Injected as the tool result; tool does not execute                                                                    |
 | `approvalOverride` adds a name              | Unlisted tool triggers approval                                                                                       |
 | `approvalOverride` suppresses with `!`      | Tool with `requiresApproval: true` executes without prompting                                                         |
-| No `onApprovalRequired` provided            | Tools with `requiresApproval: true` execute silently                                                                  |
+| No `onApprovalRequired` provided            | Tools with `requiresApproval: true` enqueue an inline approval handle on `useAgent().pendingApprovals` (default behaviour) |
 | `awaitingApproval` flag                     | Set while the callback is pending; cleared on resolve, reject, or throw                                               |
 | `INLINE_APPROVAL` exposes `PendingApproval` | Handle appears on `useAgent().pendingApprovals` while waiting                                                         |
 | `approve()` / `reject()` / `respondWith()`  | Resolve the proxy and remove the handle from the queue                                                                |

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -692,7 +692,11 @@ Tools that read from sensitive sources or write to shared state should
 typically pause for human confirmation. The flow has three pieces:
 
 1. The tool author marks the definition with `requiresApproval: true`.
-2. The app supplies an `onApprovalRequired` callback on `<AgentProvider>`.
+2. By default, the library routes such calls through the inline approval queue
+   (`useAgent().pendingApprovals`) rendered by the bundled `<InlineApproval>`
+   slot. Apps can supply an `onApprovalRequired` callback on `<AgentProvider>`
+   to plug in a different confirmation UI, auto-approve specific tools, inject
+   canned results, or short-circuit cancellations.
 3. Optional: `approvalOverride` adjusts the policy at runtime.
 
 ### 10.1 Declaring approval intent on the tool

--- a/packages/react-ui/src/approval.test.tsx
+++ b/packages/react-ui/src/approval.test.tsx
@@ -232,14 +232,40 @@ describe('AgentProvider — approval flow', () => {
     expect(tool.call).toHaveBeenCalledTimes(1);
   });
 
-  it('executes requiresApproval: true tools silently when no onApprovalRequired is provided', async () => {
-    const { runner, tool } = makeRunnerWithTool(SENSITIVE_DEF);
+  it('defaults to the inline approval queue when no onApprovalRequired is provided', async () => {
+    const { runner, tool } = makeRunnerWithTool(SENSITIVE_DEF, 'real-result');
 
     const { result } = renderHook(() => useAgent(), { wrapper: wrapper({ runner }) });
 
-    await sendAndWait(result, 'go');
+    act(() => {
+      result.current.sendMessage('go');
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Tool is paused awaiting inline approval rather than executing silently.
+    expect(tool.call).not.toHaveBeenCalled();
+    expect(result.current.pendingApprovals).toHaveLength(1);
+    expect(result.current.pendingApprovals[0]).toMatchObject({
+      toolName: 'sensitive',
+      args: {},
+    });
+
+    await act(async () => {
+      result.current.pendingApprovals[0].approve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
     expect(tool.call).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingApprovals).toHaveLength(0);
+    const completed = result.current.messages
+      .at(-1)
+      ?.toolEvents.find((t) => t.name === 'sensitive');
+    expect(completed?.result).toBe('real-result');
+    expect(completed?.status).toBe('success');
   });
 
   it('does not affect tools whose effective needsApproval is false', async () => {

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -17,6 +17,7 @@ import type { AgentConfig, Conversation, Message } from '@mast-ai/core';
 import { useAgentStream } from './hooks/useAgentStream.js';
 import { IconProvider } from './icons.js';
 import {
+  INLINE_APPROVAL,
   withApprovalProxy,
   type ApprovalProxyHooks,
   type OnApprovalRequired,
@@ -56,8 +57,13 @@ export interface AgentProviderProps {
    * {@link import('./approval.js').INLINE_APPROVAL} to defer to the inline
    * approval queue exposed via `useAgent().pendingApprovals`.
    *
-   * Not called when no tool requires approval, and not called when the prop
-   * is omitted — in which case `requiresApproval: true` tools execute silently.
+   * Defaults to a callback that returns `INLINE_APPROVAL` for every call when
+   * omitted, so tools marked `requiresApproval: true` always pause for user
+   * confirmation by default. Apps that already render `<InlineApproval>` (or
+   * read `useAgent().pendingApprovals`) get a working approval flow with no
+   * additional wiring. Provide a custom callback to plug in a different
+   * confirmation UI, auto-approve specific tools, inject canned results, or
+   * short-circuit cancellations.
    */
   onApprovalRequired?: OnApprovalRequired;
   /**
@@ -163,6 +169,14 @@ export interface UseAgentReturn {
 const AgentContext = createContext<UseAgentReturn | null>(null);
 
 /**
+ * Default `onApprovalRequired` used when the host app omits the prop. Returning
+ * `INLINE_APPROVAL` for every call honours `requiresApproval: true` by default:
+ * the call is enqueued on `useAgent().pendingApprovals` (and rendered inline by
+ * the bundled `<InlineApproval>` slot) instead of executing silently.
+ */
+const DEFAULT_ON_APPROVAL_REQUIRED: OnApprovalRequired = async () => INLINE_APPROVAL;
+
+/**
  * Wraps a subtree with agent context.
  *
  * Internally creates a {@link Conversation} via `runner.conversation(agent)`
@@ -209,7 +223,13 @@ export function AgentProvider({
     if (runner === null) return null;
     const hasApproval = onApprovalRequired !== undefined;
     const hasOverride = approvalOverride !== undefined && approvalOverride.length > 0;
-    if (!hasApproval && !hasOverride) return runner;
+    // Without an explicit callback or override we still need to wrap when at
+    // least one registered tool declares `requiresApproval: true`, so the
+    // default INLINE_APPROVAL callback can intercept it. When no tool needs
+    // approval the proxy would be a no-op, so skip the wrap entirely.
+    const tools = runner.registry?.getTools?.() ?? [];
+    const hasApprovalTool = tools.some((def) => def.requiresApproval === true);
+    if (!hasApproval && !hasOverride && !hasApprovalTool) return runner;
     const hooks: ApprovalProxyHooks = {
       notifyAwaiting: (name, awaiting) => notifyAwaitingRef.current?.(name, awaiting),
       setStatus: (name, status) => setStatusRef.current?.(name, status),
@@ -218,7 +238,7 @@ export function AgentProvider({
     };
     const provider = withApprovalProxy(
       runner.registry,
-      () => onApprovalRef.current,
+      () => onApprovalRef.current ?? DEFAULT_ON_APPROVAL_REQUIRED,
       () => approvalOverrideRef.current,
       hooks,
     );

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -134,7 +134,7 @@ interface ToolEventEntry {
 Three pieces:
 
 1. Tool author sets `requiresApproval: true` on the tool definition.
-2. App supplies `onApprovalRequired` on `<AgentProvider>`.
+2. By default, the library routes such calls through the inline approval queue (`useAgent().pendingApprovals`) rendered by `<InlineApproval>`. Apps may supply `onApprovalRequired` on `<AgentProvider>` to plug in a different confirmation UI, auto-approve specific tools, inject canned results, or short-circuit cancellations.
 3. Optional: `approvalOverride={['!safe_tool', 'third_party_tool']}` adjusts policy at runtime.
 
 ```typescript


### PR DESCRIPTION
## Summary

Closes #97.

When a tool's definition has `requiresApproval: true` but the host app does not pass an `onApprovalRequired` prop to `<AgentProvider>`, the tool used to execute silently — turning the safety flag into a footgun. `AgentProvider` now substitutes a default callback (`async () => INLINE_APPROVAL`), so:

- The `requiresApproval` contract is honoured by default — secure default.
- Apps that already render `<InlineApproval>` (or read `useAgent().pendingApprovals`) get a working approval flow with zero config.
- Apps that need a different policy (custom modal, auto-approve specific tools, inject canned results, short-circuit cancellations) still provide their own `onApprovalRequired`.

## Implementation notes

- `packages/react-ui/src/context.tsx` — added `DEFAULT_ON_APPROVAL_REQUIRED` and wired it as the fallback inside the approval proxy. The wrap is skipped only when there is no callback, no `approvalOverride`, and no registered tool with `requiresApproval: true` (so the proxy stays a no-op for apps without sensitive tools, and existing test mocks that don't fully fake `runner.registry`/`runner.adapter` keep working).
- `packages/react-ui/src/approval.test.tsx` — replaced the previous "executes silently when no callback is provided" test with one that exercises the new default: a `requiresApproval: true` tool with no `onApprovalRequired` enqueues a `PendingApproval`, then `approve()` runs the tool.
- Docs: updated `docs/react-ui/SPEC.md` (§9.4 narrative, §11.2 scenarios table, `AgentProviderProps` JSDoc), `docs/react-ui/USAGE.md` (§10 intro), `docs/react-ui/PLAN.md` (Issue 11 test note), and `skills/mast-ai/references/react-ui.md`.

The `apps/demo-react-ui` demo intentionally provides a callback to showcase both inline (`INLINE_APPROVAL`) and out-of-band (`window.confirm`) flows side-by-side, so it does not need updates.

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present` (180/180 react-ui tests pass)
- [x] `npm run build`
- [x] Manual: drop `onApprovalRequired` from `apps/demo-react-ui` temporarily and verify a `requiresApproval: true` tool surfaces an `<InlineApproval>` card instead of executing silently