### PR TITLE
feat(google-genai): forward native Gemini tools through GoogleGenAIAdapter

### DIFF
--- a/demos/google-genai/google-search-grounding/index.html
+++ b/demos/google-genai/google-search-grounding/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAST &mdash; Google Search Grounding Demo</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <div class="sidebar">
+        <h2>Search Grounding <small id="version"></small></h2>
+
+        <div class="config-panel">
+          <label>Google AI API key</label>
+          <input type="password" id="api-key" placeholder="AIza&hellip;" autocomplete="off" />
+          <p class="config-hint">Stored in localStorage on this device only.</p>
+        </div>
+
+        <div class="info-panel">
+          <h3>What this shows</h3>
+          <p>
+            <code>GoogleGenAIAdapter</code> accepts an optional <code>nativeTools</code> array that
+            is forwarded directly to Gemini alongside any function declarations from the
+            <code>ToolRegistry</code>. This demo passes <code>[{ googleSearch: {} }]</code> so the
+            model can ground answers in live web results.
+          </p>
+          <p>
+            Native tools cover Gemini's built-in tools &mdash; <code>googleSearch</code>,
+            <code>codeExecution</code>, <code>urlContext</code> &mdash; without needing adapter
+            subclasses for each.
+          </p>
+        </div>
+
+        <div class="info-panel">
+          <h3>Try this</h3>
+          <ul>
+            <li>Who won the most recent F1 Grand Prix?</li>
+            <li>What is the current price of a barrel of Brent crude?</li>
+            <li>Summarise today's top tech headlines.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="chat-container">
+        <div class="message-list" id="message-list">
+          <div class="message assistant">
+            <div class="bubble">
+              Ask me about something current. I'll use Google Search to ground my answer.
+            </div>
+          </div>
+        </div>
+
+        <div class="input-area">
+          <div class="status-indicator" id="status-indicator">Idle</div>
+          <div class="input-group">
+            <textarea
+              id="prompt-input"
+              placeholder="e.g. What is the weather in Tokyo right now?"
+            ></textarea>
+            <button id="send-button">Send</button>
+            <button id="stop-button" class="stop-button" hidden>Stop</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/demos/google-genai/google-search-grounding/package.json
+++ b/demos/google-genai/google-search-grounding/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "google-search-grounding",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/core": "*",
+    "@mast-ai/google-genai": "*"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/demos/google-genai/google-search-grounding/src/main.ts
+++ b/demos/google-genai/google-search-grounding/src/main.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { VERSION, ToolRegistry, AgentRunner, createAgent, Conversation } from '@mast-ai/core';
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
+
+const apiKeyInput = document.querySelector<HTMLInputElement>('#api-key')!;
+const API_KEY_STORAGE = 'mast-demo-google-search-grounding.gemini-api-key';
+apiKeyInput.value = localStorage.getItem(API_KEY_STORAGE) ?? '';
+
+const agent = createAgent({
+  name: 'GroundedAssistant',
+  instructions:
+    'You are a helpful assistant. When the user asks about current events, prices, weather, ' +
+    'sports results, or anything that may have changed recently, rely on the Google Search ' +
+    'tool to ground your answer. Cite the most relevant source inline when you use search.',
+});
+
+// Build the runner whenever the API key changes so the adapter picks it up.
+function buildConversation(): Conversation {
+  const apiKey = apiKeyInput.value;
+  const adapter = new GoogleGenAIAdapter(apiKey, 'gemini-3.1-pro-preview', undefined, [
+    { googleSearch: {} },
+  ]);
+  const runner = new AgentRunner(adapter, new ToolRegistry());
+  return runner.conversation(agent);
+}
+
+let conversation = buildConversation();
+
+apiKeyInput.addEventListener('change', () => {
+  localStorage.setItem(API_KEY_STORAGE, apiKeyInput.value);
+  conversation = buildConversation();
+});
+
+// --- Chat UI. ----------------------------------------------------------------
+const messageList = document.querySelector('#message-list')!;
+const promptInput = document.querySelector<HTMLTextAreaElement>('#prompt-input')!;
+const sendButton = document.querySelector<HTMLButtonElement>('#send-button')!;
+const stopButton = document.querySelector<HTMLButtonElement>('#stop-button')!;
+const statusIndicator = document.querySelector('#status-indicator')!;
+
+let currentController: AbortController | null = null;
+
+function appendMessage(role: 'user' | 'assistant', content: string): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message ${role}`;
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  bubble.textContent = content;
+  msgEl.appendChild(bubble);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return bubble;
+}
+
+function appendSystemMessage(content: string, type: 'tool' | 'error' = 'tool'): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message system ${type}`;
+  const small = document.createElement('small');
+  small.textContent = content;
+  msgEl.appendChild(small);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return msgEl;
+}
+
+async function handleSend() {
+  if (currentController) return;
+
+  const text = promptInput.value.trim();
+  if (!text) return;
+
+  if (!apiKeyInput.value.trim()) {
+    appendSystemMessage('Set a Google AI API key in the sidebar before sending.', 'error');
+    return;
+  }
+
+  promptInput.value = '';
+  promptInput.disabled = true;
+  sendButton.disabled = true;
+  stopButton.hidden = false;
+
+  appendMessage('user', text);
+
+  const controller = new AbortController();
+  currentController = controller;
+
+  statusIndicator.textContent = 'Running...';
+  statusIndicator.className = 'status-indicator running';
+
+  let bubble: HTMLElement | null = null;
+
+  try {
+    for await (const event of conversation.runStream(text, controller.signal)) {
+      if (event.type === 'text_delta') {
+        if (!bubble) bubble = appendMessage('assistant', '');
+        bubble.textContent += event.delta;
+      }
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      console.error(error);
+      appendSystemMessage(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        'error',
+      );
+    }
+  } finally {
+    currentController = null;
+    promptInput.disabled = false;
+    sendButton.disabled = false;
+    stopButton.hidden = true;
+    promptInput.focus();
+    statusIndicator.textContent = 'Idle';
+    statusIndicator.className = 'status-indicator';
+  }
+}
+
+sendButton.addEventListener('click', handleSend);
+stopButton.addEventListener('click', () => currentController?.abort());
+promptInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    handleSend();
+  }
+});

--- a/demos/google-genai/google-search-grounding/src/style.css
+++ b/demos/google-genai/google-search-grounding/src/style.css
@@ -1,0 +1,249 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  --primary-color: #3b82f6;
+  --bg-color: #f4f4f5;
+  --border-color: #e4e4e7;
+}
+
+body,
+html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+.app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar {
+  width: 320px;
+  background-color: var(--bg-color);
+  border-right: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sidebar h2 small {
+  font-size: 0.75rem;
+  color: #71717a;
+  font-weight: normal;
+}
+
+.config-panel label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #52525b;
+  margin-bottom: 0.4rem;
+}
+
+.config-panel input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.config-hint {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+  color: #71717a;
+  line-height: 1.4;
+}
+
+.info-panel {
+  font-size: 0.85rem;
+  color: #52525b;
+  line-height: 1.5;
+}
+
+.info-panel h3 {
+  font-size: 0.95rem;
+  color: #1a1a1a;
+  margin: 0 0 0.5rem;
+}
+
+.info-panel p {
+  margin: 0.4rem 0;
+}
+
+.info-panel ul {
+  margin: 0.4rem 0;
+  padding-left: 1.2rem;
+}
+
+.info-panel li {
+  margin: 0.25rem 0;
+}
+
+.info-panel code {
+  font-size: 0.8rem;
+  background: #ffffff;
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 0.05em 0.3em;
+}
+
+.chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+}
+
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+}
+
+.message.assistant {
+  align-self: flex-start;
+}
+
+.message.system {
+  align-self: center;
+  max-width: 90%;
+}
+
+.bubble {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.user .bubble {
+  background-color: var(--primary-color);
+  color: white;
+  border-bottom-right-radius: 0;
+}
+
+.assistant .bubble {
+  background-color: var(--bg-color);
+  color: #1a1a1a;
+  border-bottom-left-radius: 0;
+}
+
+.system small {
+  color: #71717a;
+  font-family: monospace;
+  font-size: 0.8rem;
+  background: #f8f8f8;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+}
+
+.system.error small {
+  color: #ef4444;
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.input-area {
+  padding: 1rem 2rem 2rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  color: #71717a;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-indicator.running {
+  color: var(--primary-color);
+  font-weight: bold;
+}
+
+.input-group {
+  display: flex;
+  gap: 1rem;
+}
+
+textarea {
+  flex: 1;
+  resize: none;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 1rem;
+  height: 60px;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+button {
+  padding: 0 1.5rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #2563eb;
+}
+
+button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.stop-button {
+  background-color: #ef4444;
+}
+
+.stop-button:hover {
+  background-color: #dc2626;
+}

--- a/demos/google-genai/google-search-grounding/tsconfig.json
+++ b/demos/google-genai/google-search-grounding/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/packages/google-genai/src/GoogleGenAIAdapter.test.ts
+++ b/packages/google-genai/src/GoogleGenAIAdapter.test.ts
@@ -153,6 +153,68 @@ describe('GoogleGenAIAdapter', () => {
     expect(response.text).toBe('Thinking... and also responding');
   });
 
+  it('should append nativeTools to the tools array alongside function declarations', async () => {
+    const { GoogleGenAI } = await import('@google/genai');
+    const mockClient = new (GoogleGenAI as unknown as new () => {
+      models: { generateContent: ReturnType<typeof vi.fn> };
+    })();
+
+    const adapterWithNative = new GoogleGenAIAdapter(
+      'fake-api-key',
+      'gemini-3.1-flash-lite-preview',
+      undefined,
+      [{ googleSearch: {} }],
+    );
+
+    await adapterWithNative.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [{ name: 'testTool', description: 'desc', parameters: {}, scope: 'read' as const }],
+    });
+
+    const call = mockClient.models.generateContent.mock.calls.at(-1)?.[0];
+    expect(call.config.tools).toEqual([
+      { functionDeclarations: [{ name: 'testTool', description: 'desc', parameters: {} }] },
+      { googleSearch: {} },
+    ]);
+  });
+
+  it('should send nativeTools alone when no function declarations are provided', async () => {
+    const { GoogleGenAI } = await import('@google/genai');
+    const mockClient = new (GoogleGenAI as unknown as new () => {
+      models: { generateContent: ReturnType<typeof vi.fn> };
+    })();
+
+    const adapterWithNative = new GoogleGenAIAdapter(
+      'fake-api-key',
+      'gemini-3.1-flash-lite-preview',
+      undefined,
+      [{ googleSearch: {} }, { urlContext: {} }],
+    );
+
+    await adapterWithNative.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.models.generateContent.mock.calls.at(-1)?.[0];
+    expect(call.config.tools).toEqual([{ googleSearch: {} }, { urlContext: {} }]);
+  });
+
+  it('should leave tools undefined when neither function declarations nor nativeTools are provided', async () => {
+    const { GoogleGenAI } = await import('@google/genai');
+    const mockClient = new (GoogleGenAI as unknown as new () => {
+      models: { generateContent: ReturnType<typeof vi.fn> };
+    })();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.models.generateContent.mock.calls.at(-1)?.[0];
+    expect(call.config.tools).toBeUndefined();
+  });
+
   it('should throw when no candidate is returned from generate', async () => {
     const { GoogleGenAI } = await import('@google/genai');
     const mockClient = new (GoogleGenAI as unknown as new () => {
@@ -284,6 +346,41 @@ describe('GoogleGenAIAdapter', () => {
         candidatesTokenCount: 2,
         totalTokenCount: 5,
       });
+    });
+
+    it('should forward nativeTools alongside function declarations in streaming requests', async () => {
+      const { GoogleGenAI } = await import('@google/genai');
+      const mockClient = new (GoogleGenAI as unknown as new () => {
+        models: { generateContentStream: ReturnType<typeof vi.fn> };
+      })();
+      mockClient.models.generateContentStream.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+            usageMetadata: {},
+          };
+        })(),
+      );
+
+      const adapterWithNative = new GoogleGenAIAdapter(
+        'fake-api-key',
+        'gemini-3.1-flash-lite-preview',
+        undefined,
+        [{ googleSearch: {} }],
+      );
+
+      for await (const _chunk of adapterWithNative.generateStream({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [{ name: 'read', description: 'reads', parameters: {}, scope: 'read' as const }],
+      })) {
+        void _chunk;
+      }
+
+      const call = mockClient.models.generateContentStream.mock.calls.at(-1)?.[0];
+      expect(call.config.tools).toEqual([
+        { functionDeclarations: [{ name: 'read', description: 'reads', parameters: {} }] },
+        { googleSearch: {} },
+      ]);
     });
 
     it('should skip chunks with no candidates', async () => {

--- a/packages/google-genai/src/GoogleGenAIAdapter.ts
+++ b/packages/google-genai/src/GoogleGenAIAdapter.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { GoogleGenAI, ThinkingLevel } from '@google/genai';
-import type { Content, FunctionDeclaration, Part, FunctionCall, Schema } from '@google/genai';
+import type { Content, FunctionDeclaration, Part, FunctionCall, Schema, Tool } from '@google/genai';
 import type {
   LlmAdapter,
   AdapterRequest,
@@ -30,30 +30,42 @@ export class GoogleGenAIAdapter implements LlmAdapter {
   private client: GoogleGenAI;
   private modelName: string;
   private onUsageUpdate?: (usage: UsageMetadata) => void;
+  private nativeTools?: Tool[];
 
   /**
    * @param apiKey - Google AI API key.
    * @param modelName - Gemini model identifier (defaults to `"gemini-3.1-flash-lite-preview"`).
    * @param onUsageUpdate - Optional callback invoked with token-usage data after each response.
+   * @param nativeTools - Optional Gemini built-in tools (e.g. `{ googleSearch: {} }`,
+   *   `{ codeExecution: {} }`, `{ urlContext: {} }`) that are appended to the tools array on
+   *   every request alongside any function declarations from the registry.
    */
   constructor(
     apiKey: string,
     modelName: string = 'gemini-3.1-flash-lite-preview',
     onUsageUpdate?: (usage: UsageMetadata) => void,
+    nativeTools?: Tool[],
   ) {
     this.client = new GoogleGenAI({ apiKey });
     this.modelName = modelName;
     this.onUsageUpdate = onUsageUpdate;
+    this.nativeTools = nativeTools;
+  }
+
+  private buildTools(request: AdapterRequest): Tool[] | undefined {
+    const functionDeclarations = request.tools.map((t) => this.mapTool(t));
+    const allTools: Tool[] = [
+      ...(functionDeclarations.length > 0 ? [{ functionDeclarations }] : []),
+      ...(this.nativeTools ?? []),
+    ];
+    return allTools.length > 0 ? allTools : undefined;
   }
 
   /** {@inheritDoc LlmAdapter.generate} */
   async generate(request: AdapterRequest): Promise<AdapterResponse> {
     const contents = this.mapMessages(request.messages);
     const systemInstruction = this.mapSystemInstruction(request.system);
-    const tools =
-      request.tools.length > 0
-        ? [{ functionDeclarations: request.tools.map((t) => this.mapTool(t)) }]
-        : undefined;
+    const tools = this.buildTools(request);
 
     const outputSchema = request.outputSchema;
     const response = await this.client.models.generateContent({
@@ -120,10 +132,7 @@ export class GoogleGenAIAdapter implements LlmAdapter {
   async *generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk> {
     const contents = this.mapMessages(request.messages);
     const systemInstruction = this.mapSystemInstruction(request.system);
-    const tools =
-      request.tools.length > 0
-        ? [{ functionDeclarations: request.tools.map((t) => this.mapTool(t)) }]
-        : undefined;
+    const tools = this.buildTools(request);
 
     const responseStream = await this.client.models.generateContentStream({
       model: this.modelName,


### PR DESCRIPTION
## Summary

- Add optional `nativeTools?: Tool[]` constructor parameter on `GoogleGenAIAdapter`. The tools array sent to Gemini becomes `[{ functionDeclarations }, ...nativeTools]`, so callers can enable built-in tools (`googleSearch`, `codeExecution`, `urlContext`) without subclassing — the proposal from #105.
- Refactor tools-array construction into a private `buildTools()` helper shared by `generate()` and `generateStream()`. `tools` stays `undefined` when neither function declarations nor native tools are provided.
- Add a `demos/google-genai/google-search-grounding` demo that wires `new GoogleGenAIAdapter(apiKey, 'gemini-2.5-flash', undefined, [{ googleSearch: {} }])` into a single-agent chat to showcase live search grounding.

Closes #105

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test --workspaces --if-present` (15/15 in `@mast-ai/google-genai`, 297 across all workspaces)
- [x] Manually exercised the `google-search-grounding` demo with a Gemini API key — grounded answers come back as expected.