### PR TITLE
feat(openai): add @mast-ai/openai package with Chat Completions and Responses adapters

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           TAG_REF="${{ github.event.inputs.tag || github.ref_name }}"
           TAG_VERSION="${TAG_REF#v}"
-          for pkg in core google-genai built-in-ai react-ui; do
+          for pkg in core google-genai built-in-ai openai react-ui; do
             PKG_VERSION=$(node -p "require('./packages/$pkg/package.json').version")
             if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
               echo "Version mismatch: tag is $TAG_VERSION but @mast-ai/$pkg is $PKG_VERSION"
@@ -46,7 +46,7 @@ jobs:
 
       # Build before tests so workspace packages that depend on
       # @mast-ai/core can resolve its `dist/index.js` entry.
-      - run: npm run build -w @mast-ai/core -w @mast-ai/google-genai -w @mast-ai/built-in-ai -w @mast-ai/react-ui
+      - run: npm run build -w @mast-ai/core -w @mast-ai/google-genai -w @mast-ai/built-in-ai -w @mast-ai/openai -w @mast-ai/react-ui
 
       - run: npm test --workspaces --if-present
 
@@ -58,6 +58,9 @@ jobs:
 
       - name: Publish @mast-ai/built-in-ai
         run: npm publish --provenance -w @mast-ai/built-in-ai
+
+      - name: Publish @mast-ai/openai
+        run: npm publish --provenance -w @mast-ai/openai
 
       - name: Publish @mast-ai/react-ui
         run: npm publish --provenance -w @mast-ai/react-ui

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ npm run lint             # Lint
 npm run format           # Format
 ```
 
+### OpenAI Adapter (`packages/openai`)
+
+```bash
+npm run build            # Build with type declarations
+npm run dev              # Watch mode
+npm test                 # Run tests
+npm run lint             # Lint
+npm run format           # Format
+```
+
 ### Frontend Demo (`demos/core/basic-chat`)
 
 ```bash
@@ -92,6 +102,10 @@ packages/built-in-ai/src/
 ├── BuiltInAIAdapter.ts    → LlmAdapter wrapping Chrome Prompt API
 └── tools/                 → summarize, translate, detectLanguage, proofread
 
+packages/openai/src/
+├── OpenAIChatCompletionsAdapter.ts → LlmAdapter calling the OpenAI Chat Completions API
+└── OpenAIResponsesAdapter.ts → LlmAdapter calling the OpenAI Responses API (surfaces reasoning summaries)
+
 demos/core/basic-chat/src/
 └── main.ts          → Chat UI wiring ToolRegistry + AgentRunner
 
@@ -114,10 +128,11 @@ demos/core/rust-server/src/
 - **`@mast-ai/core`** — `AgentRunner`, `UrpAdapter`, `ToolRegistry`, all core types; no Node globals, browser-native
 - **`@mast-ai/google-genai`** — `GoogleGenAIAdapter`: calls Google GenAI directly from the browser (no backend needed)
 - **`@mast-ai/built-in-ai`** — `BuiltInAIAdapter`: wraps Chrome's built-in AI (Prompt API / Gemini Nano) as an `LlmAdapter`; also exposes browser built-in AI capabilities as MAST tools (`SummarizeTool`, `TranslateTool`, `DetectLanguageTool`, `ProofreadTool`)
+- **`@mast-ai/openai`** — `OpenAIChatCompletionsAdapter` (Chat Completions) and `OpenAIResponsesAdapter` (Responses API). Both call OpenAI directly from the browser. Use the Responses adapter to surface reasoning summaries from gpt-5 / o-series models as `thinking` events; the Chat Completions adapter has broader provider compatibility (OpenRouter, DeepSeek)
 
 ### Key Abstractions
 
-- **LlmAdapter** — swappable interface; `UrpAdapter` for remote backends, `GoogleGenAIAdapter` for direct API calls, `BuiltInAIAdapter` for on-device inference
+- **LlmAdapter** — swappable interface; `UrpAdapter` for remote backends, `GoogleGenAIAdapter` / `OpenAIChatCompletionsAdapter` for direct API calls, `BuiltInAIAdapter` for on-device inference
 - **URP (Universal Reasoning Protocol)** — the HTTP JSON/SSE protocol between browser and backend; defined in `docs/SPEC.md`
 - **ToolRegistry** — browser-side tool store; server only receives tool metadata, never executes tools
 - **AgentRunner** — emits `AgentEvent` stream (text delta, thinking, tool call, tool result, done, error)
@@ -161,13 +176,13 @@ Before starting work on a feature, check its subdirectory in `docs/` for context
 
 ## Releases
 
-The four `@mast-ai/*` packages are published to npm in lockstep — every release bumps all four to the same version, even if some packages have no source changes. Pre-1.0 the surfaces are tightly coupled, so version drift would add more confusion than value.
+The `@mast-ai/*` packages are published to npm in lockstep — every release bumps all of them to the same version, even if some packages have no source changes. Pre-1.0 the surfaces are tightly coupled, so version drift would add more confusion than value.
 
-Releases are cut by pushing a `vX.Y.Z` tag to `main`. The `.github/workflows/publish.yml` workflow then runs lint, tests, and build, and publishes all four packages to npm via OIDC trusted publishing (no `NPM_TOKEN` involved).
+Releases are cut by pushing a `vX.Y.Z` tag to `main`. The `.github/workflows/publish.yml` workflow then runs lint, tests, and build, and publishes every package to npm via OIDC trusted publishing (no `NPM_TOKEN` involved).
 
 ### Choosing the next version
 
-Use the highest-severity change across all four packages:
+Use the highest-severity change across all packages:
 
 - **Major** — any breaking change to a public API (removed/renamed exports, changed signatures, observable behaviour change callers may depend on).
 - **Minor** — any new public API; no breaking changes.
@@ -186,7 +201,7 @@ Then walk each package's commits since that tag:
 
 ```bash
 PREV=v0.1.0  # replace with the last published tag
-for pkg in core google-genai built-in-ai react-ui; do
+for pkg in core google-genai built-in-ai openai react-ui; do
   echo "--- @mast-ai/$pkg ---"
   git log "$PREV"..HEAD --oneline -- "packages/$pkg/"
 done
@@ -208,7 +223,7 @@ After determining the next version `X.Y.Z`:
 git checkout main && git pull
 git checkout -b chore/release-vX.Y.Z
 
-npm run bump-version X.Y.Z   # bumps all four packages + their @mast-ai/core deps
+npm run bump-version X.Y.Z   # bumps all packages + their @mast-ai/core deps
 npm install                  # refresh node_modules
 npm run format               # normalise package.json formatting
 
@@ -226,7 +241,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-The tag push triggers `Publish`. If a publish step fails partway through (e.g. a network blip after `core` succeeds but before `react-ui`), re-run the workflow manually from the Actions tab via `workflow_dispatch` with the same tag — already-published packages will fail with `403` and the remaining ones will go through. Resolve by either bumping a patch version or unpublishing the partial release within npm's 72-hour window.
+The tag push triggers `Publish`. If a publish step fails partway through (e.g. a network blip after one package succeeds but before another), re-run the workflow manually from the Actions tab via `workflow_dispatch` with the same tag — already-published packages will fail with `403` and the remaining ones will go through. Resolve by either bumping a patch version or unpublishing the partial release within npm's 72-hour window.
 
 ### Bootstrapping a new package
 

--- a/demos/openai/basic-chat/index.html
+++ b/demos/openai/basic-chat/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAST &mdash; OpenAI Basic Chat</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <div class="sidebar">
+        <h2>OpenAI Basic Chat <small id="version"></small></h2>
+
+        <div class="config-panel">
+          <label>OpenAI API key</label>
+          <input type="password" id="api-key" placeholder="sk-&hellip;" autocomplete="off" />
+          <p class="config-hint">Stored in localStorage on this device only.</p>
+        </div>
+
+        <div class="config-panel">
+          <label>API</label>
+          <select id="api-mode">
+            <option value="chat">Chat Completions (OpenAIChatCompletionsAdapter)</option>
+            <option value="responses">Responses (OpenAIResponsesAdapter)</option>
+          </select>
+          <p class="config-hint">
+            Use the Responses API to surface reasoning summaries from gpt-5 / o-series models as
+            thinking events. Chat Completions does not expose reasoning content.
+          </p>
+        </div>
+
+        <div class="config-panel">
+          <label>Model</label>
+          <input type="text" id="model" value="gpt-4o-mini" />
+          <p class="config-hint">
+            Any chat-completion-compatible model (e.g. <code>gpt-4o</code>, <code>gpt-5</code>,
+            <code>o4-mini</code>).
+          </p>
+        </div>
+
+        <div class="config-panel">
+          <label>Reasoning effort (optional)</label>
+          <select id="reasoning-effort">
+            <option value="">unset</option>
+            <option value="minimal">minimal</option>
+            <option value="low">low</option>
+            <option value="medium">medium</option>
+            <option value="high">high</option>
+          </select>
+          <p class="config-hint">
+            Ignored unless the model is reasoning-capable (o-series, gpt-5).
+          </p>
+        </div>
+
+        <div class="tools-panel">
+          <h3>Available Tools</h3>
+          <ul id="tools-list"></ul>
+        </div>
+      </div>
+
+      <div class="chat-container">
+        <div class="message-list" id="message-list">
+          <div class="message assistant">
+            <div class="bubble">
+              Hi! I'm running on OpenAI directly from your browser. I can check the time and do
+              math.
+            </div>
+          </div>
+        </div>
+
+        <div class="input-area">
+          <div class="status-indicator" id="status-indicator">Idle</div>
+          <div class="input-group">
+            <textarea
+              id="prompt-input"
+              placeholder="Ask something (e.g. 'What time is it?' or 'What is 54 * 23?')"
+            ></textarea>
+            <button id="send-button">Send</button>
+            <button id="stop-button" class="stop-button" hidden>Stop</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/demos/openai/basic-chat/package.json
+++ b/demos/openai/basic-chat/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "openai-basic-chat",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mast-ai/core": "*",
+    "@mast-ai/openai": "*"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/demos/openai/basic-chat/src/main.ts
+++ b/demos/openai/basic-chat/src/main.ts
@@ -1,0 +1,210 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { VERSION, ToolRegistry, AgentRunner, createAgent, Conversation } from '@mast-ai/core';
+import { OpenAIChatCompletionsAdapter, OpenAIResponsesAdapter } from '@mast-ai/openai';
+import type { ReasoningEffort } from '@mast-ai/openai';
+import { GetCurrentTimeTool } from './tools/getCurrentTime';
+import { CalculatorTool } from './tools/calculate';
+
+const registry = new ToolRegistry()
+  .register(new GetCurrentTimeTool())
+  .register(new CalculatorTool());
+
+const agentConfig = createAgent({
+  name: 'OpenAIAssistant',
+  instructions:
+    'You are a helpful assistant. Use tools when necessary to answer user questions accurately.',
+  tools: ['getCurrentTime', 'calculate'],
+});
+
+document.querySelector<HTMLElement>('#version')!.textContent = `v${VERSION}`;
+
+const toolsList = document.querySelector<HTMLUListElement>('#tools-list')!;
+for (const { name } of registry.getTools()) {
+  const li = document.createElement('li');
+  const code = document.createElement('code');
+  code.textContent = name;
+  li.appendChild(code);
+  toolsList.appendChild(li);
+}
+
+const apiKeyInput = document.querySelector<HTMLInputElement>('#api-key')!;
+const modelInput = document.querySelector<HTMLInputElement>('#model')!;
+const reasoningEffortSelect = document.querySelector<HTMLSelectElement>('#reasoning-effort')!;
+const apiSelect = document.querySelector<HTMLSelectElement>('#api-mode')!;
+
+const API_KEY_STORAGE = 'mast-demo-openai-basic-chat.api-key';
+const MODEL_STORAGE = 'mast-demo-openai-basic-chat.model';
+const REASONING_STORAGE = 'mast-demo-openai-basic-chat.reasoning-effort';
+const API_MODE_STORAGE = 'mast-demo-openai-basic-chat.api-mode';
+
+apiKeyInput.value = localStorage.getItem(API_KEY_STORAGE) ?? '';
+modelInput.value = localStorage.getItem(MODEL_STORAGE) ?? modelInput.value;
+reasoningEffortSelect.value = localStorage.getItem(REASONING_STORAGE) ?? '';
+apiSelect.value = localStorage.getItem(API_MODE_STORAGE) ?? apiSelect.value;
+
+// Model names that accept the `reasoning_effort` parameter. Non-reasoning
+// models (gpt-4o, gpt-4.1, ...) reject it with a 400, so the demo only
+// forwards the dropdown value when it's safe.
+function isReasoningModel(name: string): boolean {
+  return /^o\d/i.test(name) || /^gpt-5/i.test(name);
+}
+
+function buildConversation(): Conversation {
+  const modelName = modelInput.value || 'gpt-4o-mini';
+  const reasoningEffort = isReasoningModel(modelName)
+    ? ((reasoningEffortSelect.value || undefined) as ReasoningEffort | undefined)
+    : undefined;
+  const adapter =
+    apiSelect.value === 'responses'
+      ? new OpenAIResponsesAdapter(
+          apiKeyInput.value,
+          modelName,
+          undefined,
+          reasoningEffort ? { reasoningEffort } : undefined,
+        )
+      : new OpenAIChatCompletionsAdapter(
+          apiKeyInput.value,
+          modelName,
+          undefined,
+          reasoningEffort ? { reasoningEffort } : undefined,
+        );
+  const runner = new AgentRunner(adapter, registry);
+  return runner.conversation(agentConfig);
+}
+
+// Built lazily on first send so an empty API key on page load doesn't
+// trip the OpenAI SDK's constructor-time credential check. Invalidated
+// whenever the user changes the key, model, or reasoning effort so the
+// next send picks up the new settings.
+let conversation: Conversation | null = null;
+
+apiKeyInput.addEventListener('change', () => {
+  localStorage.setItem(API_KEY_STORAGE, apiKeyInput.value);
+  conversation = null;
+});
+modelInput.addEventListener('change', () => {
+  localStorage.setItem(MODEL_STORAGE, modelInput.value);
+  conversation = null;
+});
+reasoningEffortSelect.addEventListener('change', () => {
+  localStorage.setItem(REASONING_STORAGE, reasoningEffortSelect.value);
+  conversation = null;
+});
+apiSelect.addEventListener('change', () => {
+  localStorage.setItem(API_MODE_STORAGE, apiSelect.value);
+  conversation = null;
+});
+
+const messageList = document.querySelector('#message-list')!;
+const promptInput = document.querySelector<HTMLTextAreaElement>('#prompt-input')!;
+const sendButton = document.querySelector<HTMLButtonElement>('#send-button')!;
+const stopButton = document.querySelector<HTMLButtonElement>('#stop-button')!;
+const statusIndicator = document.querySelector('#status-indicator')!;
+
+let currentController: AbortController | null = null;
+
+function appendMessage(role: 'user' | 'assistant', content: string): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message ${role}`;
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  bubble.textContent = content;
+  msgEl.appendChild(bubble);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return bubble;
+}
+
+function appendSystemMessage(
+  content: string,
+  type: 'tool' | 'thinking' | 'error' = 'tool',
+): HTMLElement {
+  const msgEl = document.createElement('div');
+  msgEl.className = `message system ${type}`;
+  const small = document.createElement('small');
+  small.textContent = content;
+  msgEl.appendChild(small);
+  messageList.appendChild(msgEl);
+  messageList.scrollTop = messageList.scrollHeight;
+  return msgEl;
+}
+
+async function handleSend() {
+  if (currentController) return;
+
+  const text = promptInput.value.trim();
+  if (!text) return;
+
+  if (!apiKeyInput.value.trim()) {
+    appendSystemMessage('Set an OpenAI API key in the sidebar before sending.', 'error');
+    return;
+  }
+
+  promptInput.value = '';
+  promptInput.disabled = true;
+  sendButton.disabled = true;
+  stopButton.hidden = false;
+
+  appendMessage('user', text);
+
+  const controller = new AbortController();
+  currentController = controller;
+
+  statusIndicator.textContent = 'Running...';
+  statusIndicator.className = 'status-indicator running';
+
+  let assistantBubble: HTMLElement | null = null;
+  let thinkingBubble: HTMLElement | null = null;
+
+  try {
+    if (!conversation) conversation = buildConversation();
+    const stream = conversation.runStream(text, controller.signal);
+
+    for await (const event of stream) {
+      if (event.type === 'thinking') {
+        if (!thinkingBubble) {
+          thinkingBubble = appendSystemMessage('🤔 Thinking: ' + event.delta, 'thinking');
+        } else {
+          thinkingBubble.querySelector('small')!.textContent += event.delta;
+        }
+      } else if (event.type === 'text_delta') {
+        if (!assistantBubble) {
+          assistantBubble = appendMessage('assistant', '');
+        }
+        assistantBubble.textContent += event.delta;
+      } else if (event.type === 'tool_call_started') {
+        thinkingBubble = null;
+        appendSystemMessage(`🔧 Executing: ${event.name}(${JSON.stringify(event.args)})`, 'tool');
+      } else if (event.type === 'tool_call_completed') {
+        appendSystemMessage(`✅ Result: ${JSON.stringify(event.result)}`, 'tool');
+      }
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      console.error(error);
+      appendSystemMessage(
+        `❌ Error: ${error instanceof Error ? error.message : String(error)}`,
+        'error',
+      );
+    }
+  } finally {
+    currentController = null;
+    promptInput.disabled = false;
+    sendButton.disabled = false;
+    stopButton.hidden = true;
+    promptInput.focus();
+    statusIndicator.textContent = 'Idle';
+    statusIndicator.className = 'status-indicator';
+  }
+}
+
+sendButton.addEventListener('click', handleSend);
+stopButton.addEventListener('click', () => currentController?.abort());
+promptInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    handleSend();
+  }
+});

--- a/demos/openai/basic-chat/src/style.css
+++ b/demos/openai/basic-chat/src/style.css
@@ -1,0 +1,256 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  --primary-color: #10a37f;
+  --primary-hover: #0d8a6c;
+  --bg-color: #f4f4f5;
+  --border-color: #e4e4e7;
+}
+
+body,
+html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+.app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar {
+  width: 320px;
+  background-color: var(--bg-color);
+  border-right: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sidebar h2 small {
+  font-size: 0.75rem;
+  color: #71717a;
+  font-weight: normal;
+}
+
+.config-panel label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #52525b;
+  margin-bottom: 0.4rem;
+}
+
+.config-panel input,
+.config-panel select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.config-hint {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+  color: #71717a;
+  line-height: 1.4;
+}
+
+.config-hint code {
+  font-size: 0.75rem;
+  background: #ffffff;
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 0.05em 0.3em;
+}
+
+.tools-panel h3 {
+  font-size: 0.95rem;
+  margin: 0 0 0.5rem;
+}
+
+.tools-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tools-panel li {
+  margin: 0.25rem 0;
+}
+
+.tools-panel li code {
+  background: #ffffff;
+  border: 1px solid var(--border-color);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+}
+
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+}
+
+.message.assistant {
+  align-self: flex-start;
+}
+
+.message.system {
+  align-self: center;
+  max-width: 90%;
+}
+
+.bubble {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.user .bubble {
+  background-color: var(--primary-color);
+  color: white;
+  border-bottom-right-radius: 0;
+}
+
+.assistant .bubble {
+  background-color: var(--bg-color);
+  color: #1a1a1a;
+  border-bottom-left-radius: 0;
+}
+
+.system small {
+  color: #71717a;
+  font-family: monospace;
+  font-size: 0.8rem;
+  background: #f8f8f8;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+}
+
+.system.error small {
+  color: #ef4444;
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.system.thinking small {
+  color: #7c3aed;
+  background: #f5f3ff;
+  border-color: #ddd6fe;
+}
+
+.input-area {
+  padding: 1rem 2rem 2rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  color: #71717a;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-indicator.running {
+  color: var(--primary-color);
+  font-weight: bold;
+}
+
+.input-group {
+  display: flex;
+  gap: 1rem;
+}
+
+textarea {
+  flex: 1;
+  resize: none;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 1rem;
+  height: 60px;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(16, 163, 127, 0.2);
+}
+
+button {
+  padding: 0 1.5rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: var(--primary-hover);
+}
+
+button:disabled {
+  background-color: #86d3bd;
+  cursor: not-allowed;
+}
+
+.stop-button {
+  background-color: #ef4444;
+}
+
+.stop-button:hover {
+  background-color: #dc2626;
+}

--- a/demos/openai/basic-chat/src/tools/calculate.ts
+++ b/demos/openai/basic-chat/src/tools/calculate.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolContext } from '@mast-ai/core';
+
+export class CalculatorTool implements Tool {
+  definition() {
+    return {
+      name: 'calculate',
+      description: 'Evaluates a mathematical expression (e.g. "2 + 2", "54 * 23").',
+      parameters: {
+        type: 'object',
+        properties: {
+          expression: { type: 'string' },
+        },
+        required: ['expression'],
+      },
+      scope: 'read' as const,
+    };
+  }
+
+  async call(args: unknown, _context: ToolContext): Promise<{ result: number }> {
+    const { expression } = args as { expression: string };
+    try {
+      const result = new Function(`return ${expression}`)();
+      return { result };
+    } catch {
+      throw new Error(`Failed to evaluate expression: ${expression}`);
+    }
+  }
+}

--- a/demos/openai/basic-chat/src/tools/getCurrentTime.ts
+++ b/demos/openai/basic-chat/src/tools/getCurrentTime.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolContext } from '@mast-ai/core';
+
+export class GetCurrentTimeTool implements Tool {
+  definition() {
+    return {
+      name: 'getCurrentTime',
+      description: 'Returns the current local time as an ISO-8601 string.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+      scope: 'read' as const,
+    };
+  }
+
+  async call(_args: unknown, _context: ToolContext): Promise<{ time: string }> {
+    return { time: new Date().toISOString() };
+  }
+}

--- a/demos/openai/basic-chat/tsconfig.json
+++ b/demos/openai/basic-chat/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/docs/openai/PRD.md
+++ b/docs/openai/PRD.md
@@ -1,0 +1,91 @@
+# Product Requirements Document: `@mast-ai/openai`
+
+## 1. Summary
+
+`@mast-ai/openai` is the OpenAI counterpart to `@mast-ai/google-genai`. It calls OpenAI directly from the browser, removing the URP backend from the request path for developers who already have an OpenAI key and want a no-server demo or a Chrome extension that talks straight to OpenAI.
+
+The package ships two `LlmAdapter` implementations:
+
+- **`OpenAIChatCompletionsAdapter`** — wraps the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). De-facto-standard endpoint with the broadest model coverage; also works against OpenAI-compatible providers (OpenRouter, DeepSeek).
+- **`OpenAIResponsesAdapter`** — wraps the [Responses API](https://platform.openai.com/docs/api-reference/responses). Required to surface reasoning summaries from `gpt-5` and o-series models as `thinking` events. Chat Completions does not expose reasoning content from OpenAI itself.
+
+## 2. Goals
+
+- **Drop-in adapters for OpenAI.** Anyone using `AgentRunner` with `UrpAdapter` should be able to swap in either adapter and have everything else (tools, conversation history, streaming, structured output) keep working.
+- **Reasoning models from day one.** Reasoning models (`gpt-5`, `o4-mini`, ...) must work out of the box on both adapters. `OpenAIResponsesAdapter` defaults `reasoning.summary` to `"auto"` so thinking events appear with no extra setup.
+- **Mirror `GoogleGenAIAdapter` shape.** Same constructor cadence (`apiKey, modelName, onUsageUpdate, defaults`), same lockstep version, same SDK-mocking test pattern.
+
+## 3. Non-Goals
+
+- **Server-side helpers.** Like all `@mast-ai/*` adapters, this package is browser-native. The `dangerouslyAllowBrowser` flag on the OpenAI SDK is set so the package works in the browser; users are responsible for not exposing keys publicly in production.
+- **Token counting / billing helpers.** Both adapters forward `usage` via `onUsageUpdate` exactly as `GoogleGenAIAdapter` forwards `usageMetadata`. No additional accounting is in scope.
+- **Stateful Responses API conversations.** `OpenAIResponsesAdapter` runs statelessly (`store: false`); the runner's `Conversation` replays history on every request. `previous_response_id` chaining is out of scope for v1.
+- **Encrypted reasoning echoing across turns.** When using `store: false` with reasoning models, OpenAI offers an `include: ['reasoning.encrypted_content']` flow to keep reasoning continuous across multi-turn calls. Not implemented in v1; reasoning starts fresh on each turn.
+
+## 4. Functional Requirements
+
+### `OpenAIChatCompletionsAdapter` (Chat Completions)
+
+- **`generate`** — single round-trip. Translates `AdapterRequest` → `chat.completions.create({ stream: false })`. Maps tool calls back to `AdapterResponse.toolCalls`.
+- **`generateStream`** — async generator. Yields:
+  - `{ type: 'thinking' }` for `delta.reasoning_content` / `delta.reasoning` (OpenAI-compatible providers).
+  - `{ type: 'text_delta' }` for `delta.content`.
+  - `{ type: 'tool_call' }` for accumulated `delta.tool_calls` once `finish_reason === 'tool_calls'`.
+- **Tool support** — function tools mapped 1:1 from `ToolDefinition` to OpenAI `{ type: 'function', function: { name, description, parameters } }`. `tool_calls` and `tool_result` content types are reverse-mapped into Chat Completions message shapes (`role: 'assistant', tool_calls: [...]` and `role: 'tool', tool_call_id, content`).
+- **Structured output** — when `request.outputSchema` is set, `response_format: { type: 'json_schema', json_schema: { name, schema, strict: true } }` is sent.
+- **Reasoning configuration** — `OpenAIChatCompletionsAdapterDefaults.reasoningEffort` is forwarded as `reasoning_effort` on every request. A per-request `request.config.reasoning_effort` overrides the default if the runner ever populates it.
+- **Cancellation** — `request.signal` is forwarded to the OpenAI SDK call.
+
+### `OpenAIResponsesAdapter` (Responses API)
+
+- **`generate`** — `responses.create({ stream: false, store: false })`. Walks the `output[]` array, concatenating `output_text` parts from `message` items into `AdapterResponse.text` and mapping each `function_call` item to `AdapterResponse.toolCalls`.
+- **`generateStream`** — `responses.create({ stream: true, store: false })`. Maps the SSE event stream:
+  - `response.output_text.delta` → `text_delta`
+  - `response.reasoning_summary_text.delta` and `response.reasoning_text.delta` → `thinking`
+  - `response.output_item.done` with a `function_call` item → `tool_call`
+  - `response.completed` → forwards `usage` via `onUsageUpdate`
+- **Input mapping** — `AdapterRequest.messages` becomes a heterogeneous `input` array: text turns are `{ type: 'message', role, content }`, `tool_calls` history items become one `{ type: 'function_call', call_id, name, arguments }` per call, and `tool_result` items become `{ type: 'function_call_output', call_id, output }`.
+- **System prompt** — forwarded as the top-level `instructions` field, not as a message.
+- **Tool support** — `FunctionTool` shape is flat (`{ type: 'function', name, description, parameters, strict: false }`).
+- **Structured output** — `text.format = { type: 'json_schema', name, schema, strict: true }`.
+- **Reasoning configuration** — `OpenAIResponsesAdapterDefaults.reasoningEffort` and `OpenAIResponsesAdapterDefaults.reasoningSummary` are forwarded as `reasoning.effort` and `reasoning.summary`. `reasoningSummary` defaults to `"auto"`; pass `false` to suppress thinking events.
+
+## 5. Test Coverage
+
+Unit tests (mocking the `openai` SDK constructor) must verify:
+
+### `OpenAIChatCompletionsAdapter`
+
+- Plain text generation surfaces `text` and updates usage.
+- Tool calls (single and multiple, in correct order) round-trip through both `generate` and streaming `generateStream`.
+- System instruction is prepended as a `system` message and omitted when absent.
+- `tool_calls` and `tool_result` history messages are translated into the correct OpenAI shapes.
+- `outputSchema` becomes a `json_schema` `response_format`.
+- `temperature`, `maxTokens`, `topP`, `stopSequences` map to OpenAI fields (`temperature`, `max_completion_tokens`, `top_p`, `stop`).
+- `defaults.reasoningEffort` and `request.config.reasoning_effort` both end up as `reasoning_effort` on the request, with the per-request value winning.
+- `delta.reasoning_content` and `delta.reasoning` are emitted as `thinking` chunks.
+- Streaming requests include `stream_options: { include_usage: true }`.
+- Empty `choices` arrays in non-streaming responses raise an error; empty `choices` chunks in streaming responses are skipped.
+
+### `OpenAIResponsesAdapter`
+
+- Plain text generation walks `output[].message.content[]` for `output_text` parts and updates usage from `response.usage` (`input_tokens` / `output_tokens` / `total_tokens`).
+- `function_call` output items map to `AdapterResponse.toolCalls`.
+- System prompt is forwarded as `instructions`, not a message.
+- `store: false` is set on every request.
+- `tool_calls` and `tool_result` history items are emitted as `function_call` and `function_call_output` items in the input array.
+- `FunctionTool` entries are flat (no nested `function: {}`).
+- `defaults.reasoningSummary` defaults to `"auto"` and can be disabled by passing `false`.
+- `defaults.reasoningEffort` becomes `reasoning.effort`; `request.config.reasoning_effort` overrides it.
+- `outputSchema` becomes `text.format = { type: 'json_schema', ... }`.
+- Streaming events `response.output_text.delta`, `response.reasoning_summary_text.delta`, `response.reasoning_text.delta`, and `response.output_item.done` (function call) map to the expected `AdapterStreamChunk` types.
+
+## 6. Demo
+
+`demos/openai/basic-chat` mirrors `demos/core/basic-chat` (calculator + getCurrentTime tools) but talks to OpenAI directly. The sidebar lets the user supply an API key (cached in `localStorage`), choose between the Chat Completions and Responses adapters, pick a model, and optionally choose a reasoning effort level. Any change rebuilds the adapter — and therefore the `Conversation` — so subsequent turns use the new settings.
+
+The reasoning-effort dropdown is honoured only when the model is reasoning-capable (`o*` or `gpt-5*`); for other models it is silently ignored to avoid the API rejecting the request. The Responses adapter is the only path that surfaces reasoning summaries from native OpenAI models.
+
+## 7. Release
+
+`@mast-ai/openai` joins the lockstep release. Its initial version is `0.3.0`; it is bumped alongside `core`, `google-genai`, `built-in-ai`, and `react-ui` from the next release onward. Per the bootstrap procedure in [CLAUDE.md](../../CLAUDE.md#bootstrapping-a-new-package), the very first npm publish must be performed manually before the workflow can take over.

--- a/docs/openai/SPEC.md
+++ b/docs/openai/SPEC.md
@@ -1,0 +1,195 @@
+# Technical Specification: `@mast-ai/openai`
+
+## Public API
+
+```typescript
+import type {
+  LlmAdapter,
+  AdapterRequest,
+  AdapterResponse,
+  AdapterStreamChunk,
+} from '@mast-ai/core';
+
+export interface UsageMetadata {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
+
+export interface OpenAIChatCompletionsAdapterDefaults {
+  /** Forwarded as `reasoning_effort` on every request when set. */
+  reasoningEffort?: ReasoningEffort;
+}
+
+export class OpenAIChatCompletionsAdapter implements LlmAdapter {
+  constructor(
+    apiKey: string,
+    modelName?: string, // defaults to "gpt-4o-mini"
+    onUsageUpdate?: (usage: UsageMetadata) => void,
+    defaults?: OpenAIChatCompletionsAdapterDefaults,
+  );
+
+  generate(request: AdapterRequest): Promise<AdapterResponse>;
+  generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk>;
+}
+
+export type ReasoningSummary = 'auto' | 'concise' | 'detailed';
+
+export interface OpenAIResponsesAdapterDefaults {
+  /** Forwarded as `reasoning.effort` on every request when set. */
+  reasoningEffort?: ReasoningEffort;
+  /**
+   * Forwarded as `reasoning.summary`. Defaults to `"auto"` so reasoning
+   * summary deltas surface as `thinking` events. Pass `false` to suppress.
+   */
+  reasoningSummary?: ReasoningSummary | false;
+}
+
+export class OpenAIResponsesAdapter implements LlmAdapter {
+  constructor(
+    apiKey: string,
+    modelName?: string, // defaults to "gpt-4o-mini"
+    onUsageUpdate?: (usage: UsageMetadata) => void,
+    defaults?: OpenAIResponsesAdapterDefaults,
+  );
+
+  generate(request: AdapterRequest): Promise<AdapterResponse>;
+  generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk>;
+}
+```
+
+Both constructors pass `dangerouslyAllowBrowser: true` to the underlying `OpenAI` client so the adapters work in browsers.
+
+## `OpenAIChatCompletionsAdapter` (Chat Completions)
+
+### Request Translation: `AdapterRequest` → `ChatCompletionCreateParams`
+
+| `AdapterRequest` field     | OpenAI field                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------- |
+| `system`                   | `messages: [{ role: 'system', content }, ...]`                                                    |
+| `messages`                 | `messages: [...]` (translated, see below)                                                         |
+| `tools`                    | `tools: [{ type: 'function', function: { name, description, parameters } }]` (omitted when empty) |
+| `outputSchema`             | `response_format: { type: 'json_schema', json_schema: { name: 'output', schema, strict: true } }` |
+| `signal`                   | passed via SDK `requestOptions.signal`                                                            |
+| `config.temperature`       | `temperature`                                                                                     |
+| `config.maxTokens`         | `max_completion_tokens` (works for both reasoning and non-reasoning models)                       |
+| `config.topP`              | `top_p`                                                                                           |
+| `config.stopSequences`     | `stop`                                                                                            |
+| `config.reasoning_effort`  | `reasoning_effort` (overrides `defaults.reasoningEffort`)                                         |
+| `defaults.reasoningEffort` | `reasoning_effort` (only when `config.reasoning_effort` is unset)                                 |
+
+Streaming requests additionally set `stream: true` and `stream_options: { include_usage: true }` so the final usage chunk is returned.
+
+### Message Translation: `Message` → Chat Completions message
+
+| `MessageContent.type` | OpenAI message shape                                                                                                                |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `'text'`              | `{ role: 'user' \| 'assistant', content: text }`                                                                                    |
+| `'tool_calls'`        | `{ role: 'assistant', content: null, tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }] }` |
+| `'tool_result'`       | `{ role: 'tool', tool_call_id: id, content: typeof result === 'string' ? result : JSON.stringify(result) }`                         |
+
+### Response Translation
+
+#### Non-streaming (`generate`)
+
+- The first `choices[0]` entry is required; if missing, the adapter throws `Error('No choice returned from OpenAI')`.
+- `message.content` becomes `AdapterResponse.text`.
+- `message.tool_calls` is mapped to `AdapterResponse.toolCalls`. Function call arguments are JSON-parsed; on parse failure the raw string is forwarded so the runner can surface it.
+- `usage` is forwarded via `onUsageUpdate` when provided.
+
+#### Streaming (`generateStream`)
+
+For every chunk:
+
+1. Forward `usage` via `onUsageUpdate` if present.
+2. Skip the chunk if `choices` is empty.
+3. If `delta.reasoning_content` or `delta.reasoning` is a non-empty string, yield `{ type: 'thinking', delta }`.
+4. If `delta.content` is a non-empty string, yield `{ type: 'text_delta', delta }`.
+5. Accumulate `delta.tool_calls` fragments into a per-`index` map; on `finish_reason === 'tool_calls'`, emit one `{ type: 'tool_call' }` per accumulated entry in `index` order.
+
+### Reasoning-Model Support
+
+- `OpenAIChatCompletionsAdapterDefaults.reasoningEffort` provides a constructor-time default.
+- Per-request override via `AdapterRequest.config.reasoning_effort` (forward-compatible with future runner-level config plumbing).
+- Reasoning tokens emitted by OpenAI-compatible providers (OpenRouter, DeepSeek, etc.) on `delta.reasoning_content` (or `delta.reasoning`) are forwarded as `thinking` events.
+
+The official OpenAI Chat Completions API does not surface reasoning content; reasoning still happens server-side and is billed as completion tokens. To get `thinking` events from native OpenAI reasoning models, use `OpenAIResponsesAdapter` instead.
+
+## `OpenAIResponsesAdapter` (Responses API)
+
+### Request Translation: `AdapterRequest` → `ResponseCreateParams`
+
+| `AdapterRequest` field      | Responses field                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------- |
+| `system`                    | `instructions: string`                                                                             |
+| `messages`                  | `input: ResponseInputItem[]` (heterogeneous, see below)                                            |
+| `tools`                     | `tools: [{ type: 'function', name, description, parameters, strict: false }]` (omitted when empty) |
+| `outputSchema`              | `text: { format: { type: 'json_schema', name: 'output', schema, strict: true } }`                  |
+| `signal`                    | passed via SDK `requestOptions.signal`                                                             |
+| `config.temperature`        | `temperature`                                                                                      |
+| `config.maxTokens`          | `max_output_tokens`                                                                                |
+| `config.topP`               | `top_p`                                                                                            |
+| `config.reasoning_effort`   | `reasoning.effort` (overrides `defaults.reasoningEffort`)                                          |
+| `defaults.reasoningEffort`  | `reasoning.effort` (only when `config.reasoning_effort` is unset)                                  |
+| `defaults.reasoningSummary` | `reasoning.summary` (defaults to `"auto"`; pass `false` to suppress)                               |
+| _always_                    | `store: false` (caller's `Conversation` replays full history each turn)                            |
+
+### Input Translation: `Message` → `ResponseInputItem`
+
+| `MessageContent.type` | Responses input item                                               |
+| --------------------- | ------------------------------------------------------------------ |
+| `'text'`              | `{ type: 'message', role, content: text }`                         |
+| `'tool_calls'`        | one `{ type: 'function_call', call_id, name, arguments }` per call |
+| `'tool_result'`       | `{ type: 'function_call_output', call_id: id, output }`            |
+
+### Response Translation
+
+#### Non-streaming (`generate`)
+
+Walk `response.output[]`:
+
+- For each `message` item, concatenate `content[].output_text` parts into `AdapterResponse.text`.
+- For each `function_call` item, emit `{ id: call_id, name, args: parseArguments(arguments) }` into `AdapterResponse.toolCalls`.
+- Other item types (`reasoning`, web search, etc.) are ignored in v1.
+- `response.usage` (`input_tokens`, `output_tokens`, `total_tokens`) is forwarded via `onUsageUpdate`.
+
+#### Streaming (`generateStream`)
+
+| Event type                                  | Yielded chunk                                                |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| `response.output_text.delta`                | `{ type: 'text_delta', delta }`                              |
+| `response.reasoning_summary_text.delta`     | `{ type: 'thinking', delta }`                                |
+| `response.reasoning_text.delta`             | `{ type: 'thinking', delta }`                                |
+| `response.output_item.done` (function_call) | `{ type: 'tool_call', toolCall: { id, name, args } }`        |
+| `response.completed`                        | _(no yield)_ — forwards `response.usage` via `onUsageUpdate` |
+
+All other event types (`response.created`, `response.in_progress`, content part lifecycle, audio, MCP/file-search/etc.) are ignored.
+
+### Reasoning Continuity Limitation
+
+`OpenAIResponsesAdapter` runs with `store: false` and does not echo prior `reasoning` items back in subsequent input. Reasoning continuity within a single agent run (across tool round-trips) is therefore not preserved — the model performs reasoning fresh on each call. For continuous reasoning, a follow-up could opt in to `include: ['reasoning.encrypted_content']` and replay reasoning items in the next request's input.
+
+## Error Handling
+
+- Network and HTTP errors raised by the `openai` SDK propagate unchanged to the caller. The adapters do not wrap them in `AdapterError`; they already carry status code and response body context that the runner surfaces verbatim.
+- `Error('No choice returned from OpenAI')` is thrown by `OpenAIChatCompletionsAdapter` only on a malformed non-streaming response.
+
+## File Layout
+
+```
+packages/openai/
+├── src/
+│   ├── OpenAIChatCompletionsAdapter.ts        # Chat Completions adapter
+│   ├── OpenAIChatCompletionsAdapter.test.ts
+│   ├── OpenAIResponsesAdapter.ts       # Responses API adapter
+│   ├── OpenAIResponsesAdapter.test.ts
+│   └── index.ts                        # public exports
+├── package.json
+├── tsconfig.json
+├── LICENSE
+└── README.md
+```
+
+The package depends on `openai@^6` and `@mast-ai/core` only.

--- a/packages/openai/LICENSE
+++ b/packages/openai/LICENSE
@@ -1,0 +1,193 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any patent
+      claim embodied in the Work constitutes direct or contributory patent
+      infringement, then any patent licenses granted to You under this
+      License for that Work shall terminate as of the date such litigation
+      is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, and to permit persons to whom the Contribution is
+      furnished to do so.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of
+      TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      workstop, computer failure or malfunction, or all other commercial
+      damages or losses), even if such Contributor has been advised of the
+      possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the programming language used. Source files
+      may also indicate a copyright notice separately from the text below.
+
+   Copyright 2026 Andre Cipriani Bandarra
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/openai/README.md
+++ b/packages/openai/README.md
@@ -1,0 +1,55 @@
+# @mast-ai/openai
+
+OpenAI `LlmAdapter`s for [MAST](https://github.com/andreban/mast-ai). Calls OpenAI directly from the browser, bypassing the URP backend entirely.
+
+Two adapters ship side by side:
+
+- **`OpenAIChatCompletionsAdapter`** wraps the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). Broad model coverage, works against OpenAI-compatible providers (OpenRouter, DeepSeek). Reasoning content from compatible providers is forwarded as `thinking` events; OpenAI itself does not expose reasoning content via this endpoint.
+- **`OpenAIResponsesAdapter`** wraps the [Responses API](https://platform.openai.com/docs/api-reference/responses). Required to surface reasoning summaries from `gpt-5` and `o-series` models as `thinking` events.
+
+Both support tool calling, streaming, and structured output.
+
+## Install
+
+```bash
+npm install @mast-ai/core @mast-ai/openai
+```
+
+## Chat Completions usage
+
+```typescript
+import { AgentRunner, ToolRegistry, createAgent } from '@mast-ai/core';
+import { OpenAIChatCompletionsAdapter } from '@mast-ai/openai';
+
+const adapter = new OpenAIChatCompletionsAdapter(
+  import.meta.env.VITE_OPENAI_API_KEY,
+  'gpt-4o-mini',
+);
+
+const registry = new ToolRegistry();
+// ...register tools...
+
+const agent = createAgent({ name: 'Assistant', instructions: '...', tools: [] });
+const runner = new AgentRunner(adapter, registry);
+
+const result = await runner.run(agent, 'Hello!');
+```
+
+## Responses API usage (with reasoning)
+
+```typescript
+import { OpenAIResponsesAdapter } from '@mast-ai/openai';
+
+const adapter = new OpenAIResponsesAdapter(apiKey, 'gpt-5', undefined, {
+  reasoningEffort: 'medium',
+  // reasoningSummary defaults to "auto"; set to false to disable thinking events.
+});
+```
+
+`OpenAIResponsesAdapter` runs statelessly (`store: false`) — the runner's `Conversation` history is replayed on every request. With `reasoningSummary` set, every reasoning model call emits `thinking` events alongside the final text.
+
+> **Note:** Calling OpenAI directly from the browser exposes your API key. Use this in trusted contexts (extensions, internal tools, demos) or front it with a proxy that injects the key server-side. Both adapters set `dangerouslyAllowBrowser: true` to permit browser usage of the official OpenAI SDK.
+
+## License
+
+Apache-2.0. Copyright 2026 Andre Cipriani Bandarra.

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mast-ai/openai",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andreban/mast-ai.git",
+    "directory": "packages/openai"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "npm run clean && tsc",
+    "prepublishOnly": "npm run build",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "lint": "eslint src",
+    "format": "prettier --write src"
+  },
+  "dependencies": {
+    "@mast-ai/core": "^0.3.0",
+    "openai": "^6.37.0"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/openai/src/OpenAIChatCompletionsAdapter.test.ts
+++ b/packages/openai/src/OpenAIChatCompletionsAdapter.test.ts
@@ -1,0 +1,552 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenAIChatCompletionsAdapter } from './OpenAIChatCompletionsAdapter.js';
+
+vi.mock('openai', () => {
+  const create = vi.fn().mockResolvedValue({
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content: 'Hello from OpenAI!',
+          tool_calls: [],
+        },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    },
+  });
+
+  return {
+    default: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      this.chat = { completions: { create } };
+    }),
+  };
+});
+
+type MockClient = { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+
+async function getMockClient(): Promise<MockClient> {
+  const OpenAI = (await import('openai')).default as unknown as new () => MockClient;
+  return new OpenAI();
+}
+
+describe('OpenAIChatCompletionsAdapter', () => {
+  let adapter: OpenAIChatCompletionsAdapter;
+  const mockUsageUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new OpenAIChatCompletionsAdapter('fake-api-key', 'gpt-4o-mini', mockUsageUpdate);
+  });
+
+  it('should generate text response', async () => {
+    const response = await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    expect(response.text).toBe('Hello from OpenAI!');
+    expect(mockUsageUpdate).toHaveBeenCalledWith({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('should handle tool calls', async () => {
+    const mockClient = await getMockClient();
+    mockClient.chat.completions.create.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'testTool', arguments: '{"arg1":"val1"}' },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+    });
+
+    const response = await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Call tool' } }],
+      tools: [{ name: 'testTool', description: 'desc', parameters: {}, scope: 'read' as const }],
+    });
+
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls[0]).toEqual({
+      id: 'call_1',
+      name: 'testTool',
+      args: { arg1: 'val1' },
+    });
+    expect(response.text).toBeUndefined();
+  });
+
+  it('should forward a system instruction when provided', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      system: 'You are terse.',
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.messages[0]).toEqual({ role: 'system', content: 'You are terse.' });
+    expect(call.messages[1]).toEqual({ role: 'user', content: 'Hi' });
+  });
+
+  it('should omit the system instruction when not provided', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.messages).toHaveLength(1);
+    expect(call.messages[0]).toEqual({ role: 'user', content: 'Hi' });
+  });
+
+  it('should map tool_calls and tool_result messages back to OpenAI format', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [
+        { role: 'user', content: { type: 'text', text: 'Compute 2+2' } },
+        {
+          role: 'assistant',
+          content: {
+            type: 'tool_calls',
+            calls: [{ id: 'call_a', name: 'calc', args: { expr: '2+2' } }],
+          },
+        },
+        {
+          role: 'user',
+          content: { type: 'tool_result', id: 'call_a', name: 'calc', result: { value: 4 } },
+        },
+      ],
+      tools: [{ name: 'calc', description: 'd', parameters: {}, scope: 'read' as const }],
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.messages[1]).toEqual({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call_a',
+          type: 'function',
+          function: { name: 'calc', arguments: '{"expr":"2+2"}' },
+        },
+      ],
+    });
+    expect(call.messages[2]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_a',
+      content: '{"value":4}',
+    });
+  });
+
+  it('should map ToolDefinitions to OpenAI function tools', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [
+        {
+          name: 'lookup',
+          description: 'Looks something up',
+          parameters: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+          scope: 'read' as const,
+        },
+      ],
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.tools).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'lookup',
+          description: 'Looks something up',
+          parameters: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+        },
+      },
+    ]);
+  });
+
+  it('should leave tools undefined when no tools are provided', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.tools).toBeUndefined();
+  });
+
+  it('should forward outputSchema as a json_schema response_format', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      outputSchema: {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+      },
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: {
+        name: 'output',
+        schema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+        strict: true,
+      },
+    });
+  });
+
+  it('should forward reasoning_effort from ModelConfig', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      config: { reasoning_effort: 'medium' },
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning_effort).toBe('medium');
+  });
+
+  it('should apply defaults.reasoningEffort to every request', async () => {
+    const mockClient = await getMockClient();
+
+    const reasoningAdapter = new OpenAIChatCompletionsAdapter('fake-api-key', 'gpt-5', undefined, {
+      reasoningEffort: 'high',
+    });
+    await reasoningAdapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning_effort).toBe('high');
+  });
+
+  it('should let request.config.reasoning_effort override defaults.reasoningEffort', async () => {
+    const mockClient = await getMockClient();
+
+    const reasoningAdapter = new OpenAIChatCompletionsAdapter('fake-api-key', 'gpt-5', undefined, {
+      reasoningEffort: 'high',
+    });
+    await reasoningAdapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      config: { reasoning_effort: 'low' },
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning_effort).toBe('low');
+  });
+
+  it('should map ModelConfig to OpenAI request fields', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      config: {
+        temperature: 0.4,
+        maxTokens: 1000,
+        topP: 0.9,
+        stopSequences: ['STOP'],
+      },
+    });
+
+    const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+    expect(call.temperature).toBe(0.4);
+    expect(call.max_completion_tokens).toBe(1000);
+    expect(call.top_p).toBe(0.9);
+    expect(call.stop).toEqual(['STOP']);
+  });
+
+  it('should throw when no choice is returned from generate', async () => {
+    const mockClient = await getMockClient();
+    mockClient.chat.completions.create.mockResolvedValueOnce({
+      choices: [],
+      usage: { prompt_tokens: 5, completion_tokens: 0, total_tokens: 5 },
+    });
+
+    await expect(
+      adapter.generate({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      }),
+    ).rejects.toThrow('No choice returned from OpenAI');
+  });
+
+  describe('generateStream', () => {
+    async function collectChunks(
+      request: Parameters<OpenAIChatCompletionsAdapter['generateStream']>[0],
+    ) {
+      const chunks: { type: string; delta?: string; toolCall?: unknown }[] = [];
+      for await (const chunk of adapter.generateStream(request)) {
+        chunks.push(chunk as never);
+      }
+      return chunks;
+    }
+
+    it('should yield text_delta chunks for streamed content', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            choices: [{ delta: { content: 'Hello ' }, finish_reason: null, index: 0 }],
+          };
+          yield {
+            choices: [{ delta: { content: 'world' }, finish_reason: null, index: 0 }],
+          };
+          yield {
+            choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+            usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([
+        { type: 'text_delta', delta: 'Hello ' },
+        { type: 'text_delta', delta: 'world' },
+      ]);
+      expect(mockUsageUpdate).toHaveBeenCalledWith({
+        promptTokens: 3,
+        completionTokens: 2,
+        totalTokens: 5,
+      });
+    });
+
+    it('should yield thinking chunks for delta.reasoning_content', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            choices: [
+              { delta: { reasoning_content: 'Considering...' }, finish_reason: null, index: 0 },
+            ],
+          };
+          yield {
+            choices: [{ delta: { content: 'Done.' }, finish_reason: null, index: 0 }],
+          };
+          yield {
+            choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([
+        { type: 'thinking', delta: 'Considering...' },
+        { type: 'text_delta', delta: 'Done.' },
+      ]);
+    });
+
+    it('should also map delta.reasoning to thinking events', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            choices: [{ delta: { reasoning: 'hmm...' }, finish_reason: null, index: 0 }],
+          };
+          yield {
+            choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([{ type: 'thinking', delta: 'hmm...' }]);
+    });
+
+    it('should accumulate streamed tool call fragments and emit one tool_call chunk', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_1',
+                      type: 'function',
+                      function: { name: 'lookup', arguments: '{"q":"' },
+                    },
+                  ],
+                },
+                finish_reason: null,
+                index: 0,
+              },
+            ],
+          };
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [{ index: 0, function: { arguments: 'mast' } }],
+                },
+                finish_reason: null,
+                index: 0,
+              },
+            ],
+          };
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [{ index: 0, function: { arguments: '"}' } }],
+                },
+                finish_reason: null,
+                index: 0,
+              },
+            ],
+          };
+          yield {
+            choices: [{ delta: {}, finish_reason: 'tool_calls', index: 0 }],
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [{ name: 'lookup', description: 'd', parameters: {}, scope: 'read' as const }],
+      });
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toEqual({
+        type: 'tool_call',
+        toolCall: { id: 'call_1', name: 'lookup', args: { q: 'mast' } },
+      });
+    });
+
+    it('should emit multiple tool calls in index order', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 1,
+                      id: 'call_b',
+                      type: 'function',
+                      function: { name: 'second', arguments: '{}' },
+                    },
+                    {
+                      index: 0,
+                      id: 'call_a',
+                      type: 'function',
+                      function: { name: 'first', arguments: '{}' },
+                    },
+                  ],
+                },
+                finish_reason: 'tool_calls',
+                index: 0,
+              },
+            ],
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [
+          { name: 'first', description: 'd', parameters: {}, scope: 'read' as const },
+          { name: 'second', description: 'd', parameters: {}, scope: 'read' as const },
+        ],
+      });
+
+      expect(chunks).toHaveLength(2);
+      expect((chunks[0] as { toolCall: { name: string } }).toolCall.name).toBe('first');
+      expect((chunks[1] as { toolCall: { name: string } }).toolCall.name).toBe('second');
+    });
+
+    it('should request usage in the streaming request', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop', index: 0 }] };
+        })(),
+      );
+
+      for await (const _chunk of adapter.generateStream({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      })) {
+        void _chunk;
+      }
+
+      const call = mockClient.chat.completions.create.mock.calls.at(-1)?.[0];
+      expect(call.stream).toBe(true);
+      expect(call.stream_options).toEqual({ include_usage: true });
+    });
+
+    it('should skip chunks with no choices', async () => {
+      const mockClient = await getMockClient();
+      mockClient.chat.completions.create.mockResolvedValueOnce(
+        (async function* () {
+          yield { choices: [] };
+          yield {
+            choices: [{ delta: { content: 'hello' }, finish_reason: 'stop', index: 0 }],
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([{ type: 'text_delta', delta: 'hello' }]);
+    });
+  });
+});

--- a/packages/openai/src/OpenAIChatCompletionsAdapter.ts
+++ b/packages/openai/src/OpenAIChatCompletionsAdapter.ts
@@ -1,0 +1,302 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import OpenAI from 'openai';
+import type {
+  ChatCompletionTool,
+  ChatCompletionMessageParam,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from 'openai/resources/chat/completions';
+import type {
+  LlmAdapter,
+  AdapterRequest,
+  AdapterResponse,
+  AdapterStreamChunk,
+  Message,
+  ToolDefinition,
+} from '@mast-ai/core';
+
+/** Token-usage statistics reported by the OpenAI Chat Completions API. */
+export interface UsageMetadata {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+/** Reasoning-effort level for o-series and gpt-5 models. */
+export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
+
+/** Per-request defaults applied to every call made by an {@link OpenAIChatCompletionsAdapter}. */
+export interface OpenAIChatCompletionsAdapterDefaults {
+  /**
+   * Forwarded as `reasoning_effort` on every request. Reasoning models honour
+   * this; non-reasoning models reject the field, so set it only when the
+   * configured `modelName` is a reasoning model.
+   */
+  reasoningEffort?: ReasoningEffort;
+}
+
+type ReasoningDelta = {
+  reasoning_content?: string | null;
+  reasoning?: string | null;
+};
+
+/**
+ * {@link LlmAdapter} implementation backed by the OpenAI Chat Completions API.
+ *
+ * Supports tool calling, structured output via JSON Schema, and streaming.
+ * Reasoning models (o-series, gpt-5, ...) work out of the box: pass
+ * `reasoning_effort` through `ModelConfig` and any reasoning content the model
+ * exposes via `delta.reasoning_content` (used by OpenAI-compatible providers
+ * such as OpenRouter and DeepSeek) is forwarded as `thinking` events.
+ *
+ * To surface reasoning content from native OpenAI reasoning models, use
+ * {@link OpenAIResponsesAdapter} instead — Chat Completions does not return
+ * reasoning tokens for OpenAI's own models.
+ */
+export class OpenAIChatCompletionsAdapter implements LlmAdapter {
+  private client: OpenAI;
+  private modelName: string;
+  private onUsageUpdate?: (usage: UsageMetadata) => void;
+  private defaults: OpenAIChatCompletionsAdapterDefaults;
+
+  /**
+   * @param apiKey - OpenAI API key.
+   * @param modelName - Model identifier (defaults to `"gpt-4o-mini"`). Any
+   *   chat-completion-compatible model works, including reasoning models.
+   * @param onUsageUpdate - Optional callback invoked with token-usage data after each response.
+   * @param defaults - Provider-specific defaults applied to every request
+   *   (e.g. `reasoningEffort` for o-series / gpt-5).
+   */
+  constructor(
+    apiKey: string,
+    modelName: string = 'gpt-4o-mini',
+    onUsageUpdate?: (usage: UsageMetadata) => void,
+    defaults?: OpenAIChatCompletionsAdapterDefaults,
+  ) {
+    this.client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+    this.modelName = modelName;
+    this.onUsageUpdate = onUsageUpdate;
+    this.defaults = defaults ?? {};
+  }
+
+  private buildTools(request: AdapterRequest): ChatCompletionTool[] | undefined {
+    if (request.tools.length === 0) return undefined;
+    return request.tools.map((t) => this.mapTool(t));
+  }
+
+  private buildBaseParams(
+    request: AdapterRequest,
+  ): Omit<ChatCompletionCreateParamsNonStreaming, 'stream'> {
+    const messages = this.mapMessages(request);
+    const tools = this.buildTools(request);
+    const config = (request.config ?? {}) as Record<string, unknown>;
+
+    const reasoningEffort =
+      (typeof config.reasoning_effort === 'string'
+        ? (config.reasoning_effort as ReasoningEffort)
+        : undefined) ?? this.defaults.reasoningEffort;
+
+    const params: Omit<ChatCompletionCreateParamsNonStreaming, 'stream'> = {
+      model: this.modelName,
+      messages,
+      ...(tools ? { tools } : {}),
+      ...(typeof config.temperature === 'number' ? { temperature: config.temperature } : {}),
+      ...(typeof config.maxTokens === 'number' ? { max_completion_tokens: config.maxTokens } : {}),
+      ...(typeof config.topP === 'number' ? { top_p: config.topP } : {}),
+      ...(Array.isArray(config.stopSequences) ? { stop: config.stopSequences as string[] } : {}),
+      ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+      ...(request.outputSchema
+        ? {
+            response_format: {
+              type: 'json_schema',
+              json_schema: {
+                name: 'output',
+                schema: request.outputSchema,
+                strict: true,
+              },
+            },
+          }
+        : {}),
+    };
+
+    return params;
+  }
+
+  /** {@inheritDoc LlmAdapter.generate} */
+  async generate(request: AdapterRequest): Promise<AdapterResponse> {
+    const params: ChatCompletionCreateParamsNonStreaming = {
+      ...this.buildBaseParams(request),
+      stream: false,
+    };
+
+    const response = await this.client.chat.completions.create(params, { signal: request.signal });
+
+    if (response.usage && this.onUsageUpdate) {
+      this.onUsageUpdate({
+        promptTokens: response.usage.prompt_tokens,
+        completionTokens: response.usage.completion_tokens,
+        totalTokens: response.usage.total_tokens,
+      });
+    }
+
+    const choice = response.choices?.[0];
+    if (!choice) {
+      throw new Error('No choice returned from OpenAI');
+    }
+
+    const message = choice.message;
+    return {
+      text:
+        typeof message.content === 'string' && message.content.length > 0
+          ? message.content
+          : undefined,
+      toolCalls: (message.tool_calls ?? []).flatMap((tc) =>
+        tc.type === 'function'
+          ? [
+              {
+                id: tc.id,
+                name: tc.function.name,
+                args: parseArguments(tc.function.arguments),
+              },
+            ]
+          : [],
+      ),
+    };
+  }
+
+  /** {@inheritDoc LlmAdapter.generateStream} */
+  async *generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk> {
+    const params: ChatCompletionCreateParamsStreaming = {
+      ...this.buildBaseParams(request),
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+
+    const stream = await this.client.chat.completions.create(params, { signal: request.signal });
+
+    const accumulators = new Map<number, { id?: string; name?: string; args: string }>();
+
+    for await (const chunk of stream) {
+      if (chunk.usage && this.onUsageUpdate) {
+        this.onUsageUpdate({
+          promptTokens: chunk.usage.prompt_tokens,
+          completionTokens: chunk.usage.completion_tokens,
+          totalTokens: chunk.usage.total_tokens,
+        });
+      }
+
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+
+      const delta = choice.delta as typeof choice.delta & ReasoningDelta;
+
+      const reasoning = delta.reasoning_content ?? delta.reasoning;
+      if (typeof reasoning === 'string' && reasoning.length > 0) {
+        yield { type: 'thinking', delta: reasoning };
+      }
+
+      if (typeof delta.content === 'string' && delta.content.length > 0) {
+        yield { type: 'text_delta', delta: delta.content };
+      }
+
+      if (delta.tool_calls) {
+        for (const tcDelta of delta.tool_calls) {
+          if (tcDelta.type !== undefined && tcDelta.type !== 'function') continue;
+          const idx = tcDelta.index;
+          let acc = accumulators.get(idx);
+          if (!acc) {
+            acc = { args: '' };
+            accumulators.set(idx, acc);
+          }
+          if (tcDelta.id) acc.id = tcDelta.id;
+          if (tcDelta.function?.name) acc.name = tcDelta.function.name;
+          if (tcDelta.function?.arguments) acc.args += tcDelta.function.arguments;
+        }
+      }
+
+      if (choice.finish_reason === 'tool_calls') {
+        const indices = [...accumulators.keys()].sort((a, b) => a - b);
+        for (const idx of indices) {
+          const acc = accumulators.get(idx)!;
+          if (!acc.name) continue;
+          yield {
+            type: 'tool_call',
+            toolCall: {
+              id: acc.id ?? crypto.randomUUID(),
+              name: acc.name,
+              args: parseArguments(acc.args),
+            },
+          };
+        }
+        accumulators.clear();
+      }
+    }
+  }
+
+  private mapMessages(request: AdapterRequest): ChatCompletionMessageParam[] {
+    const result: ChatCompletionMessageParam[] = [];
+    if (request.system) {
+      result.push({ role: 'system', content: request.system });
+    }
+    for (const message of request.messages) {
+      const mapped = mapMessage(message);
+      if (mapped.length > 0) result.push(...mapped);
+    }
+    return result;
+  }
+
+  private mapTool(tool: ToolDefinition): ChatCompletionTool {
+    return {
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    };
+  }
+}
+
+function mapMessage(message: Message): ChatCompletionMessageParam[] {
+  if (message.content.type === 'text') {
+    return [{ role: message.role, content: message.content.text }];
+  }
+  if (message.content.type === 'tool_calls') {
+    return [
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: message.content.calls.map((call) => ({
+          id: call.id,
+          type: 'function',
+          function: {
+            name: call.name,
+            arguments: typeof call.args === 'string' ? call.args : JSON.stringify(call.args ?? {}),
+          },
+        })),
+      },
+    ];
+  }
+  // tool_result -> { role: 'tool', tool_call_id, content }
+  return [
+    {
+      role: 'tool',
+      tool_call_id: message.content.id,
+      content:
+        typeof message.content.result === 'string'
+          ? message.content.result
+          : JSON.stringify(message.content.result),
+    },
+  ];
+}
+
+function parseArguments(raw: string | undefined): unknown {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/openai/src/OpenAIResponsesAdapter.test.ts
+++ b/packages/openai/src/OpenAIResponsesAdapter.test.ts
@@ -1,0 +1,370 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenAIResponsesAdapter } from './OpenAIResponsesAdapter.js';
+
+vi.mock('openai', () => {
+  const create = vi.fn().mockResolvedValue({
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello from Responses!' }],
+      },
+    ],
+    usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+  });
+
+  return {
+    default: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      this.responses = { create };
+    }),
+  };
+});
+
+type MockClient = { responses: { create: ReturnType<typeof vi.fn> } };
+
+async function getMockClient(): Promise<MockClient> {
+  const OpenAI = (await import('openai')).default as unknown as new () => MockClient;
+  return new OpenAI();
+}
+
+describe('OpenAIResponsesAdapter', () => {
+  let adapter: OpenAIResponsesAdapter;
+  const mockUsageUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new OpenAIResponsesAdapter('fake-api-key', 'gpt-5', mockUsageUpdate);
+  });
+
+  it('should generate text response', async () => {
+    const response = await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    expect(response.text).toBe('Hello from Responses!');
+    expect(mockUsageUpdate).toHaveBeenCalledWith({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('should map function_call output items to AdapterResponse.toolCalls', async () => {
+    const mockClient = await getMockClient();
+    mockClient.responses.create.mockResolvedValueOnce({
+      output: [
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'testTool',
+          arguments: '{"arg1":"val1"}',
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 5, total_tokens: 10 },
+    });
+
+    const response = await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Call tool' } }],
+      tools: [{ name: 'testTool', description: 'desc', parameters: {}, scope: 'read' as const }],
+    });
+
+    expect(response.toolCalls).toEqual([
+      { id: 'call_1', name: 'testTool', args: { arg1: 'val1' } },
+    ]);
+    expect(response.text).toBeUndefined();
+  });
+
+  it('should forward request.system as instructions and use store: false', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      system: 'You are terse.',
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.instructions).toBe('You are terse.');
+    expect(call.store).toBe(false);
+  });
+
+  it('should map ToolDefinitions to flat FunctionTool entries', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [
+        {
+          name: 'lookup',
+          description: 'Looks something up',
+          parameters: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+          scope: 'read' as const,
+        },
+      ],
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.tools).toEqual([
+      {
+        type: 'function',
+        name: 'lookup',
+        description: 'Looks something up',
+        parameters: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+        strict: false,
+      },
+    ]);
+  });
+
+  it('should map tool_calls and tool_result history into the input array', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [
+        { role: 'user', content: { type: 'text', text: 'Compute 2+2' } },
+        {
+          role: 'assistant',
+          content: {
+            type: 'tool_calls',
+            calls: [{ id: 'call_a', name: 'calc', args: { expr: '2+2' } }],
+          },
+        },
+        {
+          role: 'user',
+          content: { type: 'tool_result', id: 'call_a', name: 'calc', result: { value: 4 } },
+        },
+      ],
+      tools: [{ name: 'calc', description: 'd', parameters: {}, scope: 'read' as const }],
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.input).toEqual([
+      { type: 'message', role: 'user', content: 'Compute 2+2' },
+      {
+        type: 'function_call',
+        call_id: 'call_a',
+        name: 'calc',
+        arguments: '{"expr":"2+2"}',
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'call_a',
+        output: '{"value":4}',
+      },
+    ]);
+  });
+
+  it('should default reasoning.summary to "auto"', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning).toEqual({ summary: 'auto' });
+  });
+
+  it('should disable reasoning summary when defaults.reasoningSummary is false', async () => {
+    const mockClient = await getMockClient();
+
+    const off = new OpenAIResponsesAdapter('fake-api-key', 'gpt-5', undefined, {
+      reasoningSummary: false,
+    });
+    await off.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning).toBeUndefined();
+  });
+
+  it('should forward defaults.reasoningEffort and override with config.reasoning_effort', async () => {
+    const mockClient = await getMockClient();
+
+    const adapterWithDefaults = new OpenAIResponsesAdapter('fake-api-key', 'gpt-5', undefined, {
+      reasoningEffort: 'high',
+    });
+    await adapterWithDefaults.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+    });
+
+    let call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+
+    await adapterWithDefaults.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      config: { reasoning_effort: 'low' },
+    });
+
+    call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.reasoning).toEqual({ effort: 'low', summary: 'auto' });
+  });
+
+  it('should forward outputSchema as a json_schema text format', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      outputSchema: { type: 'object', properties: { answer: { type: 'string' } } },
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.text).toEqual({
+      format: {
+        type: 'json_schema',
+        name: 'output',
+        schema: { type: 'object', properties: { answer: { type: 'string' } } },
+        strict: true,
+      },
+    });
+  });
+
+  it('should map ModelConfig to OpenAI Responses request fields', async () => {
+    const mockClient = await getMockClient();
+
+    await adapter.generate({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+      tools: [],
+      config: { temperature: 0.4, maxTokens: 1000, topP: 0.9 },
+    });
+
+    const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+    expect(call.temperature).toBe(0.4);
+    expect(call.max_output_tokens).toBe(1000);
+    expect(call.top_p).toBe(0.9);
+  });
+
+  describe('generateStream', () => {
+    async function collectChunks(request: Parameters<OpenAIResponsesAdapter['generateStream']>[0]) {
+      const chunks: { type: string; delta?: string; toolCall?: unknown }[] = [];
+      for await (const chunk of adapter.generateStream(request)) {
+        chunks.push(chunk as never);
+      }
+      return chunks;
+    }
+
+    it('should yield thinking chunks for reasoning summary deltas', async () => {
+      const mockClient = await getMockClient();
+      mockClient.responses.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            type: 'response.reasoning_summary_text.delta',
+            delta: 'Considering the question...',
+          };
+          yield { type: 'response.output_text.delta', delta: 'Done.' };
+          yield {
+            type: 'response.completed',
+            response: { usage: { input_tokens: 3, output_tokens: 2, total_tokens: 5 } },
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([
+        { type: 'thinking', delta: 'Considering the question...' },
+        { type: 'text_delta', delta: 'Done.' },
+      ]);
+      expect(mockUsageUpdate).toHaveBeenCalledWith({
+        promptTokens: 3,
+        completionTokens: 2,
+        totalTokens: 5,
+      });
+    });
+
+    it('should also map response.reasoning_text.delta to thinking events', async () => {
+      const mockClient = await getMockClient();
+      mockClient.responses.create.mockResolvedValueOnce(
+        (async function* () {
+          yield { type: 'response.reasoning_text.delta', delta: 'inner monologue' };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([{ type: 'thinking', delta: 'inner monologue' }]);
+    });
+
+    it('should yield tool_call chunks when an output_item.done event carries a function_call', async () => {
+      const mockClient = await getMockClient();
+      mockClient.responses.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            type: 'response.output_item.done',
+            item: {
+              type: 'function_call',
+              call_id: 'call_1',
+              name: 'lookup',
+              arguments: '{"q":"mast"}',
+            },
+          };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [{ name: 'lookup', description: 'd', parameters: {}, scope: 'read' as const }],
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_call',
+          toolCall: { id: 'call_1', name: 'lookup', args: { q: 'mast' } },
+        },
+      ]);
+    });
+
+    it('should ignore non-function_call output items', async () => {
+      const mockClient = await getMockClient();
+      mockClient.responses.create.mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            type: 'response.output_item.done',
+            item: { type: 'reasoning', id: 'r1', summary: [] },
+          };
+          yield { type: 'response.output_text.delta', delta: 'ok' };
+        })(),
+      );
+
+      const chunks = await collectChunks({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      });
+
+      expect(chunks).toEqual([{ type: 'text_delta', delta: 'ok' }]);
+    });
+
+    it('should request streaming mode in the SDK call', async () => {
+      const mockClient = await getMockClient();
+      mockClient.responses.create.mockResolvedValueOnce(
+        (async function* () {
+          yield { type: 'response.output_text.delta', delta: 'ok' };
+        })(),
+      );
+
+      for await (const _chunk of adapter.generateStream({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Hi' } }],
+        tools: [],
+      })) {
+        void _chunk;
+      }
+
+      const call = mockClient.responses.create.mock.calls.at(-1)?.[0];
+      expect(call.stream).toBe(true);
+    });
+  });
+});

--- a/packages/openai/src/OpenAIResponsesAdapter.ts
+++ b/packages/openai/src/OpenAIResponsesAdapter.ts
@@ -1,0 +1,278 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import OpenAI from 'openai';
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseCreateParamsStreaming,
+  ResponseInputItem,
+  ResponseOutputItem,
+  FunctionTool,
+  Tool as ResponseTool,
+} from 'openai/resources/responses/responses';
+import type {
+  LlmAdapter,
+  AdapterRequest,
+  AdapterResponse,
+  AdapterStreamChunk,
+  Message,
+  ToolDefinition,
+} from '@mast-ai/core';
+import type { ReasoningEffort, UsageMetadata } from './OpenAIChatCompletionsAdapter.js';
+
+/** Reasoning-summary verbosity that gates what the model emits as `thinking` events. */
+export type ReasoningSummary = 'auto' | 'concise' | 'detailed';
+
+/** Per-request defaults applied to every call made by an {@link OpenAIResponsesAdapter}. */
+export interface OpenAIResponsesAdapterDefaults {
+  /** Forwarded as `reasoning.effort` on every request. Reasoning models honour this. */
+  reasoningEffort?: ReasoningEffort;
+  /**
+   * Forwarded as `reasoning.summary` on every request. Required to receive
+   * reasoning summary deltas as `thinking` events. Defaults to `"auto"` so
+   * reasoning models surface thinking content without extra configuration.
+   * Set to `false` to disable.
+   */
+  reasoningSummary?: ReasoningSummary | false;
+}
+
+/**
+ * {@link LlmAdapter} implementation backed by the OpenAI Responses API
+ * (`/v1/responses`).
+ *
+ * Unlike {@link OpenAIChatCompletionsAdapter}, this adapter surfaces reasoning
+ * content from reasoning models — `gpt-5`, `o-series` — as `thinking` events.
+ * The adapter runs statelessly (`store: false`); the caller's `Conversation`
+ * history is replayed on every request.
+ */
+export class OpenAIResponsesAdapter implements LlmAdapter {
+  private client: OpenAI;
+  private modelName: string;
+  private onUsageUpdate?: (usage: UsageMetadata) => void;
+  private defaults: OpenAIResponsesAdapterDefaults;
+
+  /**
+   * @param apiKey - OpenAI API key.
+   * @param modelName - Model identifier (defaults to `"gpt-4o-mini"`). Any
+   *   Responses-API-compatible model works, including reasoning models.
+   * @param onUsageUpdate - Optional callback invoked with token-usage data after each response.
+   * @param defaults - Provider-specific defaults applied to every request.
+   */
+  constructor(
+    apiKey: string,
+    modelName: string = 'gpt-4o-mini',
+    onUsageUpdate?: (usage: UsageMetadata) => void,
+    defaults?: OpenAIResponsesAdapterDefaults,
+  ) {
+    this.client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+    this.modelName = modelName;
+    this.onUsageUpdate = onUsageUpdate;
+    this.defaults = defaults ?? {};
+  }
+
+  private buildBaseParams(
+    request: AdapterRequest,
+  ): Omit<ResponseCreateParamsNonStreaming, 'stream'> {
+    const input = mapInput(request.messages);
+    const tools = mapTools(request.tools);
+    const config = (request.config ?? {}) as Record<string, unknown>;
+
+    const reasoningEffort =
+      (typeof config.reasoning_effort === 'string'
+        ? (config.reasoning_effort as ReasoningEffort)
+        : undefined) ?? this.defaults.reasoningEffort;
+
+    const reasoningSummary =
+      this.defaults.reasoningSummary === false
+        ? undefined
+        : (this.defaults.reasoningSummary ?? 'auto');
+
+    const params: Omit<ResponseCreateParamsNonStreaming, 'stream'> = {
+      model: this.modelName,
+      input,
+      ...(request.system ? { instructions: request.system } : {}),
+      ...(tools ? { tools } : {}),
+      store: false,
+      ...(typeof config.temperature === 'number' ? { temperature: config.temperature } : {}),
+      ...(typeof config.maxTokens === 'number' ? { max_output_tokens: config.maxTokens } : {}),
+      ...(typeof config.topP === 'number' ? { top_p: config.topP } : {}),
+      ...(reasoningEffort || reasoningSummary
+        ? {
+            reasoning: {
+              ...(reasoningEffort ? { effort: reasoningEffort } : {}),
+              ...(reasoningSummary ? { summary: reasoningSummary } : {}),
+            },
+          }
+        : {}),
+      ...(request.outputSchema
+        ? {
+            text: {
+              format: {
+                type: 'json_schema',
+                name: 'output',
+                schema: request.outputSchema,
+                strict: true,
+              },
+            },
+          }
+        : {}),
+    };
+
+    return params;
+  }
+
+  /** {@inheritDoc LlmAdapter.generate} */
+  async generate(request: AdapterRequest): Promise<AdapterResponse> {
+    const params: ResponseCreateParamsNonStreaming = {
+      ...this.buildBaseParams(request),
+      stream: false,
+    };
+
+    const response = await this.client.responses.create(params, { signal: request.signal });
+
+    if (response.usage && this.onUsageUpdate) {
+      this.onUsageUpdate({
+        promptTokens: response.usage.input_tokens,
+        completionTokens: response.usage.output_tokens,
+        totalTokens: response.usage.total_tokens,
+      });
+    }
+
+    let text: string | undefined;
+    const toolCalls: AdapterResponse['toolCalls'] = [];
+
+    for (const item of response.output ?? []) {
+      const parsed = parseOutputItem(item);
+      if (parsed.text !== undefined) {
+        text = (text ?? '') + parsed.text;
+      }
+      if (parsed.toolCall) {
+        toolCalls.push(parsed.toolCall);
+      }
+    }
+
+    return { text, toolCalls };
+  }
+
+  /** {@inheritDoc LlmAdapter.generateStream} */
+  async *generateStream(request: AdapterRequest): AsyncIterable<AdapterStreamChunk> {
+    const params: ResponseCreateParamsStreaming = {
+      ...this.buildBaseParams(request),
+      stream: true,
+    };
+
+    const stream = await this.client.responses.create(params, { signal: request.signal });
+
+    for await (const event of stream) {
+      switch (event.type) {
+        case 'response.output_text.delta':
+          if (event.delta) yield { type: 'text_delta', delta: event.delta };
+          break;
+        case 'response.reasoning_summary_text.delta':
+        case 'response.reasoning_text.delta':
+          if (event.delta) yield { type: 'thinking', delta: event.delta };
+          break;
+        case 'response.output_item.done':
+          if (event.item.type === 'function_call') {
+            yield {
+              type: 'tool_call',
+              toolCall: {
+                id: event.item.call_id,
+                name: event.item.name,
+                args: parseArguments(event.item.arguments),
+              },
+            };
+          }
+          break;
+        case 'response.completed':
+          if (event.response.usage && this.onUsageUpdate) {
+            this.onUsageUpdate({
+              promptTokens: event.response.usage.input_tokens,
+              completionTokens: event.response.usage.output_tokens,
+              totalTokens: event.response.usage.total_tokens,
+            });
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}
+
+function mapTools(tools: ToolDefinition[]): ResponseTool[] | undefined {
+  if (tools.length === 0) return undefined;
+  return tools.map(
+    (t): FunctionTool => ({
+      type: 'function',
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+      strict: false,
+    }),
+  );
+}
+
+function mapInput(messages: Message[]): ResponseInputItem[] {
+  const items: ResponseInputItem[] = [];
+  for (const message of messages) {
+    if (message.content.type === 'text') {
+      items.push({
+        type: 'message',
+        role: message.role,
+        content: message.content.text,
+      });
+    } else if (message.content.type === 'tool_calls') {
+      for (const call of message.content.calls) {
+        items.push({
+          type: 'function_call',
+          call_id: call.id,
+          name: call.name,
+          arguments: typeof call.args === 'string' ? call.args : JSON.stringify(call.args ?? {}),
+        });
+      }
+    } else {
+      items.push({
+        type: 'function_call_output',
+        call_id: message.content.id,
+        output:
+          typeof message.content.result === 'string'
+            ? message.content.result
+            : JSON.stringify(message.content.result),
+      });
+    }
+  }
+  return items;
+}
+
+function parseOutputItem(item: ResponseOutputItem): {
+  text?: string;
+  toolCall?: AdapterResponse['toolCalls'][number];
+} {
+  if (item.type === 'message') {
+    let text = '';
+    for (const part of item.content) {
+      if (part.type === 'output_text') text += part.text;
+    }
+    return text ? { text } : {};
+  }
+  if (item.type === 'function_call') {
+    return {
+      toolCall: {
+        id: item.call_id,
+        name: item.name,
+        args: parseArguments(item.arguments),
+      },
+    };
+  }
+  return {};
+}
+
+function parseArguments(raw: string | undefined): unknown {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export { OpenAIChatCompletionsAdapter } from './OpenAIChatCompletionsAdapter.js';
+export type {
+  UsageMetadata,
+  ReasoningEffort,
+  OpenAIChatCompletionsAdapterDefaults,
+} from './OpenAIChatCompletionsAdapter.js';
+export { OpenAIResponsesAdapter } from './OpenAIResponsesAdapter.js';
+export type { ReasoningSummary, OpenAIResponsesAdapterDefaults } from './OpenAIResponsesAdapter.js';

--- a/packages/openai/tsconfig.json
+++ b/packages/openai/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Bumps all four publishable packages to the same version in lockstep,
+// Bumps all publishable packages to the same version in lockstep,
 // and updates `@mast-ai/core` references in dependents to match.
 //
 // Usage: node scripts/bump-version.mjs <version>
@@ -9,7 +9,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
-const PACKAGES = ['core', 'google-genai', 'built-in-ai', 'react-ui'];
+const PACKAGES = ['core', 'google-genai', 'built-in-ai', 'openai', 'react-ui'];
 
 const newVersion = process.argv[2];
 if (!newVersion || !SEMVER.test(newVersion)) {


### PR DESCRIPTION
## Summary

Introduces a new `@mast-ai/openai` package that calls OpenAI directly from the browser, mirroring the role `@mast-ai/google-genai` plays for Gemini.

Two `LlmAdapter` implementations ship side by side:

- **`OpenAIChatCompletionsAdapter`** wraps `/v1/chat/completions`. Broad model coverage; also works against OpenAI-compatible providers (OpenRouter, DeepSeek), where `delta.reasoning_content` is forwarded as `thinking` events.
- **`OpenAIResponsesAdapter`** wraps `/v1/responses`. Required to surface reasoning summaries from native OpenAI reasoning models (`gpt-5`, o-series) as `thinking` events. Defaults `reasoning.summary` to `"auto"` so reasoning shows up out of the box; pass `{ reasoningSummary: false }` to suppress. Runs stateless (`store: false`).

Both adapters mirror `GoogleGenAIAdapter`'s constructor shape (`apiKey, modelName, onUsageUpdate, defaults`), set `dangerouslyAllowBrowser: true`, and support tool calling, streaming, and JSON-schema structured output.

### Other changes

- `demos/openai/basic-chat` — calculator + getCurrentTime tools, sidebar pickers for adapter / model / reasoning effort (all persisted to `localStorage`). The reasoning-effort dropdown is honoured only when the model is reasoning-capable so non-reasoning models don't 400.
- `docs/openai/PRD.md` and `docs/openai/SPEC.md` documenting both adapters and the open caveats (no reasoning continuity across multi-turn `store: false` calls in v1).
- `CLAUDE.md`, `scripts/bump-version.mjs`, and `.github/workflows/publish.yml` updated to include the new package in the lockstep release. The very first publish must be done manually per the bootstrap procedure in CLAUDE.md.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm test --workspaces --if-present` (332 tests, including 35 new in `@mast-ai/openai` — 20 Chat Completions + 15 Responses)
- [x] Manual: ran the demo against OpenAI, verified Chat Completions tool calls and Responses-API thinking blocks (`gpt-5`).