### PR TITLE
fix(demo-react-ui): theme entire demo shell, not just the chat panel

### DIFF
--- a/apps/demo-react-ui/src/App.tsx
+++ b/apps/demo-react-ui/src/App.tsx
@@ -165,9 +165,10 @@ function clearApiKey() {
 
 interface ApiKeySetupProps {
   onSubmit: (key: string) => void;
+  theme: 'light' | 'dark' | undefined;
 }
 
-function ApiKeySetup({ onSubmit }: ApiKeySetupProps) {
+function ApiKeySetup({ onSubmit, theme }: ApiKeySetupProps) {
   const [value, setValue] = useState('');
   const trimmed = value.trim();
 
@@ -177,7 +178,7 @@ function ApiKeySetup({ onSubmit }: ApiKeySetupProps) {
   };
 
   return (
-    <div className="demo-shell">
+    <div className="demo-shell" data-mast-root data-mast-theme={theme}>
       <header className="demo-header">
         <h1>MAST React UI Demo</h1>
       </header>
@@ -556,11 +557,11 @@ export default function App() {
   const isUnsavedNew = !active;
 
   if (!apiKey || !runner) {
-    return <ApiKeySetup onSubmit={handleApiKey} />;
+    return <ApiKeySetup onSubmit={handleApiKey} theme={panelTheme} />;
   }
 
   return (
-    <div className="demo-shell">
+    <div className="demo-shell" data-mast-root data-mast-theme={panelTheme}>
       <header className="demo-header">
         <h1>MAST React UI Demo</h1>
         <div className="demo-header-controls">

--- a/apps/demo-react-ui/src/index.css
+++ b/apps/demo-react-ui/src/index.css
@@ -18,6 +18,12 @@ body {
   }
 }
 
+/*
+ * The demo shell carries `data-mast-root` so the library's `--mast-*` tokens
+ * resolve on every descendant — header, sidebar, instructions, API key card.
+ * `data-mast-theme` is forwarded from App state so the toggle restyles the
+ * whole demo (not just the chat panel) in lockstep.
+ */
 .demo-shell {
   display: flex;
   flex-direction: column;
@@ -27,6 +33,8 @@ body {
   margin: 0 auto;
   padding: 1rem;
   box-sizing: border-box;
+  background: var(--mast-bg-subtle);
+  color: var(--mast-fg);
 }
 
 .demo-header {
@@ -42,13 +50,18 @@ body {
 }
 
 .demo-header-button {
-  background: transparent;
-  border: 1px solid currentColor;
-  color: inherit;
+  background: var(--mast-bg);
+  border: 1px solid var(--mast-border);
+  color: var(--mast-fg);
   padding: 0.4rem 0.75rem;
-  border-radius: 0.5rem;
+  border-radius: var(--mast-radius);
   cursor: pointer;
   font: inherit;
+}
+
+.demo-header-button:hover:not(:disabled),
+.demo-header-button:focus-visible:not(:disabled) {
+  background: var(--mast-bg-subtle);
 }
 
 .demo-header-button:disabled {
@@ -69,8 +82,9 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  border: 1px solid rgba(127, 127, 127, 0.3);
-  border-radius: 0.5rem;
+  background: var(--mast-bg);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
   padding: 0.5rem;
   overflow: hidden;
 }
@@ -80,13 +94,13 @@ body {
   font-size: 0.8125rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: rgba(127, 127, 127, 1);
+  color: var(--mast-fg-muted);
 }
 
 .demo-sidebar-empty {
   margin: 0;
   font-size: 0.8125rem;
-  color: rgba(127, 127, 127, 1);
+  color: var(--mast-fg-muted);
 }
 
 .demo-conversation-list {
@@ -107,7 +121,7 @@ body {
 }
 
 .demo-conversation-item-active {
-  background: rgba(127, 127, 127, 0.15);
+  background: var(--mast-bg-subtle);
 }
 
 .demo-conversation-select {
@@ -129,7 +143,7 @@ body {
 
 .demo-conversation-select:hover,
 .demo-conversation-select:focus-visible {
-  background: rgba(127, 127, 127, 0.12);
+  background: var(--mast-bg-subtle);
 }
 
 .demo-conversation-title {
@@ -143,7 +157,7 @@ body {
 
 .demo-conversation-date {
   font-size: 0.75rem;
-  color: rgba(127, 127, 127, 1);
+  color: var(--mast-fg-muted);
 }
 
 .demo-conversation-delete {
@@ -161,8 +175,8 @@ body {
 .demo-conversation-delete:hover,
 .demo-conversation-delete:focus-visible {
   opacity: 1;
-  background: rgba(220, 38, 38, 0.15);
-  color: #dc2626;
+  background: var(--mast-tool-error-bg);
+  color: var(--mast-tool-error-fg);
 }
 
 .demo-main {
@@ -195,7 +209,7 @@ body {
   font-size: 0.8125rem;
   padding: 0.25rem 0.5rem;
   border-radius: 9999px;
-  background: var(--mast-tool-pending, #f59e0b);
+  background: var(--mast-tool-pending);
   color: #1f2937;
   font-weight: 600;
 }
@@ -205,9 +219,9 @@ body {
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.75rem;
-  border: 2px solid var(--mast-accent, #2563eb);
-  border-radius: var(--mast-radius, 0.5rem);
-  background: var(--mast-bg, #ffffff);
+  border: 2px solid var(--mast-accent);
+  border-radius: var(--mast-radius);
+  background: var(--mast-bg);
 }
 
 .demo-set-title-approval-header {
@@ -219,17 +233,17 @@ body {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;
-  background: var(--mast-bg-subtle, #f9fafb);
+  background: var(--mast-bg-subtle);
   border-radius: 0.25rem;
 }
 
 .demo-set-title-approval-label {
-  color: var(--mast-fg-muted, #6b7280);
+  color: var(--mast-fg-muted);
   font-size: 0.8125rem;
 }
 
 .demo-set-title-approval-preview code {
-  font-family: var(--mast-font-mono, ui-monospace, monospace);
+  font-family: var(--mast-font-mono);
   font-weight: 600;
 }
 
@@ -247,8 +261,8 @@ body {
 }
 
 .demo-approval-approve {
-  background: var(--mast-accent, #2563eb);
-  color: var(--mast-accent-fg, #ffffff);
+  background: var(--mast-accent);
+  color: var(--mast-accent-fg);
 }
 
 .demo-approval-reject {
@@ -267,8 +281,9 @@ body {
   flex-direction: column;
   gap: 0.75rem;
   min-height: 0;
-  border: 1px solid rgba(127, 127, 127, 0.3);
-  border-radius: 0.5rem;
+  background: var(--mast-bg);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
   padding: 0.75rem;
   overflow-y: auto;
   font-size: 0.875rem;
@@ -285,7 +300,7 @@ body {
   font-size: 0.8125rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: rgba(127, 127, 127, 1);
+  color: var(--mast-fg-muted);
 }
 
 .demo-instructions-section p,
@@ -301,11 +316,11 @@ body {
 }
 
 .demo-instructions-section code {
-  font-family: ui-monospace, monospace;
+  font-family: var(--mast-font-mono);
   font-size: 0.8125rem;
   padding: 0 0.2rem;
   border-radius: 0.2rem;
-  background: rgba(127, 127, 127, 0.15);
+  background: var(--mast-bg-subtle);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -328,9 +343,9 @@ body {
   width: 100%;
   max-width: 28rem;
   padding: 1.25rem;
-  border: 1px solid rgba(127, 127, 127, 0.3);
-  border-radius: 0.75rem;
-  background: rgba(127, 127, 127, 0.05);
+  border: 1px solid var(--mast-border);
+  border-radius: var(--mast-radius);
+  background: var(--mast-bg);
 }
 
 .demo-api-key-title {
@@ -345,7 +360,7 @@ body {
 }
 
 .demo-api-key-card code {
-  font-family: ui-monospace, monospace;
+  font-family: var(--mast-font-mono);
   font-size: 0.8125rem;
 }
 
@@ -363,7 +378,7 @@ body {
 .demo-api-key-label input {
   font: inherit;
   padding: 0.4rem 0.55rem;
-  border: 1px solid rgba(127, 127, 127, 0.4);
+  border: 1px solid var(--mast-border);
   border-radius: 0.375rem;
   background: transparent;
   color: inherit;


### PR DESCRIPTION
## Summary

- Set `data-mast-root data-mast-theme={panelTheme}` on `.demo-shell` in both the main app and the API key setup screen, so the library's `--mast-*` tokens resolve across the whole demo.
- Rewrote `apps/demo-react-ui/src/index.css` to drive demo chrome (header buttons, sidebar, instructions panel, conversation rows, API key card) from the library tokens instead of hard-coded light-mode colors.
- Forwarded the existing `theme` state to the API key setup screen so a returning user who picked Light/Dark and clicked "Reset API key" sees the entry screen in their chosen theme.

Closes #92.

## Approach

Took option 1 from the issue (reuse the library's `--mast-*` tokens), which matches the pattern already documented in `docs/react-ui/USAGE.md` §8 for surrounding chrome. No library changes; this is purely demo polish.

## Test plan

- [x] `npm run lint`, `npm run format`, `npm run build`, `npm test --workspaces --if-present` all pass.
- [x] Manually verified the theme button cycles System / Light / Dark and the entire demo shell (header bar, conversation list sidebar, instructions panel, API key setup screen, conversation row hover states) restyles in lockstep with the chat panel.
- [x] "System" follows `prefers-color-scheme` for the whole shell.
- [x] No regression in the chat panel's existing theming.