### PR TITLE
feat(react-ui): inherit typography from host by default

### DIFF
--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -99,11 +99,13 @@ at any scope without `!important`.
   --mast-user-bubble: #dbeafe;
   --mast-user-fg: #1e3a8a;
 
-  /* Typography */
-  --mast-font: system-ui, sans-serif;
+  /* Typography — defaults inherit from the host so the panel adopts the
+     surrounding app's font and base size automatically. Hosts pin a fixed
+     look by setting --mast-font / --mast-text-base on [data-mast-root]. */
+  --mast-font: inherit;
   --mast-font-mono: ui-monospace, monospace;
-  --mast-text-sm: 0.875rem;
-  --mast-text-base: 1rem;
+  --mast-text-sm: 0.875em;
+  --mast-text-base: 1em;
 
   /* Spacing */
   --mast-gap: 0.75rem;

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -277,7 +277,30 @@ under `[data-mast-root]`, so consumers can override individual tokens, swap the
 whole palette, or remap every token onto an existing design system without
 `!important` and without forking the stylesheet.
 
-### 5.1 Dark mode
+### 5.1 Typography inherits from the host
+
+The library's typography tokens default to `inherit` so the panel adopts the
+host's font and base size automatically. With no `--mast-*` overrides, a host
+that sets `body { font: 18px Arial; }` (or anywhere else along the
+`[data-mast-root]` ancestor chain) sees the panel render in Arial at 18px;
+secondary text scales relatively (`--mast-text-sm: 0.875em`).
+
+If no host typography is set, the browser's user-agent stylesheet provides a
+sensible fallback (typically `system-ui` at 16px). Hosts that want to pin the
+panel to a specific font regardless of their surrounding styles set the tokens
+explicitly on `[data-mast-root]`:
+
+```css
+[data-mast-root] {
+  --mast-font: 'Inter', system-ui, sans-serif;
+  --mast-text-base: 1rem;
+}
+```
+
+The same override mechanism works for `--mast-font-mono`, `--mast-text-sm`,
+and any of the other tokens listed in §5.3.
+
+### 5.2 Dark mode
 
 The default stylesheet ships a light theme and an automatic dark theme that
 follows `prefers-color-scheme`. Apps that manage their own theme switching can
@@ -301,7 +324,7 @@ selects on that attribute so OS preferences are overridden without
 already transparent in the DOM by default, so set `data-mast-theme={theme}`
 yourself on the element that carries `data-mast-root`.
 
-### 5.2 Token reference
+### 5.3 Token reference
 
 Every token below is defined on `[data-mast-root]` in the default stylesheet
 and is safe to override at any scope.
@@ -347,7 +370,7 @@ Tokens whose default is `var(--mast-bg)` or `var(--mast-bg-subtle)` inherit
 from the base color tokens automatically, so overriding `--mast-bg` once is
 usually enough.
 
-### 5.3 Cascade layer
+### 5.4 Cascade layer
 
 Every rule in `@mast-ai/react-ui/styles.css` (and the bundled theme presets)
 lives inside a CSS cascade layer named `mast-ai`. Layered rules always lose
@@ -378,7 +401,7 @@ This is the highest-leverage way to integrate the library into an existing
 design system: hosts no longer need descendant element selectors or
 `!important` to defeat the library's defaults.
 
-### 5.4 Overriding individual tokens
+### 5.5 Overriding individual tokens
 
 Set whichever tokens you want to change on any selector that contains a
 `[data-mast-root]` element. The default stylesheet uses single-attribute
@@ -400,7 +423,7 @@ after `@mast-ai/react-ui/styles.css`.
 }
 ```
 
-### 5.5 Mapping onto an existing design system (Tailwind / shadcn)
+### 5.6 Mapping onto an existing design system (Tailwind / shadcn)
 
 Apps with their own design tokens typically want library components to inherit
 the app theme rather than ship a parallel palette. The pattern is to remap
@@ -479,7 +502,7 @@ forward `data-mast-theme` onto the element that carries `data-mast-root`:
 </aside>
 ```
 
-### 5.6 Importing the bundled Tailwind / shadcn preset
+### 5.7 Importing the bundled Tailwind / shadcn preset
 
 The preset above also ships as an importable stylesheet. Add it after the
 default styles import to skip writing the mapping yourself:
@@ -494,12 +517,12 @@ The preset assumes the standard shadcn variables (`--background`,
 `--muted-foreground`, `--border`, `--destructive`) are defined as raw HSL
 triples on `:root` and `.dark`, which is the default shadcn layout. Tailwind
 v4 / shadcn v4 projects that store full color values should copy the snippet
-in §5.5 and drop the `hsl()` wrapper instead.
+in §5.6 and drop the `hsl()` wrapper instead.
 
-You still need to forward the app theme via `data-mast-theme` (§5.5) so the
+You still need to forward the app theme via `data-mast-theme` (§5.6) so the
 library's dark detection stays in sync with the `.dark` class.
 
-### 5.7 Plain CSS without a design system
+### 5.8 Plain CSS without a design system
 
 For apps that do not use Tailwind or shadcn, override the tokens directly in
 your global stylesheet. The library's automatic dark mode applies whenever

--- a/packages/react-ui/styles/default.css
+++ b/packages/react-ui/styles/default.css
@@ -44,11 +44,13 @@
     --mast-mention-picker-active-bg: var(--mast-bg-subtle);
     --mast-mention-picker-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* Typography */
-    --mast-font: system-ui, sans-serif;
+    /* Typography. Defaults inherit from the host so the panel adopts the
+       surrounding app's font and base size automatically. Hosts that want a
+       fixed look pin --mast-font / --mast-text-base on [data-mast-root]. */
+    --mast-font: inherit;
     --mast-font-mono: ui-monospace, monospace;
-    --mast-text-sm: 0.875rem;
-    --mast-text-base: 1rem;
+    --mast-text-sm: 0.875em;
+    --mast-text-base: 1em;
 
     /* Spacing */
     --mast-gap: 0.75rem;
@@ -489,6 +491,7 @@
     border-radius: var(--mast-radius);
     cursor: pointer;
     padding: 0;
+    font-family: inherit;
   }
 
   .mast-chat-input-send:disabled {

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -291,6 +291,8 @@ Override individual tokens by setting CSS custom properties under `[data-mast-ro
 
 Element-shape tokens (`--mast-button-border`, `--mast-button-padding`, `--mast-input-border`, `--mast-message-border-width`, `--mast-user-bubble-border`) cover the long tail of "my buttons / inputs / message bubbles look slightly different" without reaching into specific class names. Defaults preserve the current visuals.
 
+Typography inherits from the host by default: `--mast-font` is `inherit` and `--mast-text-base` is `1em`, so the panel adopts the surrounding app's font and base size. Hosts that want to pin a specific font set `--mast-font` (and optionally `--mast-text-base`) on `[data-mast-root]`.
+
 For Tailwind / shadcn apps, import the bundled preset to remap every `--mast-*` token onto the standard shadcn HSL variables in one line:
 
 ```ts


### PR DESCRIPTION
## Summary

- Default `--mast-font: inherit` and `--mast-text-base: 1em` (was `system-ui, sans-serif` / `1rem`) so the panel adopts the surrounding app's font and base size without host overrides. Also relativised `--mast-text-sm` to `0.875em` so the secondary/base ratio is preserved when the host scales the base.
- Added `font-family: inherit` to `.mast-chat-input-send` / `.mast-chat-input-cancel` so host button resets pass through. (`.mast-inline-approval-button` and `.mast-chat-input-textarea` already use `font: inherit`, which is the shorthand that includes `font-family`.)
- Documented the new behaviour in `docs/react-ui/USAGE.md` (new §5.1 "Typography inherits from the host", existing §5.2-§5.8 renumbered) and `docs/react-ui/SPEC.md`. Added a one-liner to `skills/mast-ai/references/react-ui.md`.

## Behaviour change

Pre-1.0 minor-bump-acceptable per `CLAUDE.md` release policy. Hosts that previously relied on the panel rendering in `system-ui` at 16px regardless of their `body` font now see the panel pick up host typography. Migration: pin `--mast-font` and `--mast-text-base` on `[data-mast-root]` to restore the old look.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format` — clean
- [x] `npm test --workspaces --if-present` — 180 passed
- [x] `npm run build` — clean
- [x] Manually verified in `demos/react-ui/chat`:
  - Default demo (no host typography pinned) still looks intentional.
  - Setting `body { font: 18px Arial; }` makes the panel render in Arial 18px without any `--mast-*` override.
  - Pinning `--mast-font` on `[data-mast-root]` still overrides as expected.

Closes #112