### PR TITLE
chore: release v0.4.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.3.0"
+    "@mast-ai/core": "^0.4.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.3.0"
+    "@mast-ai/core": "^0.4.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/openai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.3.0",
+    "@mast-ai/core": "^0.4.0",
     "openai": "^6.37.0"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.3.0",
+    "@mast-ai/core": "^0.4.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
## Summary

Bumps every `@mast-ai/*` package from `0.3.0` to `0.4.0`. Pre-1.0, the minor bump covers breaking changes.

### Changes since v0.3.0

- **`@mast-ai/core`** — no changes (lockstep bump)
- **`@mast-ai/built-in-ai`** — no changes (lockstep bump)
- **`@mast-ai/google-genai`** — forward native Gemini tools through `GoogleGenAIAdapter` (#117)
- **`@mast-ai/openai`** — new package: Chat Completions and Responses adapters (#118)
- **`@mast-ai/react-ui`** — observable breaking changes:
  - Panel chrome moved off `[data-mast-root]` onto a new `.mast-panel` class; default theme flips to light; `theme` prop widened to `'light' | 'dark' | 'auto'` (#113)
  - Default `--mast-font` set to `inherit`; `--mast-text-base`/`--mast-text-sm` switched to em-relative units (#112)
  - Default CSS wrapped in `@layer mast-ai`; five new element-shape tokens (#111)

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present`
- [x] `npm run build`
- [ ] After merge: tag `v0.4.0` on `main` and push to trigger the publish workflow