### PR TITLE
feat(react-ui): split data-mast-root scope from chrome and make OS dark-mode opt-in

### DIFF
--- a/demos/react-ui/chat/src/App.tsx
+++ b/demos/react-ui/chat/src/App.tsx
@@ -119,18 +119,18 @@ const mentionsConfig: MentionsConfig<DemoDoc> = {
   },
 };
 
-type ThemeChoice = 'system' | 'light' | 'dark';
+type ThemeChoice = 'light' | 'dark' | 'auto';
 
 const NEXT_THEME: Record<ThemeChoice, ThemeChoice> = {
-  system: 'light',
   light: 'dark',
-  dark: 'system',
+  dark: 'auto',
+  auto: 'light',
 };
 
 const THEME_LABEL: Record<ThemeChoice, string> = {
-  system: 'Theme: System',
   light: 'Theme: Light',
   dark: 'Theme: Dark',
+  auto: 'Theme: Auto (OS)',
 };
 
 // ---------------------------------------------------------------------------
@@ -165,7 +165,7 @@ function clearApiKey() {
 
 interface ApiKeySetupProps {
   onSubmit: (key: string) => void;
-  theme: 'light' | 'dark' | undefined;
+  theme: ThemeChoice;
 }
 
 function ApiKeySetup({ onSubmit, theme }: ApiKeySetupProps) {
@@ -470,7 +470,7 @@ function InstructionsPanel() {
         <h3>UI tips</h3>
         <ul>
           <li>Click any tool bubble to expand its arguments and result.</li>
-          <li>Use the theme button to cycle System / Light / Dark.</li>
+          <li>Use the theme button to cycle Light / Dark / Auto (OS).</li>
           <li>
             Conversations save to <code>localStorage</code> and reload on refresh.
           </li>
@@ -482,8 +482,7 @@ function InstructionsPanel() {
 }
 
 export default function App() {
-  const [theme, setTheme] = useState<ThemeChoice>('system');
-  const panelTheme = theme === 'system' ? undefined : theme;
+  const [theme, setTheme] = useState<ThemeChoice>('light');
 
   const [apiKey, setApiKey] = useState<string | null>(() => loadApiKey());
 
@@ -557,11 +556,11 @@ export default function App() {
   const isUnsavedNew = !active;
 
   if (!apiKey || !runner) {
-    return <ApiKeySetup onSubmit={handleApiKey} theme={panelTheme} />;
+    return <ApiKeySetup onSubmit={handleApiKey} theme={theme} />;
   }
 
   return (
-    <div className="demo-shell" data-mast-root data-mast-theme={panelTheme}>
+    <div className="demo-shell" data-mast-root data-mast-theme={theme}>
       <header className="demo-header">
         <h1>MAST React UI Demo</h1>
         <div className="demo-header-controls">
@@ -612,7 +611,7 @@ export default function App() {
               <PendingApprovalsBadge />
             </div>
             <ConversationPanel
-              theme={panelTheme}
+              theme={theme}
               renderApproval={renderApproval}
               mentions={mentionsConfig as MentionsConfig}
               inputPlaceholder="Type @ to reference a doc, then press Enter."

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -62,6 +62,17 @@ import '@mast-ai/react-ui/styles.css';
 This file is plain CSS with no build-tool dependencies. It uses CSS custom properties
 scoped under `[data-mast-root]` so it does not pollute the global namespace.
 
+`[data-mast-root]` is purely the theming scope: it defines the `--mast-*`
+tokens (and resets `box-sizing` for descendants) without applying any
+visible chrome on its own. The bundled panel chrome (border, padding, flex
+column, `height: 100%`, background, font, gap) lives on a separate
+`mast-panel` class. `<ConversationPanel>` renders both the data attribute
+and the class so the default user-facing component looks identical to the
+pre-split behaviour; consumers composing primitives manually (see
+[USAGE.md §8](./USAGE.md#8-composing-a-custom-layout-with-primitives))
+opt into chrome by adding `mast-panel`, or skip it to use their own card
+without doubled borders or manual zero-out.
+
 Every rule in `styles.css` (and the bundled theme presets in §2.4) is wrapped in
 a `@layer mast-ai { … }` block. Layered rules always lose to unlayered rules
 regardless of source order, so a host stylesheet authored against the
@@ -72,8 +83,10 @@ overrides still win.
 
 ### 2.2 CSS Custom Properties
 
-The default stylesheet defines a light theme and an automatic dark theme. Both are
-expressed as CSS custom property blocks so consuming apps can override individual tokens
+The default stylesheet defines a light theme and an opt-in dark theme. The light
+theme is the default for every panel; OS-following behaviour is opt-in via
+`data-mast-theme="auto"` (see "Manual theme control" below). Both are expressed
+as CSS custom property blocks so consuming apps can override individual tokens
 at any scope without `!important`.
 
 ```css
@@ -119,9 +132,9 @@ at any scope without `!important`.
   --mast-user-bubble-border: none;
 }
 
-/* Dark theme — activated by OS preference OR explicit attribute */
+/* Dark theme — opt-in via data-mast-theme="dark" or "auto" + OS dark */
 @media (prefers-color-scheme: dark) {
-  [data-mast-root]:not([data-mast-theme='light']) {
+  [data-mast-root][data-mast-theme='auto'] {
     --mast-bg: #111827;
     --mast-bg-subtle: #1f2937;
     --mast-fg: #f9fafb;
@@ -149,15 +162,20 @@ at any scope without `!important`.
 }
 ```
 
-**Manual theme control:** Apps that manage their own theme switching (e.g. via
-`next-themes`) pass `data-mast-theme="light"` or `data-mast-theme="dark"` to the
-root element. `ConversationPanel` accepts a `theme` prop that sets this attribute:
+**Manual theme control:** Apps choose their theme via `data-mast-theme` on the
+panel root. `ConversationPanel` (and `<AgentProvider>` when opted into the
+auto wrapper via `disableRoot={false}`) accepts a `theme` prop that sets the
+attribute:
 
 ```tsx
-<ConversationPanel theme="dark" />        // force dark
-<ConversationPanel theme="light" />       // force light
-<ConversationPanel />                     // follow OS (default)
+<ConversationPanel theme="dark" />   // force dark
+<ConversationPanel theme="light" />  // force light (default)
+<ConversationPanel theme="auto" />   // follow OS preference
 ```
+
+The library defaults to light when `data-mast-theme` is unset; OS-following
+behaviour is opt-in via `theme="auto"` so apps without their own dark theme
+do not get a surprise dark panel inside an otherwise-light surface.
 
 ### 2.3 CSS class naming
 
@@ -174,14 +192,15 @@ an existing design system in one import. Presets are plain CSS published under
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `@mast-ai/react-ui/themes/tailwind-shadcn.css` | shadcn HSL variables (`--background`, `--foreground`, `--primary`, `--muted`, `--destructive`) |
 
-Presets use a triple-selector rule (`[data-mast-root], [data-mast-root][data-mast-theme='dark'], [data-mast-root][data-mast-theme='light']`)
-to match the specificity of the library's own dark-theme block, so source order
-tie-breaks in favour of the preset when it is loaded after `styles.css`. The
-preset declares its rules inside the same `@layer mast-ai` block as the
-default stylesheet so the source-order tie-break is preserved when both files
-are loaded. See [`USAGE.md` §5](./USAGE.md#5-theming) for the full integration
-guide, including how to forward `data-mast-theme` for class-based dark-mode
-setups.
+Presets use a quadruple-selector rule
+(`[data-mast-root], [data-mast-root][data-mast-theme='dark'], [data-mast-root][data-mast-theme='light'], [data-mast-root][data-mast-theme='auto']`)
+to match the specificity of the library's own dark-theme blocks at every
+theme variant, so source order tie-breaks in favour of the preset when it is
+loaded after `styles.css`. The preset declares its rules inside the same
+`@layer mast-ai` block as the default stylesheet so the source-order
+tie-break is preserved when both files are loaded. See
+[`USAGE.md` §5](./USAGE.md#5-theming) for the full integration guide,
+including how to forward `data-mast-theme` for class-based dark-mode setups.
 
 ---
 
@@ -311,13 +330,15 @@ interface AgentProviderProps {
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
 
   /**
-   * Forces a theme on the auto-rendered [data-mast-root] wrapper. Only
-   * meaningful when disableRoot is explicitly false (so the provider actually
-   * renders the wrapper). When omitted or true, the prop has no effect and
-   * consumers should set data-mast-theme themselves on whatever element
-   * carries data-mast-root.
+   * Selects the theme on the auto-rendered [data-mast-root] wrapper.
+   * Defaults to 'light'. Pass 'dark' to force the dark palette or 'auto' to
+   * follow the OS prefers-color-scheme preference. Only meaningful when
+   * disableRoot is explicitly false (so the provider actually renders the
+   * wrapper). When omitted or true, the prop has no effect and consumers
+   * should set data-mast-theme themselves on whatever element carries
+   * data-mast-root.
    */
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | 'auto';
 
   /**
    * Controls whether the provider renders an auto wrapper <div data-mast-root>
@@ -357,7 +378,10 @@ When `disableRoot` is `false`, the provider renders an auto wrapper:
 ```
 
 This is the opt-in zero-config mode for layouts that do not have their own
-container element.
+container element. The wrapper anchors `data-mast-root` only — it does
+**not** add `mast-panel`, since `<AgentProvider>` is rarely the chat panel
+itself. Use `<ConversationPanel>` or stack a `mast-panel` container
+inside the wrapper to add the bundled chrome.
 
 **Internal state managed by `AgentProvider`:**
 
@@ -413,17 +437,34 @@ interface ConversationPanelProps {
 
   /** Placeholder text for the input field. */
   inputPlaceholder?: string;
+
+  /**
+   * Selects the panel's theme. Defaults to 'light'. Pass 'dark' to force
+   * the dark palette regardless of OS preference, or 'auto' to follow the
+   * user's prefers-color-scheme setting.
+   */
+  theme?: 'light' | 'dark' | 'auto';
 }
 ```
 
 Renders:
 
 ```html
-<div data-mast-root class="mast-conversation-panel {className}">
+<div
+  data-mast-root
+  data-mast-theme="{theme}"
+  class="mast-panel mast-conversation-panel {className}"
+>
   <MessageList renderToolCall="{...}" renderMessage="{...}" />
   <ChatInput placeholder="{...}" />
 </div>
 ```
+
+The bundled chrome (border, padding, flex column, `height: 100%`) lives on
+`mast-panel`, not `[data-mast-root]`, so consumers composing primitives
+directly (see §4.1 / [USAGE.md §8](./USAGE.md#8-composing-a-custom-layout-with-primitives))
+opt into the chrome by adding the class themselves or skip it to use their
+own card.
 
 ### 4.3 `<MessageList>`
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -158,14 +158,15 @@ nested inside the provider.
 
 `<AgentProvider>` is transparent in the DOM by default: it does not render
 its own wrapper around `children`. `<ConversationPanel>` carries its own
-`data-mast-root` so the snippet above works with no extra setup. When
-composing primitives directly, place `data-mast-root` on whichever element
-should anchor the library's CSS variables (typically the outermost
-container) — see §8.
+`data-mast-root` and `mast-panel` class so the snippet above works with no
+extra setup. When composing primitives directly, place `data-mast-root` on
+whichever element should anchor the library's CSS variables (typically the
+outermost container) — see §8.
 
 Pass `disableRoot={false}` to opt back into a zero-config wrapper when you
 have nowhere else to put `data-mast-root`; in that mode the provider also
-forwards `theme="light" | "dark"` onto the wrapper as `data-mast-theme`.
+forwards `theme="light" | "dark" | "auto"` onto the wrapper as
+`data-mast-theme`.
 
 > Do not bake the API key into a public bundle. The reference demo
 > (`demos/react-ui/chat`) prompts for the key at runtime and stores it in
@@ -302,16 +303,19 @@ and any of the other tokens listed in §5.3.
 
 ### 5.2 Dark mode
 
-The default stylesheet ships a light theme and an automatic dark theme that
-follows `prefers-color-scheme`. Apps that manage their own theme switching can
-force a value via the `theme` prop on `<ConversationPanel>` (which sets it on
-the panel root). When opted into the auto wrapper via `disableRoot={false}`,
-the same prop on `<AgentProvider>` forwards it onto the wrapper.
+The default stylesheet ships a light theme and an opt-in dark theme. The
+default is light, including for users whose OS reports
+`prefers-color-scheme: dark` — apps without their own dark theme stay light
+end-to-end without surprises. Apps that want OS-following behaviour pass
+`theme="auto"`; apps that manage their own theme switching force a value
+via `theme="light"` / `theme="dark"`. The same prop is accepted by
+`<ConversationPanel>` (which sets it on the panel root) and by
+`<AgentProvider>` when opted into the auto wrapper via `disableRoot={false}`.
 
 ```tsx
 <ConversationPanel theme="dark" />   // force dark
-<ConversationPanel theme="light" />  // force light
-<ConversationPanel />                // follow OS (default)
+<ConversationPanel theme="light" />  // force light (default)
+<ConversationPanel theme="auto" />   // follow OS preference
 
 <AgentProvider runner={runner} agent={agent} disableRoot={false} theme="dark">
   <ConversationPanel />
@@ -525,9 +529,10 @@ library's dark detection stays in sync with the `.dark` class.
 ### 5.8 Plain CSS without a design system
 
 For apps that do not use Tailwind or shadcn, override the tokens directly in
-your global stylesheet. The library's automatic dark mode applies whenever
-`data-mast-theme` is unset, so you only need a second block for explicit
-themes:
+your global stylesheet. The library defaults to light, so the base block
+covers the normal case; add a second block for explicit `theme="dark"`,
+and optionally a third block for `theme="auto"` users whose OS reports
+dark:
 
 ```css
 [data-mast-root] {
@@ -543,6 +548,14 @@ themes:
   --mast-bg: #1c1917;
   --mast-fg: #fafafa;
   --mast-accent: #fb923c;
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-mast-root][data-mast-theme='auto'] {
+    --mast-bg: #1c1917;
+    --mast-fg: #fafafa;
+    --mast-accent: #fb923c;
+  }
 }
 ```
 
@@ -634,7 +647,18 @@ those primitives directly into your own JSX. `<AgentProvider>` is transparent
 in the DOM by default, so place `data-mast-root` on whichever element should
 anchor the CSS custom properties (typically the outermost container, so
 non-library UI inside such as a header, badges, or surrounding chrome also
-picks up the variables):
+picks up the variables).
+
+`data-mast-root` is purely the theming scope: it defines the `--mast-*`
+tokens and resets `box-sizing` for descendants, but carries no visible
+chrome on its own. The bundled border, padding, flex column, and
+`height: 100%` live on a separate `mast-panel` class that `<ConversationPanel>`
+applies internally. Composing primitives manually means deciding what
+chrome the surrounding element should have:
+
+- Add `mast-panel` to get the same look as `<ConversationPanel>`.
+- Skip it to drop the bundled chrome and rely on your own card styling
+  (no doubled borders, no manual zero-out).
 
 ```tsx
 import { AgentProvider, MessageList, ChatInput } from '@mast-ai/react-ui';
@@ -667,11 +691,12 @@ For zero-config setups that have no natural outer container, set
 </AgentProvider>
 ```
 
-The auto wrapper carries panel chrome (border, padding, `height: 100%`),
-which is appropriate when it actually wraps a chat panel but surprises apps
-that mount `<AgentProvider>` near the React tree root. The default
-(`disableRoot` omitted or `true`) keeps the provider transparent so the
-chrome only appears where you ask for it.
+The auto wrapper anchors `data-mast-root` only — it does **not** add
+`mast-panel`, since `<AgentProvider>` is rarely the chat panel itself. If
+you also want the bundled chrome around `<MessageList>` + `<ChatInput>`,
+either render `<ConversationPanel>` instead or stack a `mast-panel`
+container inside the wrapper. The default (`disableRoot` omitted or `true`)
+keeps the provider transparent in the DOM.
 
 Other primitives exported for compositional use: `<MessageItem>`,
 `<UserMessage>`, `<AssistantMessage>`, `<ThinkingBlock>`, `<ToolCallBlock>`,

--- a/packages/react-ui/src/components/ConversationPanel.tsx
+++ b/packages/react-ui/src/components/ConversationPanel.tsx
@@ -16,11 +16,11 @@ import type { GetToolLabel } from './ToolLabelContext.js';
  */
 export interface ConversationPanelProps {
   /**
-   * Forces a theme regardless of the user's `prefers-color-scheme` setting.
-   * When omitted, the panel follows the OS preference via the default
-   * stylesheet's media query.
+   * Selects the panel's theme. Defaults to `'light'`. Pass `'dark'` to force
+   * the dark palette regardless of OS preference, or `'auto'` to follow the
+   * user's `prefers-color-scheme` setting.
    */
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | 'auto';
   /** Optional class added to the root `[data-mast-root]` element. */
   className?: string;
   /**
@@ -62,8 +62,12 @@ export interface ConversationPanelProps {
  *
  * Internally renders {@link MessageList} and {@link ChatInput} inside a
  * `[data-mast-root]` div so the default stylesheet's CSS custom properties
- * resolve. Sets `data-mast-theme` from the optional `theme` prop, which the
- * default stylesheet uses to override the OS-driven dark mode preference.
+ * resolve. The same div carries `mast-panel` so the bundled chrome (border,
+ * padding, flex column, `height: 100%`) is applied; consumers composing
+ * primitives manually opt into chrome by adding the class themselves (see
+ * USAGE.md §8). `data-mast-theme` is set from the optional `theme` prop;
+ * the default stylesheet uses it to select between light, dark, and an
+ * OS-following auto mode.
  *
  * Must be rendered inside an `<AgentProvider>`.
  */
@@ -77,7 +81,7 @@ export function ConversationPanel({
   inputPlaceholder,
   mentions,
 }: ConversationPanelProps) {
-  const rootClass = ['mast-conversation-panel', className].filter(Boolean).join(' ');
+  const rootClass = ['mast-panel', 'mast-conversation-panel', className].filter(Boolean).join(' ');
 
   return (
     <div data-mast-root data-mast-theme={theme} className={rootClass}>

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -414,7 +414,8 @@ describe('useAgent', () => {
     expect(root!.tagName).toBe('DIV');
     expect(root!.querySelector('[data-testid="child"]')).not.toBeNull();
     // No `data-mast-theme` is set when the prop is omitted, so the default
-    // stylesheet's `prefers-color-scheme` media query takes over.
+    // stylesheet's light tokens apply. Hosts opt into OS-following with
+    // theme="auto".
     expect(root!.hasAttribute('data-mast-theme')).toBe(false);
   });
 

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -93,15 +93,15 @@ export interface AgentProviderProps {
    */
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
   /**
-   * Forces a theme on the auto-rendered `[data-mast-root]` wrapper. Only
+   * Selects the theme on the auto-rendered `[data-mast-root]` wrapper.
+   * Defaults to `'light'`. Pass `'dark'` to force the dark palette or
+   * `'auto'` to follow the OS `prefers-color-scheme` preference. Only
    * meaningful when `disableRoot` is explicitly `false` (so the provider
    * actually renders the wrapper); when omitted or `true`, this prop has no
    * effect and consumers should set `data-mast-theme` themselves on whatever
-   * element carries `data-mast-root`. When the wrapper is rendered without a
-   * theme set, the panel follows OS preference via the default stylesheet's
-   * `prefers-color-scheme` media query.
+   * element carries `data-mast-root`.
    */
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | 'auto';
   /**
    * Controls whether the provider renders an auto wrapper `<div data-mast-root>`
    * around `children`.

--- a/packages/react-ui/styles/default.css
+++ b/packages/react-ui/styles/default.css
@@ -67,7 +67,7 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    [data-mast-root]:not([data-mast-theme='light']) {
+    [data-mast-root][data-mast-theme='auto'] {
       --mast-bg: #111827;
       --mast-bg-subtle: #1f2937;
       --mast-fg: #f9fafb;
@@ -159,7 +159,25 @@
   /* ConversationPanel                                                          */
   /* -------------------------------------------------------------------------- */
 
+  /*
+   * `[data-mast-root]` is purely a theming scope: it defines the `--mast-*`
+   * tokens (above) and resets `box-sizing` for descendants so layout maths
+   * inside the panel stay predictable. Hosts that want the bundled panel
+   * chrome (border, padding, flex column, height: 100%) opt in by adding the
+   * `.mast-panel` class. `<ConversationPanel>` renders both the data
+   * attribute and the class so the default user-facing component looks
+   * identical to before; consumers composing primitives (see USAGE.md §8)
+   * can skip the class to drop the chrome and use their own card.
+   */
   [data-mast-root] {
+    box-sizing: border-box;
+  }
+
+  [data-mast-root] * {
+    box-sizing: border-box;
+  }
+
+  .mast-panel {
     display: flex;
     flex-direction: column;
     gap: var(--mast-gap);
@@ -172,11 +190,6 @@
     border: 1px solid var(--mast-border);
     border-radius: var(--mast-radius);
     padding: var(--mast-gap);
-    box-sizing: border-box;
-  }
-
-  [data-mast-root] * {
-    box-sizing: border-box;
   }
 
   /* -------------------------------------------------------------------------- */

--- a/packages/react-ui/themes/tailwind-shadcn.css
+++ b/packages/react-ui/themes/tailwind-shadcn.css
@@ -16,18 +16,19 @@
  *
  * Two non-obvious tricks this preset relies on:
  *
- * 1. Listing all three selectors with equal specificity so source order
+ * 1. Listing every theme variant with equal specificity so source order
  *    tie-breaks in the consumer's favor. A bare [data-mast-root] block loses
- *    to the library's [data-mast-root][data-mast-theme='dark'] block in dark
- *    mode and the dark theme would keep the library's hardcoded colors. The
+ *    to the library's [data-mast-root][data-mast-theme='dark'] (and the
+ *    OS-following [data-mast-theme='auto']) blocks, so explicit dark mode
+ *    and OS-following users would keep the library's hardcoded colors. The
  *    preset declares its rules inside the same `@layer mast-ai` block as the
  *    default stylesheet, so the source-order tie-break is preserved when
  *    both files are loaded.
  *
  * 2. Setting data-mast-theme={theme} on the panel root in your app keeps the
  *    library's dark detection in sync with shadcn's class-based dark mode
- *    (.dark on <html>). Without it, the library follows OS preference and
- *    can mismatch the app theme.
+ *    (.dark on <html>). Without it, the library defaults to the light theme
+ *    and can mismatch an app forced into dark.
  *
  * See docs/react-ui/USAGE.md §5 for the full integration guide.
  */
@@ -35,7 +36,8 @@
 @layer mast-ai {
   [data-mast-root],
   [data-mast-root][data-mast-theme='dark'],
-  [data-mast-root][data-mast-theme='light'] {
+  [data-mast-root][data-mast-theme='light'],
+  [data-mast-root][data-mast-theme='auto'] {
     --mast-bg: hsl(var(--background));
     --mast-bg-subtle: hsl(var(--muted) / 0.2);
     --mast-fg: hsl(var(--foreground));

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -35,7 +35,7 @@ interface AgentProviderProps {
   initialHistory?: Message[]; // read once on mount
   initialEntries?: ConversationEntry[]; // read once on mount
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
-  theme?: 'light' | 'dark'; // forwarded to the auto wrapper when disableRoot={false}
+  theme?: 'light' | 'dark' | 'auto'; // forwarded to the auto wrapper when disableRoot={false}; default 'light'
   disableRoot?: boolean; // default true; pass false to opt into the auto <div data-mast-root> wrapper
 }
 ```
@@ -69,13 +69,13 @@ interface UseAgentReturn {
 
 ## ConversationPanel
 
-Drop-in chat UI. Wraps `<MessageList>` and `<ChatInput>` inside a `[data-mast-root]` element.
+Drop-in chat UI. Wraps `<MessageList>` and `<ChatInput>` inside a `[data-mast-root]` element that also carries the `mast-panel` class for the bundled chrome.
 
 ```typescript
 import { ConversationPanel } from '@mast-ai/react-ui';
 
 interface ConversationPanelProps {
-  theme?: 'light' | 'dark'; // omit to follow prefers-color-scheme
+  theme?: 'light' | 'dark' | 'auto'; // default 'light'; pass 'auto' to follow prefers-color-scheme
   className?: string;
   renderToolCall?: (entry: ToolEventEntry, approval?: PendingApproval) => ReactNode;
   renderApproval?: (entry: ToolEventEntry, approval: PendingApproval) => ReactNode;
@@ -87,7 +87,7 @@ interface ConversationPanelProps {
 
 ## Primitives
 
-For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. `<AgentProvider>` is already transparent by default, so just add `data-mast-root` to whatever element should anchor the CSS custom properties. (Use `disableRoot={false}` when you want the provider to render its own zero-config wrapper instead.)
+For non-default layouts (sidebar, docked panel, etc.), drop the primitives into your own JSX. `<AgentProvider>` is already transparent by default, so just add `data-mast-root` to whatever element should anchor the CSS custom properties. (Use `disableRoot={false}` when you want the provider to render its own zero-config wrapper instead.) `[data-mast-root]` is purely the theming scope; add the `mast-panel` class to the same element if you want the bundled chrome (border, padding, flex column, `height: 100%`), or skip it to use your own card without doubled borders.
 
 ```typescript
 import {
@@ -275,7 +275,7 @@ const {
 
 ## Theming
 
-The default stylesheet ships a light theme and an automatic dark theme that follows `prefers-color-scheme`. Apps that manage their own theme can force a value with `theme="light" | "dark"` on `<ConversationPanel>` (or, when opted in via `disableRoot={false}`, on `<AgentProvider>` so it's forwarded onto the auto wrapper). Both set `data-mast-theme`.
+The default stylesheet ships a light theme (default) and an opt-in dark theme. Apps choose with `theme="light" | "dark" | "auto"` on `<ConversationPanel>` (or, when opted in via `disableRoot={false}`, on `<AgentProvider>` so it's forwarded onto the auto wrapper). Both set `data-mast-theme`. Pass `"auto"` to follow `prefers-color-scheme`; the library defaults to light when the attribute is unset, so apps without their own dark theme do not get a surprise dark panel inside an otherwise-light surface.
 
 Every rule in `styles.css` and the bundled theme presets lives inside a `@layer mast-ai` cascade layer. Layered rules always lose to unlayered rules, so a host stylesheet authored against the existing class names overrides the library at equal specificity without `!important`. Hosts that prefer to keep their overrides layered can declare `@layer mast-ai, host;` and write rules inside `@layer host { … }`.
 
@@ -300,7 +300,7 @@ import '@mast-ai/react-ui/styles.css';
 import '@mast-ai/react-ui/themes/tailwind-shadcn.css';
 ```
 
-Two gotchas when writing the mapping by hand: list `[data-mast-root]`, `[data-mast-root][data-mast-theme='dark']`, and `[data-mast-root][data-mast-theme='light']` together so source order tie-breaks against the library's dark-mode block, and pass `data-mast-theme={theme}` on the panel root so the library tracks the app's class-based dark mode (`.dark` on `<html>`).
+Two gotchas when writing the mapping by hand: list `[data-mast-root]`, `[data-mast-root][data-mast-theme='dark']`, `[data-mast-root][data-mast-theme='light']`, and `[data-mast-root][data-mast-theme='auto']` together so source order tie-breaks against the library's dark-mode blocks at every theme variant, and pass `data-mast-theme={theme}` on the panel root so the library tracks the app's class-based dark mode (`.dark` on `<html>`).
 
 The full token list, gotcha rationale, and a plain-CSS example are in `docs/react-ui/USAGE.md` §5.
 


### PR DESCRIPTION
## Summary

- Split `[data-mast-root]` into pure theming scope (tokens + `box-sizing`) and a new `.mast-panel` class that carries the bundled chrome (border, padding, flex column, `height: 100%`, background, font, gap). `<ConversationPanel>` now renders both attribute and class so the default user-facing component looks identical; consumers composing primitives manually opt into chrome by adding the class, or skip it to drop into their own card without doubled borders or manual zero-out.
- Made OS-following dark mode opt-in. The `prefers-color-scheme: dark` block is now gated on `[data-mast-theme='auto']` instead of `:not([data-mast-theme='light'])`, so apps without their own dark theme stay light end-to-end. The `theme` prop on `<ConversationPanel>` and `<AgentProvider>` widens to `'light' | 'dark' | 'auto'`; default is `'light'`.
- Updated `themes/tailwind-shadcn.css` to include `[data-mast-theme='auto']` in its selector list so the preset wins at every theme variant.
- Updated `docs/react-ui/USAGE.md`, `docs/react-ui/SPEC.md`, the `skills/mast-ai/references/react-ui.md` reference, and the `demos/react-ui/chat` demo (theme cycle is now Light → Dark → Auto).

Closes #113.

## Breaking changes (pre-1.0, minor-bump-acceptable per `CLAUDE.md`)

- Existing consumers who relied on OS-following without setting `theme` see the panel stay light. Migration: pass `theme=\"auto\"`.
- Existing consumers who manually emit `<div data-mast-root>` (per USAGE §8) and depend on the implicit border/padding/flex must now add the `mast-panel` class. Migration: append the class.

## Test plan

- [x] `npm run lint`, `npm run format`, `npm run build`, `npm test --workspaces --if-present`
- [x] Default `<ConversationPanel>` (no `theme` prop) stays light even when OS is dark
- [x] Cycling to **Theme: Dark** in the demo restyles panel and demo shell
- [x] Cycling to **Theme: Auto (OS)** follows OS preference
- [x] Composing primitives without `mast-panel` shows no library border/padding/`height: 100%`