### PR TITLE
chore: release v0.3.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.2.0"
+    "@mast-ai/core": "^0.3.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.2.0"
+    "@mast-ai/core": "^0.3.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.2.0",
+    "@mast-ai/core": "^0.3.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
## Summary

Bumps all four `@mast-ai/*` packages from `0.2.0` to `0.3.0`. Minor bump per the release rule that, while pre-1.0, minor is the breaking-change line.

### Changes since v0.2.0

**@mast-ai/core** (minor)
- `feat(core): emit events from ToolRegistry on register/unregister` — adds `addEventListener`/`removeEventListener` to `ToolRegistry` and `ToolRegistryView` (#26)
- `fix(core): use concrete buckets for ToolRegistry listener storage` — internal typing fix

**@mast-ai/react-ui** (minor — breaking under pre-1.0 rules)
- `fix(react-ui): invert AgentProvider's disableRoot default to true` — flips a public default; consumers wanting the auto wrapper now opt in via `disableRoot={false}` (#96)
- `fix(react-ui): default approval UI to inline queue when callback is omitted` — `requiresApproval: true` tools now pause for confirmation by default instead of executing silently (#97)
- `fix(react-ui): keep MessageList scroll sticky-at-bottom when user is at the end` — bug fix to scroll stickiness state machine

**@mast-ai/google-genai** and **@mast-ai/built-in-ai** — no source changes; bumped in lockstep and pick up the `@mast-ai/core` minor through their workspace dep.

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present`
- [x] `npm run build`
- [ ] After merge: tag `v0.3.0` on `main` and push to trigger the publish workflow