### PR TITLE
feat(core): emit events from ToolRegistry on register/unregister

### DIFF
--- a/apps/demo-tool-registry-events/index.html
+++ b/apps/demo-tool-registry-events/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAST — ToolRegistry Events Demo</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <aside class="sidebar">
+        <h2>ToolRegistry Events <small id="version"></small></h2>
+
+        <div class="info-panel">
+          Toggle each tool to fire <code>tool-registered</code> and
+          <code>tool-unregistered</code> events. The panels on the right are populated entirely by
+          listeners on a <code>ToolRegistry</code> and a scope-filtered
+          <code>ToolRegistryView</code>.
+        </div>
+
+        <div class="controls-panel">
+          <h3>Tools</h3>
+          <ul class="tool-controls" id="tool-controls"></ul>
+        </div>
+
+        <div class="bulk-panel">
+          <button id="register-all" class="secondary-button">Register all</button>
+          <button id="unregister-all" class="secondary-button">Unregister all</button>
+        </div>
+      </aside>
+
+      <main class="main-container">
+        <section class="pane">
+          <header class="pane-header">
+            <span class="pane-label">Full registry</span>
+            <span class="pane-sub">live from <code>registry.addEventListener(...)</code></span>
+          </header>
+          <ul class="tool-list" id="full-list">
+            <li class="placeholder">No tools registered.</li>
+          </ul>
+        </section>
+
+        <section class="pane">
+          <header class="pane-header">
+            <span class="pane-label">Read-only view</span>
+            <span class="pane-sub"
+              >scope filtered via <code>registry.readOnly().addEventListener(...)</code></span
+            >
+          </header>
+          <ul class="tool-list" id="readonly-list">
+            <li class="placeholder">No read-scope tools registered.</li>
+          </ul>
+        </section>
+
+        <section class="pane log-pane">
+          <header class="pane-header">
+            <span class="pane-label">Event log</span>
+            <button id="clear-log" class="link-button">Clear</button>
+          </header>
+          <ol class="event-log" id="event-log">
+            <li class="placeholder">Events will appear here.</li>
+          </ol>
+        </section>
+      </main>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/demo-tool-registry-events/package.json
+++ b/apps/demo-tool-registry-events/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "demo-tool-registry-events",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/core": "*"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/demo-tool-registry-events/src/main.ts
+++ b/apps/demo-tool-registry-events/src/main.ts
@@ -1,0 +1,197 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { VERSION, ToolRegistry } from '@mast-ai/core';
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
+
+// --- Sample tools (mixed scopes) ---
+
+function makeTool(def: ToolDefinition, run: (args: unknown) => unknown): Tool {
+  return {
+    definition: () => def,
+    call: async (args) => run(args),
+  };
+}
+
+const SAMPLE_TOOLS: Tool[] = [
+  makeTool(
+    {
+      name: 'clock',
+      description: 'Returns the current time.',
+      parameters: { type: 'object', properties: {} },
+      scope: 'read',
+    },
+    () => new Date().toISOString(),
+  ),
+  makeTool(
+    {
+      name: 'searchWeb',
+      description: 'Searches the web for a query.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+      scope: 'read',
+    },
+    (args) => `Results for "${(args as { query: string }).query}"`,
+  ),
+  makeTool(
+    {
+      name: 'addNote',
+      description: 'Saves a note to local storage.',
+      parameters: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text'],
+      },
+      scope: 'write',
+    },
+    (args) => `Saved: ${(args as { text: string }).text}`,
+  ),
+];
+
+// --- Registry + read-only view ---
+
+const registry = new ToolRegistry();
+const readOnlyView = registry.readOnly();
+
+// --- DOM elements ---
+
+const fullList = document.querySelector<HTMLUListElement>('#full-list')!;
+const readOnlyList = document.querySelector<HTMLUListElement>('#readonly-list')!;
+const eventLog = document.querySelector<HTMLOListElement>('#event-log')!;
+const toolControls = document.querySelector<HTMLUListElement>('#tool-controls')!;
+
+// --- Tool controls (register / unregister buttons) ---
+
+for (const tool of SAMPLE_TOOLS) {
+  const def = tool.definition();
+  const li = document.createElement('li');
+  li.className = 'tool-control';
+  li.dataset.tool = def.name;
+  li.innerHTML = `
+    <div class="tool-control-info">
+      <span class="tool-control-name">${def.name}</span>
+      <span class="scope-badge scope-${def.scope}">${def.scope}</span>
+    </div>
+    <button class="toggle-button" type="button">Register</button>
+  `;
+  const button = li.querySelector<HTMLButtonElement>('.toggle-button')!;
+  button.addEventListener('click', () => {
+    if (registry.getTool(def.name)) {
+      registry.unregister(def.name);
+    } else {
+      registry.register(tool);
+    }
+  });
+  toolControls.appendChild(li);
+}
+
+function refreshControls(): void {
+  for (const li of toolControls.querySelectorAll<HTMLLIElement>('.tool-control')) {
+    const name = li.dataset.tool!;
+    const button = li.querySelector<HTMLButtonElement>('.toggle-button')!;
+    const registered = registry.getTool(name) !== undefined;
+    li.classList.toggle('registered', registered);
+    button.textContent = registered ? 'Unregister' : 'Register';
+  }
+}
+
+// --- Bulk buttons ---
+
+document.querySelector('#register-all')!.addEventListener('click', () => {
+  for (const tool of SAMPLE_TOOLS) {
+    if (!registry.getTool(tool.definition().name)) registry.register(tool);
+  }
+});
+
+document.querySelector('#unregister-all')!.addEventListener('click', () => {
+  for (const tool of SAMPLE_TOOLS) {
+    registry.unregister(tool.definition().name);
+  }
+});
+
+// --- List rendering ---
+
+function renderToolList(target: HTMLUListElement, definitions: ToolDefinition[]): void {
+  target.innerHTML = '';
+  if (definitions.length === 0) {
+    const li = document.createElement('li');
+    li.className = 'placeholder';
+    li.textContent =
+      target === readOnlyList ? 'No read-scope tools registered.' : 'No tools registered.';
+    target.appendChild(li);
+    return;
+  }
+  for (const def of definitions) {
+    const li = document.createElement('li');
+    li.className = 'tool-row';
+    li.innerHTML = `
+      <div class="tool-row-head">
+        <span class="tool-row-name">${def.name}</span>
+        <span class="scope-badge scope-${def.scope}">${def.scope}</span>
+      </div>
+      <p class="tool-row-desc">${def.description}</p>
+    `;
+    target.appendChild(li);
+  }
+}
+
+// --- Event log ---
+
+let logCleared = true;
+function logEvent(source: 'registry' | 'view', type: string, detail: string): void {
+  if (logCleared) {
+    eventLog.innerHTML = '';
+    logCleared = false;
+  }
+  const li = document.createElement('li');
+  li.className = `log-entry source-${source} type-${type}`;
+  const time = new Date().toLocaleTimeString();
+  li.innerHTML = `
+    <span class="log-time">${time}</span>
+    <span class="log-source">${source}</span>
+    <span class="log-type">${type}</span>
+    <span class="log-detail">${detail}</span>
+  `;
+  eventLog.prepend(li);
+}
+
+document.querySelector('#clear-log')!.addEventListener('click', () => {
+  eventLog.innerHTML = '<li class="placeholder">Events will appear here.</li>';
+  logCleared = true;
+});
+
+// --- Wire listeners (the whole point of the demo) ---
+
+registry.addEventListener('tool-registered', ({ tool }) => {
+  const def = tool.definition();
+  logEvent('registry', 'tool-registered', def.name);
+  renderToolList(fullList, registry.getTools());
+  refreshControls();
+});
+
+registry.addEventListener('tool-unregistered', ({ name }) => {
+  logEvent('registry', 'tool-unregistered', name);
+  renderToolList(fullList, registry.getTools());
+  refreshControls();
+});
+
+readOnlyView.addEventListener('tool-registered', ({ tool }) => {
+  logEvent('view', 'tool-registered', tool.definition().name);
+  renderToolList(readOnlyList, readOnlyView.getTools());
+});
+
+readOnlyView.addEventListener('tool-unregistered', ({ name }) => {
+  logEvent('view', 'tool-unregistered', name);
+  renderToolList(readOnlyList, readOnlyView.getTools());
+});
+
+// --- Initial paint (no events fire on an empty registry) ---
+
+renderToolList(fullList, registry.getTools());
+renderToolList(readOnlyList, readOnlyView.getTools());
+refreshControls();

--- a/apps/demo-tool-registry-events/src/style.css
+++ b/apps/demo-tool-registry-events/src/style.css
@@ -1,0 +1,365 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  --primary-color: #3b82f6;
+  --bg-color: #f4f4f5;
+  --border-color: #e4e4e7;
+  --muted: #71717a;
+  --read-bg: #dbeafe;
+  --read-fg: #1e3a8a;
+  --write-bg: #fee2e2;
+  --write-fg: #991b1b;
+}
+
+body,
+html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+code {
+  font-size: 0.85em;
+  background: var(--bg-color);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+/* ---- Sidebar ---- */
+
+.sidebar {
+  width: 320px;
+  background-color: var(--bg-color);
+  border-right: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.sidebar h2 small {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-weight: normal;
+  margin-left: 0.4rem;
+}
+
+.sidebar h3 {
+  font-size: 0.9rem;
+  margin: 0 0 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.info-panel {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #3f3f46;
+  background: #fff;
+  padding: 0.9rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+}
+
+.controls-panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.tool-controls {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tool-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  transition: border-color 0.15s;
+}
+
+.tool-control.registered {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 1px var(--primary-color);
+}
+
+.tool-control-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.tool-control-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.toggle-button {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--primary-color);
+  background: #fff;
+  color: var(--primary-color);
+  cursor: pointer;
+  font-weight: 600;
+  font-family: inherit;
+}
+
+.toggle-button:hover {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.tool-control.registered .toggle-button {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.tool-control.registered .toggle-button:hover {
+  background: #ef4444;
+  color: #fff;
+}
+
+.bulk-panel {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.secondary-button {
+  flex: 1;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.75rem;
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: #3f3f46;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 500;
+}
+
+.secondary-button:hover {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+/* ---- Scope badges (shared) ---- */
+
+.scope-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.scope-read {
+  background: var(--read-bg);
+  color: var(--read-fg);
+}
+
+.scope-write {
+  background: var(--write-bg);
+  color: var(--write-fg);
+}
+
+/* ---- Main area ---- */
+
+.main-container {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  min-width: 0;
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+  min-height: 0;
+}
+
+.pane + .pane {
+  border-left: 1px solid var(--border-color);
+}
+
+.log-pane {
+  grid-column: 1 / -1;
+  border-bottom: none;
+  border-left: none;
+}
+
+.pane-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.pane-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.pane-sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.link-button {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+/* ---- Tool list (used in both panels) ---- */
+
+.tool-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tool-row {
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  animation: fade-in 0.18s ease-out;
+}
+
+.tool-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.tool-row-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.tool-row-desc {
+  margin: 0.3rem 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.placeholder {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 0.85rem;
+  list-style: none;
+}
+
+/* ---- Event log ---- */
+
+.event-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+  overflow-y: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+}
+
+.log-entry {
+  display: grid;
+  grid-template-columns: 90px 80px 160px 1fr;
+  gap: 0.75rem;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+  animation: fade-in 0.18s ease-out;
+}
+
+.log-time {
+  color: var(--muted);
+}
+
+.log-source {
+  font-weight: 600;
+}
+
+.log-entry.source-registry .log-source {
+  color: #6366f1;
+}
+
+.log-entry.source-view .log-source {
+  color: #0d9488;
+}
+
+.log-entry.type-tool-unregistered .log-type {
+  color: #ef4444;
+}
+
+.log-entry.type-tool-registered .log-type {
+  color: #16a34a;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/apps/demo-tool-registry-events/tsconfig.json
+++ b/apps/demo-tool-registry-events/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -137,9 +137,20 @@ export class ToolRegistry {
   get(name: string): Tool | undefined;
   definitions(): ToolDefinition[];
 }
+
+export type ToolRegistryEventMap = {
+  'tool-registered': { tool: Tool };
+  'tool-unregistered': { name: string };
+};
+
+// `ToolRegistry` and `ToolRegistryView` both expose:
+//   addEventListener<K>(type: K, listener: (event: ToolRegistryEventMap[K]) => void): void;
+//   removeEventListener<K>(type: K, listener: (event: ToolRegistryEventMap[K]) => void): void;
 ```
 
 `ToolDefinition` is the runtime metadata forwarded to the remote backend in a URP request. It is never stored inside `AgentConfig`.
+
+Mutation events fire synchronously from `register()` and `unregister()` after the internal map is updated. `register()` throwing on a duplicate name does not fire `tool-registered`; `unregister()` for an unknown name is a silent no-op. `ToolRegistryView` forwards events from its parent registry but delivers only those for tools whose `scope` matches the view's scope.
 
 ### `LlmAdapter` (`src/adapter/index.ts`)
 

--- a/packages/core/src/tool.test.ts
+++ b/packages/core/src/tool.test.ts
@@ -146,3 +146,122 @@ describe('ToolRegistryView', () => {
     expect(view.getTools()).toHaveLength(0);
   });
 });
+
+describe('ToolRegistry events', () => {
+  it('fires tool-registered after a tool is added', () => {
+    const registry = new ToolRegistry();
+    const tool = makeTool('alpha', 'read');
+    const listener = vi.fn();
+
+    registry.addEventListener('tool-registered', listener);
+    registry.register(tool);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ tool });
+  });
+
+  it('fires tool-unregistered after a tool is removed', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('beta', 'write'));
+    const listener = vi.fn();
+
+    registry.addEventListener('tool-unregistered', listener);
+    registry.unregister('beta');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ name: 'beta' });
+  });
+
+  it('does not fire tool-unregistered for no-op unregister calls', () => {
+    const registry = new ToolRegistry();
+    const listener = vi.fn();
+
+    registry.addEventListener('tool-unregistered', listener);
+    registry.unregister('missing');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not fire tool-registered when register throws on duplicate', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('dup', 'read'));
+    const listener = vi.fn();
+
+    registry.addEventListener('tool-registered', listener);
+    expect(() => registry.register(makeTool('dup', 'write'))).toThrow();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('removeEventListener stops further notifications', () => {
+    const registry = new ToolRegistry();
+    const listener = vi.fn();
+
+    registry.addEventListener('tool-registered', listener);
+    registry.register(makeTool('one', 'read'));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    registry.removeEventListener('tool-registered', listener);
+    registry.register(makeTool('two', 'read'));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple listeners for the same event', () => {
+    const registry = new ToolRegistry();
+    const a = vi.fn();
+    const b = vi.fn();
+
+    registry.addEventListener('tool-registered', a);
+    registry.addEventListener('tool-registered', b);
+    registry.register(makeTool('shared', 'read'));
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ToolRegistryView events', () => {
+  it('forwards tool-registered only for tools matching the view scope', () => {
+    const registry = new ToolRegistry();
+    const view = registry.readOnly();
+    const listener = vi.fn();
+
+    view.addEventListener('tool-registered', listener);
+    const reader = makeTool('reader', 'read');
+    const writer = makeTool('writer', 'write');
+    registry.register(reader);
+    registry.register(writer);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ tool: reader });
+  });
+
+  it('forwards tool-unregistered only for tools that previously matched the view scope', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('reader', 'read'));
+    registry.register(makeTool('writer', 'write'));
+    const view = registry.readOnly();
+    const listener = vi.fn();
+
+    view.addEventListener('tool-unregistered', listener);
+    registry.unregister('writer');
+    registry.unregister('reader');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ name: 'reader' });
+  });
+
+  it('removeEventListener stops further notifications on the view', () => {
+    const registry = new ToolRegistry();
+    const view = registry.readOnly();
+    const listener = vi.fn();
+
+    view.addEventListener('tool-registered', listener);
+    registry.register(makeTool('first', 'read'));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    view.removeEventListener('tool-registered', listener);
+    registry.register(makeTool('second', 'read'));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -53,9 +53,52 @@ export interface ToolProvider {
   getTool(name: string): Tool | undefined;
 }
 
+/**
+ * Events emitted by {@link ToolRegistry} (and {@link ToolRegistryView}) when its
+ * contents change at runtime. UI components and adapters can subscribe via
+ * `addEventListener` to refresh toolbars, re-advertise capabilities, or trigger
+ * a new agent turn.
+ */
+export type ToolRegistryEventMap = {
+  /** Fired after a tool is successfully added. */
+  'tool-registered': { tool: Tool };
+  /** Fired after a tool is removed. Not fired for no-op `unregister` calls. */
+  'tool-unregistered': { name: string };
+};
+
+type ToolRegistryListener<K extends keyof ToolRegistryEventMap> = (
+  event: ToolRegistryEventMap[K],
+) => void;
+
+class ToolRegistryEventEmitter {
+  private listeners: {
+    [K in keyof ToolRegistryEventMap]?: Set<ToolRegistryListener<K>>;
+  } = {};
+
+  on<K extends keyof ToolRegistryEventMap>(type: K, listener: ToolRegistryListener<K>): void {
+    let set = this.listeners[type];
+    if (!set) {
+      set = new Set();
+      this.listeners[type] = set;
+    }
+    set.add(listener);
+  }
+
+  off<K extends keyof ToolRegistryEventMap>(type: K, listener: ToolRegistryListener<K>): void {
+    this.listeners[type]?.delete(listener);
+  }
+
+  emit<K extends keyof ToolRegistryEventMap>(type: K, event: ToolRegistryEventMap[K]): void {
+    const set = this.listeners[type];
+    if (!set) return;
+    for (const listener of [...set]) listener(event);
+  }
+}
+
 /** Holds all tools available to an {@link AgentRunner} and resolves them by name during execution. */
 export class ToolRegistry implements ToolProvider {
   private _tools = new Map<string, Tool>();
+  private _emitter = new ToolRegistryEventEmitter();
 
   /**
    * Registers a tool. Throws if a tool with the same name is already registered.
@@ -67,12 +110,14 @@ export class ToolRegistry implements ToolProvider {
       throw new Error(`Tool '${name}' is already registered.`);
     }
     this._tools.set(name, tool);
+    this._emitter.emit('tool-registered', { tool });
     return this;
   }
 
   /** Removes the tool registered under `name`. No-op if not found. */
   unregister(name: string): void {
-    this._tools.delete(name);
+    if (!this._tools.delete(name)) return;
+    this._emitter.emit('tool-unregistered', { name });
   }
 
   /** Returns the tool registered under `name`, or `undefined` if not found. */
@@ -89,6 +134,22 @@ export class ToolRegistry implements ToolProvider {
   readOnly(): ToolRegistryView {
     return new ToolRegistryView(this, 'read');
   }
+
+  /** Subscribe to registry mutation events. */
+  addEventListener<K extends keyof ToolRegistryEventMap>(
+    type: K,
+    listener: ToolRegistryListener<K>,
+  ): void {
+    this._emitter.on(type, listener);
+  }
+
+  /** Unsubscribe a previously registered listener. */
+  removeEventListener<K extends keyof ToolRegistryEventMap>(
+    type: K,
+    listener: ToolRegistryListener<K>,
+  ): void {
+    this._emitter.off(type, listener);
+  }
 }
 
 /**
@@ -98,6 +159,9 @@ export class ToolRegistry implements ToolProvider {
  * Only tools whose `scope` matches the view's scope are visible.
  */
 export class ToolRegistryView implements ToolProvider {
+  private _emitter = new ToolRegistryEventEmitter();
+  private _scopedNames?: Set<string>;
+
   constructor(
     private readonly parent: ToolRegistry,
     private readonly scope: 'read' | 'write',
@@ -111,5 +175,44 @@ export class ToolRegistryView implements ToolProvider {
     const tool = this.parent.getTool(name);
     if (!tool) return undefined;
     return tool.definition().scope === this.scope ? tool : undefined;
+  }
+
+  /**
+   * Subscribe to mutation events forwarded from the parent registry. Only
+   * events for tools whose `scope` matches this view's scope are delivered.
+   */
+  addEventListener<K extends keyof ToolRegistryEventMap>(
+    type: K,
+    listener: ToolRegistryListener<K>,
+  ): void {
+    this.ensureParentSubscription();
+    this._emitter.on(type, listener);
+  }
+
+  /** Unsubscribe a previously registered listener. */
+  removeEventListener<K extends keyof ToolRegistryEventMap>(
+    type: K,
+    listener: ToolRegistryListener<K>,
+  ): void {
+    this._emitter.off(type, listener);
+  }
+
+  private ensureParentSubscription(): void {
+    if (this._scopedNames) return;
+    const scoped = new Set<string>();
+    for (const def of this.parent.getTools()) {
+      if (def.scope === this.scope) scoped.add(def.name);
+    }
+    this._scopedNames = scoped;
+    this.parent.addEventListener('tool-registered', (event) => {
+      const def = event.tool.definition();
+      if (def.scope !== this.scope) return;
+      scoped.add(def.name);
+      this._emitter.emit('tool-registered', event);
+    });
+    this.parent.addEventListener('tool-unregistered', (event) => {
+      if (!scoped.delete(event.name)) return;
+      this._emitter.emit('tool-unregistered', event);
+    });
   }
 }

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -71,27 +71,27 @@ type ToolRegistryListener<K extends keyof ToolRegistryEventMap> = (
 ) => void;
 
 class ToolRegistryEventEmitter {
-  private listeners: {
-    [K in keyof ToolRegistryEventMap]?: Set<ToolRegistryListener<K>>;
-  } = {};
+  private readonly registered = new Set<ToolRegistryListener<'tool-registered'>>();
+  private readonly unregistered = new Set<ToolRegistryListener<'tool-unregistered'>>();
 
   on<K extends keyof ToolRegistryEventMap>(type: K, listener: ToolRegistryListener<K>): void {
-    let set = this.listeners[type];
-    if (!set) {
-      set = new Set();
-      this.listeners[type] = set;
-    }
-    set.add(listener);
+    this.bucket(type).add(listener);
   }
 
   off<K extends keyof ToolRegistryEventMap>(type: K, listener: ToolRegistryListener<K>): void {
-    this.listeners[type]?.delete(listener);
+    this.bucket(type).delete(listener);
   }
 
   emit<K extends keyof ToolRegistryEventMap>(type: K, event: ToolRegistryEventMap[K]): void {
-    const set = this.listeners[type];
-    if (!set) return;
-    for (const listener of [...set]) listener(event);
+    for (const listener of [...this.bucket(type)]) listener(event);
+  }
+
+  // The cast is contained here: each generic call resolves `K` to one of the
+  // literal keys, and the matching bucket has a compatible listener type.
+  private bucket<K extends keyof ToolRegistryEventMap>(type: K): Set<ToolRegistryListener<K>> {
+    return (type === 'tool-registered' ? this.registered : this.unregistered) as Set<
+      ToolRegistryListener<K>
+    >;
   }
 }
 

--- a/skills/mast-ai/references/core-api.md
+++ b/skills/mast-ai/references/core-api.md
@@ -41,6 +41,12 @@ const registry = new ToolRegistry().register({
   definition: () => ({ name: 'myTool', description: '...', parameters: { ... } }),
   call: async (args, context) => { ... }
 });
+
+// Subscribe to runtime mutations.
+registry.addEventListener('tool-registered', ({ tool }) => { /* ... */ });
+registry.addEventListener('tool-unregistered', ({ name }) => { /* ... */ });
+// `ToolRegistryView` (returned by `registry.readOnly()`) exposes the same
+// addEventListener / removeEventListener API, scoped to the view's filter.
 ```
 
 ## AgentRunner


### PR DESCRIPTION
## Summary

- Add an `addEventListener` / `removeEventListener` interface to `ToolRegistry` and `ToolRegistryView` so UI components and adapters can react when tools are added or removed at runtime without polling `getTools()`.
- `ToolRegistry` fires `tool-registered` after a successful `register()` and `tool-unregistered` after a `unregister()` that actually removed something. No-op `unregister` calls and duplicate-name `register` calls do not fire events.
- `ToolRegistryView` lazily subscribes to its parent on first listener attach, snapshots the names whose scope matches the view, and forwards events filtered by that scope (so `tool-unregistered` is correctly suppressed for tools that never matched the view, even though the tool's definition is no longer reachable when the event fires).
- Adds `apps/demo-tool-registry-events`, a single-page demo with three sample tools (mixed scopes), three live panels (full registry, read-only view, event log) populated entirely by event listeners.

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present` (215 passing, 11 new)
- [x] `npm run build`
- [x] `npm run format`
- [x] Manually verified the demo: toggling a `write`-scope tool fires only on the registry; toggling `read` tools fires on both; bulk register / unregister fires events in order; event log clears properly.

Closes #26