### PR TITLE
fix(react-ui): interleave thinking blocks with tool calls per LLM turn

### DIFF
--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -227,12 +227,21 @@ export interface ToolEventEntry {
   status?: ToolCallStatus; // populated when isStreaming flips to false
 }
 
+export interface ThinkingEntry {
+  id: string; // stable key for React reconciliation
+  type: 'thinking';
+  content: string; // accumulated reasoning text
+}
+
+// Ordered list of content blocks within one assistant turn.
+// ThinkingEntry and ToolEventEntry are interleaved in the order they occurred.
+export type ContentBlock = ThinkingEntry | ToolEventEntry;
+
 export interface ConversationEntry {
   id: string; // stable key for React reconciliation
   role: 'user' | 'assistant';
   text: string; // accumulated text (empty while streaming)
-  thinking?: string; // accumulated thinking (empty while streaming)
-  toolEvents: ToolEventEntry[];
+  contentBlocks: ContentBlock[]; // ordered thinking blocks and tool calls
   isStreaming: boolean;
 }
 ```
@@ -248,8 +257,16 @@ A `'cancelled'` status set by the proxy is preserved when the runner emits the
 final `tool_call_completed` event so the synthetic cancelled result does not
 get reclassified as success.
 
-`nestedToolEvents` captures the tool calls a sub-agent fires while the
-parent tool is executing. The list is populated as `tool_call_started` and
+`contentBlocks` replaces the former separate `thinking` string and `toolEvents` array.
+Each `thinking` delta is appended to the last `ThinkingEntry` in `contentBlocks`, or
+starts a new one when the previous block is a tool call (or the array is empty). Each
+`tool_call_started` pushes a new `ToolEventEntry`. This interleaved ordering means
+multi-turn thinking (think → tool → think again) renders correctly: two separate
+`<ThinkingBlock>` components are shown, one before and one after the `<ToolCallBlock>`,
+rather than a single merged block displayed before all tool calls.
+
+`nestedToolEvents` on a `ToolEventEntry` captures the tool calls a sub-agent fires
+while the parent tool is executing. The list is populated as `tool_call_started` and
 `tool_call_completed` events arrive on the parent's `onToolEvent` callback;
 `<ToolCallBlock>` renders nested entries recursively. Currently scoped to a
 single level of nesting — grandchild events route back to the outermost
@@ -566,9 +583,12 @@ interface MessageItemProps {
 
 ### 4.5 `<AssistantMessage>`
 
-Renders an assistant turn: optional `<ThinkingBlock>`, zero or more
-`<ToolCallBlock>` entries, then the final text. Text is rendered via the optional
-`react-markdown` renderer or the `renderMessage` override.
+Renders an assistant turn: the ordered `contentBlocks` (each block is either a
+`<ThinkingBlock>` or a `<ToolCallBlock>`, interleaved in the sequence they occurred),
+then the final text. Text is rendered via the optional `react-markdown` renderer or
+the `renderMessage` override. Only the last `ThinkingEntry` block shows a streaming
+pulse indicator while the entry is still generating; earlier thinking blocks are
+rendered as completed.
 
 ```tsx
 interface AssistantMessageProps {
@@ -918,22 +938,22 @@ export paths under `@mast-ai/react-ui/themes/<name>.css` (see §2.4).
 `useAgentStream` subscribes to the `AgentEvent` stream from `AgentRunner` and
 maintains `ConversationEntry[]` as follows:
 
-| Event                                 | Action                                                                                                                                   |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| User sends message                    | Append `{ role: 'user', text: displayText ?? prompt, isStreaming: false }`; pass `prompt` to `runStream`                                 |
-| Run starts                            | Append `{ role: 'assistant', text: '', isStreaming: true }`                                                                              |
-| `text_delta`                          | Mutate last entry: append `delta` to `text`                                                                                              |
-| `thinking`                            | Mutate last entry: append `delta` to `thinking`                                                                                          |
-| `tool_call_started`                   | Mutate last entry: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` to `toolEvents`                               |
-| `onToolEvent` → `thinking`            | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                        |
-| `onToolEvent` → `text_delta`          | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                            |
-| `onToolEvent` → `tool_call_started`   | Mutate matching parent `ToolEventEntry`: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` onto `nestedToolEvents` |
-| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error`              |
-| Approval proxy notifies               | Mutate matching `ToolEventEntry`: set `awaitingApproval` to `true`/`false`                                                               |
-| Approval proxy cancels                | Mutate matching `ToolEventEntry`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                        |
-| `tool_call_completed`                 | Mutate matching `ToolEventEntry`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`) |
-| `done`                                | Mutate last entry: set `text = output`, `isStreaming = false`                                                                            |
-| Error / cancel                        | Mutate last entry: set `isStreaming = false`; optionally append error text                                                               |
+| Event                                 | Action                                                                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User sends message                    | Append `{ role: 'user', text: displayText ?? prompt, isStreaming: false }`; pass `prompt` to `runStream`                                                                              |
+| Run starts                            | Append `{ role: 'assistant', text: '', contentBlocks: [], isStreaming: true }`                                                                                                        |
+| `text_delta`                          | Mutate last entry: append `delta` to `text`                                                                                                                                           |
+| `thinking`                            | Mutate last entry: if last `contentBlocks` element is a `ThinkingEntry`, append `delta` to its `content`; otherwise push a new `{ id, type: 'thinking', content: delta }` block      |
+| `tool_call_started`                   | Mutate last entry: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` to `contentBlocks`                                                                         |
+| `onToolEvent` → `thinking`            | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                                                                     |
+| `onToolEvent` → `text_delta`          | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                                                                         |
+| `onToolEvent` → `tool_call_started`   | Mutate matching parent `ToolEventEntry`: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` onto `nestedToolEvents`                                              |
+| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error`                                                           |
+| Approval proxy notifies               | Mutate matching `ToolEventEntry` in `contentBlocks`: set `awaitingApproval` to `true`/`false`                                                                                         |
+| Approval proxy cancels                | Mutate matching `ToolEventEntry` in `contentBlocks`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                                                  |
+| `tool_call_completed`                 | Mutate matching `ToolEventEntry` in `contentBlocks`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`)                           |
+| `done`                                | Mutate last entry: set `text = output`, `isStreaming = false`                                                                                                                         |
+| Error / cancel                        | Mutate last entry: set `isStreaming = false`; optionally append error text                                                                                                            |
 
 `onToolEvent` events are wired by passing an `onToolEvent` handler to `RunBuilder` inside `useAgentStream`. Events are matched to the correct `ToolEventEntry` by `toolName`. The `done` event from a sub-agent is ignored — the parent's `tool_call_completed` is the authoritative signal that a tool finished.
 

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -938,22 +938,22 @@ export paths under `@mast-ai/react-ui/themes/<name>.css` (see §2.4).
 `useAgentStream` subscribes to the `AgentEvent` stream from `AgentRunner` and
 maintains `ConversationEntry[]` as follows:
 
-| Event                                 | Action                                                                                                                                                                                |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| User sends message                    | Append `{ role: 'user', text: displayText ?? prompt, isStreaming: false }`; pass `prompt` to `runStream`                                                                              |
-| Run starts                            | Append `{ role: 'assistant', text: '', contentBlocks: [], isStreaming: true }`                                                                                                        |
-| `text_delta`                          | Mutate last entry: append `delta` to `text`                                                                                                                                           |
-| `thinking`                            | Mutate last entry: if last `contentBlocks` element is a `ThinkingEntry`, append `delta` to its `content`; otherwise push a new `{ id, type: 'thinking', content: delta }` block      |
-| `tool_call_started`                   | Mutate last entry: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` to `contentBlocks`                                                                         |
-| `onToolEvent` → `thinking`            | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                                                                     |
-| `onToolEvent` → `text_delta`          | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                                                                         |
-| `onToolEvent` → `tool_call_started`   | Mutate matching parent `ToolEventEntry`: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` onto `nestedToolEvents`                                              |
-| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error`                                                           |
-| Approval proxy notifies               | Mutate matching `ToolEventEntry` in `contentBlocks`: set `awaitingApproval` to `true`/`false`                                                                                         |
-| Approval proxy cancels                | Mutate matching `ToolEventEntry` in `contentBlocks`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                                                  |
-| `tool_call_completed`                 | Mutate matching `ToolEventEntry` in `contentBlocks`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`)                           |
-| `done`                                | Mutate last entry: set `text = output`, `isStreaming = false`                                                                                                                         |
-| Error / cancel                        | Mutate last entry: set `isStreaming = false`; optionally append error text                                                                                                            |
+| Event                                 | Action                                                                                                                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User sends message                    | Append `{ role: 'user', text: displayText ?? prompt, isStreaming: false }`; pass `prompt` to `runStream`                                                                        |
+| Run starts                            | Append `{ role: 'assistant', text: '', contentBlocks: [], isStreaming: true }`                                                                                                  |
+| `text_delta`                          | Mutate last entry: append `delta` to `text`                                                                                                                                     |
+| `thinking`                            | Mutate last entry: if last `contentBlocks` element is a `ThinkingEntry`, append `delta` to its `content`; otherwise push a new `{ id, type: 'thinking', content: delta }` block |
+| `tool_call_started`                   | Mutate last entry: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` to `contentBlocks`                                                                   |
+| `onToolEvent` → `thinking`            | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                                                               |
+| `onToolEvent` → `text_delta`          | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                                                                   |
+| `onToolEvent` → `tool_call_started`   | Mutate matching parent `ToolEventEntry`: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` onto `nestedToolEvents`                                        |
+| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error`                                                     |
+| Approval proxy notifies               | Mutate matching `ToolEventEntry` in `contentBlocks`: set `awaitingApproval` to `true`/`false`                                                                                   |
+| Approval proxy cancels                | Mutate matching `ToolEventEntry` in `contentBlocks`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                                            |
+| `tool_call_completed`                 | Mutate matching `ToolEventEntry` in `contentBlocks`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`)                     |
+| `done`                                | Mutate last entry: set `text = output`, `isStreaming = false`                                                                                                                   |
+| Error / cancel                        | Mutate last entry: set `isStreaming = false`; optionally append error text                                                                                                      |
 
 `onToolEvent` events are wired by passing an `onToolEvent` handler to `RunBuilder` inside `useAgentStream`. Events are matched to the correct `ToolEventEntry` by `toolName`. The `done` event from a sub-agent is ignored — the parent's `tool_call_completed` is the authoritative signal that a tool finished.
 

--- a/packages/react-ui/src/approval.test.tsx
+++ b/packages/react-ui/src/approval.test.tsx
@@ -18,6 +18,7 @@ import {
 
 import { AgentProvider, useAgent } from './context.js';
 import { INLINE_APPROVAL, type OnApprovalRequired } from './approval.js';
+import type { ToolEventEntry } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -160,7 +161,9 @@ describe('AgentProvider — approval flow', () => {
 
     expect(tool.call).not.toHaveBeenCalled();
     const lastTurn = result.current.messages.at(-1);
-    const completed = lastTurn?.toolEvents.find((t) => t.name === 'sensitive');
+    const completed = lastTurn?.contentBlocks.find(
+      (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+    );
     expect(completed?.result).toMatch(/cancel/i);
   });
 
@@ -176,7 +179,9 @@ describe('AgentProvider — approval flow', () => {
 
     expect(tool.call).not.toHaveBeenCalled();
     const lastTurn = result.current.messages.at(-1);
-    const completed = lastTurn?.toolEvents.find((t) => t.name === 'sensitive');
+    const completed = lastTurn?.contentBlocks.find(
+      (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+    );
     expect(completed?.result).toBe('synthetic result');
   });
 
@@ -192,7 +197,9 @@ describe('AgentProvider — approval flow', () => {
 
     expect(tool.call).toHaveBeenCalledTimes(1);
     const lastTurn = result.current.messages.at(-1);
-    const completed = lastTurn?.toolEvents.find((t) => t.name === 'sensitive');
+    const completed = lastTurn?.contentBlocks.find(
+      (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+    );
     expect(completed?.result).toBe('real-result');
   });
 
@@ -263,7 +270,9 @@ describe('AgentProvider — approval flow', () => {
     expect(result.current.pendingApprovals).toHaveLength(0);
     const completed = result.current.messages
       .at(-1)
-      ?.toolEvents.find((t) => t.name === 'sensitive');
+      ?.contentBlocks.find(
+        (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+      );
     expect(completed?.result).toBe('real-result');
     expect(completed?.status).toBe('success');
   });
@@ -309,7 +318,9 @@ describe('AgentProvider — approval flow', () => {
 
       const awaitingEntry = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(awaitingEntry?.awaitingApproval).toBe(true);
       expect(awaitingEntry?.isStreaming).toBe(true);
 
@@ -322,7 +333,9 @@ describe('AgentProvider — approval flow', () => {
 
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.awaitingApproval).toBe(false);
       expect(completed?.isStreaming).toBe(false);
     });
@@ -339,7 +352,9 @@ describe('AgentProvider — approval flow', () => {
 
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.awaitingApproval).toBe(false);
     });
 
@@ -357,7 +372,9 @@ describe('AgentProvider — approval flow', () => {
 
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.awaitingApproval).toBe(false);
     });
   });
@@ -370,7 +387,11 @@ describe('AgentProvider — approval flow', () => {
 
       await sendAndWait(result, 'go');
 
-      const completed = result.current.messages.at(-1)?.toolEvents.find((t) => t.name === 'safe');
+      const completed = result.current.messages
+        .at(-1)
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'safe',
+        );
       expect(completed?.status).toBe('success');
     });
 
@@ -394,7 +415,11 @@ describe('AgentProvider — approval flow', () => {
 
       await sendAndWait(result, 'go');
 
-      const completed = result.current.messages.at(-1)?.toolEvents.find((t) => t.name === 'safe');
+      const completed = result.current.messages
+        .at(-1)
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'safe',
+        );
       expect(completed?.status).toBe('error');
     });
 
@@ -410,7 +435,9 @@ describe('AgentProvider — approval flow', () => {
 
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.status).toBe('cancelled');
     });
   });
@@ -467,7 +494,9 @@ describe('AgentProvider — approval flow', () => {
       expect(result.current.pendingApprovals).toHaveLength(0);
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.result).toBe('real-result');
       expect(completed?.status).toBe('success');
     });
@@ -497,7 +526,9 @@ describe('AgentProvider — approval flow', () => {
       expect(tool.call).not.toHaveBeenCalled();
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.status).toBe('cancelled');
       expect(completed?.result).toMatch(/cancel/i);
     });
@@ -527,7 +558,9 @@ describe('AgentProvider — approval flow', () => {
       expect(tool.call).not.toHaveBeenCalled();
       const completed = result.current.messages
         .at(-1)
-        ?.toolEvents.find((t) => t.name === 'sensitive');
+        ?.contentBlocks.find(
+          (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'sensitive',
+        );
       expect(completed?.result).toBe('synthetic');
     });
 

--- a/packages/react-ui/src/components/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/AssistantMessage.tsx
@@ -175,12 +175,19 @@ export function AssistantMessage({
         data-streaming={entry.isStreaming ? 'true' : undefined}
         className={rootClass}
       >
-        {entry.thinking ? (
-          <ThinkingBlock content={entry.thinking} isStreaming={entry.isStreaming} />
-        ) : null}
-        {entry.toolEvents.map((toolEvent, index) => (
-          <Fragment key={`${toolEvent.id}-${index}`}>{renderToolEvent(toolEvent)}</Fragment>
-        ))}
+        {entry.contentBlocks.map((block, index) => {
+          const isLastBlock = index === entry.contentBlocks.length - 1;
+          if (block.type === 'thinking') {
+            return (
+              <ThinkingBlock
+                key={block.id}
+                content={block.content}
+                isStreaming={entry.isStreaming && isLastBlock}
+              />
+            );
+          }
+          return <Fragment key={`${block.id}-${index}`}>{renderToolEvent(block)}</Fragment>;
+        })}
         {entry.text ? (
           renderMessage ? (
             renderMessage(entry.text)

--- a/packages/react-ui/src/context.test.tsx
+++ b/packages/react-ui/src/context.test.tsx
@@ -343,14 +343,14 @@ describe('useAgent', () => {
         id: 'u-1',
         role: 'user',
         text: 'previously',
-        toolEvents: [],
+        contentBlocks: [],
         isStreaming: false,
       },
       {
         id: 'a-1',
         role: 'assistant',
         text: 'previously answered',
-        toolEvents: [],
+        contentBlocks: [],
         isStreaming: false,
       },
     ];

--- a/packages/react-ui/src/hooks/useAgentStream.test.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.test.ts
@@ -4,6 +4,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import type { AgentEvent, Conversation } from '@mast-ai/core';
+import type { ThinkingEntry, ToolEventEntry } from '../types.js';
 import { useAgentStream } from './useAgentStream.js';
 
 // ---------------------------------------------------------------------------
@@ -226,7 +227,7 @@ describe('useAgentStream', () => {
   // Thinking streaming
   // -------------------------------------------------------------------------
 
-  it('accumulates thinking deltas into the thinking field', async () => {
+  it('accumulates thinking deltas into a ThinkingEntry in contentBlocks', async () => {
     const conv = mockConversation([
       { type: 'thinking', delta: 'Step 1. ' },
       { type: 'thinking', delta: 'Step 2.' },
@@ -239,11 +240,14 @@ describe('useAgentStream', () => {
       result.current.sendMessage('think');
     });
 
-    expect(result.current.entries[1].thinking).toBe('Step 1. Step 2.');
+    const blocks = result.current.entries[1].contentBlocks;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('thinking');
+    expect((blocks[0] as ThinkingEntry).content).toBe('Step 1. Step 2.');
     expect(result.current.entries[1].text).toBe('Answer');
   });
 
-  it('thinking field is undefined when no thinking deltas are emitted', async () => {
+  it('contentBlocks is empty when no thinking or tool events are emitted', async () => {
     const conv = mockConversation([
       { type: 'text_delta', delta: 'Answer' },
       { type: 'done', output: 'Answer', history: [] },
@@ -254,14 +258,38 @@ describe('useAgentStream', () => {
       result.current.sendMessage('hi');
     });
 
-    expect(result.current.entries[1].thinking).toBeUndefined();
+    expect(result.current.entries[1].contentBlocks).toHaveLength(0);
+  });
+
+  it('creates separate ThinkingEntry blocks for thinking before and after a tool call', async () => {
+    const conv = mockConversation([
+      { type: 'thinking', delta: 'Pre-tool thought.' },
+      { type: 'tool_call_started', name: 'search', args: {} },
+      { type: 'tool_call_completed', name: 'search', result: 'data' },
+      { type: 'thinking', delta: 'Post-tool thought.' },
+      { type: 'done', output: 'Answer', history: [] },
+    ]);
+    const { result } = renderHook(() => useAgentStream(conv));
+
+    await act(async () => {
+      result.current.sendMessage('research');
+    });
+
+    const blocks = result.current.entries[1].contentBlocks;
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].type).toBe('thinking');
+    expect((blocks[0] as ThinkingEntry).content).toBe('Pre-tool thought.');
+    expect(blocks[1].type).toBe('tool_call_completed');
+    expect((blocks[1] as ToolEventEntry).name).toBe('search');
+    expect(blocks[2].type).toBe('thinking');
+    expect((blocks[2] as ThinkingEntry).content).toBe('Post-tool thought.');
   });
 
   // -------------------------------------------------------------------------
   // Tool call lifecycle
   // -------------------------------------------------------------------------
 
-  it('appends a streaming ToolEventEntry on tool_call_started', async () => {
+  it('appends a streaming ToolEventEntry in contentBlocks on tool_call_started', async () => {
     const { conversation, resume } = pausableConversation(
       [{ type: 'tool_call_started', name: 'my_tool', args: { x: 1 } }],
       [
@@ -277,9 +305,9 @@ describe('useAgentStream', () => {
 
     // The tool_call_started state update is async; waitFor polls until it lands.
     await waitFor(() => {
-      expect(result.current.entries[1].toolEvents).toHaveLength(1);
+      expect(result.current.entries[1].contentBlocks).toHaveLength(1);
     });
-    expect(result.current.entries[1].toolEvents[0]).toMatchObject({
+    expect(result.current.entries[1].contentBlocks[0]).toMatchObject({
       type: 'tool_call_started',
       name: 'my_tool',
       args: { x: 1 },
@@ -290,7 +318,7 @@ describe('useAgentStream', () => {
     await act(async () => {});
   });
 
-  it('marks ToolEventEntry completed with result on tool_call_completed', async () => {
+  it('marks ToolEventEntry in contentBlocks completed with result on tool_call_completed', async () => {
     const conv = mockConversation([
       { type: 'tool_call_started', name: 'calc', args: { expr: '2+2' } },
       { type: 'tool_call_completed', name: 'calc', result: 4 },
@@ -302,7 +330,7 @@ describe('useAgentStream', () => {
       result.current.sendMessage('calculate');
     });
 
-    const toolEvent = result.current.entries[1].toolEvents[0];
+    const toolEvent = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
     expect(toolEvent.type).toBe('tool_call_completed');
     expect(toolEvent.result).toBe(4);
     expect(toolEvent.isStreaming).toBe(false);
@@ -336,7 +364,8 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run agent');
     });
 
-    expect(result.current.entries[1].toolEvents[0].subThinking).toBe('Considering... Done.');
+    const toolBlock = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
+    expect(toolBlock.subThinking).toBe('Considering... Done.');
   });
 
   // -------------------------------------------------------------------------
@@ -367,7 +396,8 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run agent');
     });
 
-    expect(result.current.entries[1].toolEvents[0].subText).toBe('Sub response.');
+    const toolBlock = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
+    expect(toolBlock.subText).toBe('Sub response.');
   });
 
   // -------------------------------------------------------------------------
@@ -446,7 +476,7 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run nested');
     });
 
-    const parent = result.current.entries[1].toolEvents[0];
+    const parent = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
     expect(parent.name).toBe('agent_tool');
     expect(parent.nestedToolEvents).toHaveLength(1);
     expect(parent.nestedToolEvents![0]).toMatchObject({
@@ -498,11 +528,11 @@ describe('useAgentStream', () => {
     });
 
     await waitFor(() => {
-      const parent = result.current.entries[1].toolEvents[0];
+      const parent = result.current.entries[1].contentBlocks[0] as ToolEventEntry | undefined;
       expect(parent?.nestedToolEvents).toHaveLength(1);
     });
 
-    const parent = result.current.entries[1].toolEvents[0];
+    const parent = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
     expect(parent.nestedToolEvents![0]).toMatchObject({
       type: 'tool_call_started',
       name: 'inner_tool',
@@ -542,7 +572,7 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run');
     });
 
-    const parent = result.current.entries[1].toolEvents[0];
+    const parent = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
     expect(parent.nestedToolEvents![0].status).toBe('error');
   });
 
@@ -572,7 +602,8 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run');
     });
 
-    const nested = result.current.entries[1].toolEvents[0].nestedToolEvents!;
+    const parent = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
+    const nested = parent.nestedToolEvents!;
     expect(nested.map((n) => n.name)).toEqual(['inner_a', 'inner_b']);
     expect(nested.map((n) => n.result)).toEqual(['a', 'b']);
     expect(nested.every((n) => !n.isStreaming)).toBe(true);
@@ -604,7 +635,7 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run');
     });
 
-    const parent = result.current.entries[1].toolEvents[0];
+    const parent = result.current.entries[1].contentBlocks[0] as ToolEventEntry;
     expect(parent.subThinking).toBe('planning ');
     expect(parent.subText).toBe('narration ');
     expect(parent.nestedToolEvents).toHaveLength(1);
@@ -637,15 +668,17 @@ describe('useAgentStream', () => {
       result.current.sendMessage('run both');
     });
 
-    const toolEvents = result.current.entries[1].toolEvents;
-    expect(toolEvents).toHaveLength(2);
+    const toolBlocks = result.current.entries[1].contentBlocks.filter(
+      (b): b is ToolEventEntry => b.type !== 'thinking',
+    );
+    expect(toolBlocks).toHaveLength(2);
 
-    const a = toolEvents.find((t) => t.name === 'tool_a')!;
+    const a = toolBlocks.find((t) => t.name === 'tool_a')!;
     expect(a.subText).toBe('Sub text A');
     expect(a.result).toBe('result_a');
     expect(a.isStreaming).toBe(false);
 
-    const b = toolEvents.find((t) => t.name === 'tool_b')!;
+    const b = toolBlocks.find((t) => t.name === 'tool_b')!;
     expect(b.subThinking).toBe('Sub thinking B');
     expect(b.result).toBe('result_b');
     expect(b.isStreaming).toBe(false);

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -4,7 +4,13 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { Conversation, Message } from '@mast-ai/core';
 import type { AgentEvent } from '@mast-ai/core';
-import type { ConversationEntry, ToolCallStatus, ToolEventEntry } from '../types.js';
+import type {
+  ContentBlock,
+  ConversationEntry,
+  ThinkingEntry,
+  ToolCallStatus,
+  ToolEventEntry,
+} from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Private helpers
@@ -15,7 +21,7 @@ function makeEntry(
   text: string,
   isStreaming: boolean,
 ): ConversationEntry {
-  return { id: crypto.randomUUID(), role, text, toolEvents: [], isStreaming };
+  return { id: crypto.randomUUID(), role, text, contentBlocks: [], isStreaming };
 }
 
 /**
@@ -33,7 +39,7 @@ function updateEntry(
 /**
  * Returns a new array where the first `ToolEventEntry` in the entry identified
  * by `entryId` that matches `toolName` and is still streaming is replaced by
- * the result of `updater`. All other entries and tool events are unchanged.
+ * the result of `updater`. All other entries and content blocks are unchanged.
  */
 function updateToolEvent(
   entries: ConversationEntry[],
@@ -43,14 +49,14 @@ function updateToolEvent(
 ): ConversationEntry[] {
   return updateEntry(entries, entryId, (entry) => {
     let patched = false;
-    const toolEvents = entry.toolEvents.map((t) => {
-      if (!patched && t.name === toolName && t.isStreaming) {
+    const contentBlocks: ContentBlock[] = entry.contentBlocks.map((block) => {
+      if (!patched && block.type !== 'thinking' && block.name === toolName && block.isStreaming) {
         patched = true;
-        return updater(t);
+        return updater(block);
       }
-      return t;
+      return block;
     });
-    return { ...entry, toolEvents };
+    return { ...entry, contentBlocks };
   });
 }
 
@@ -374,11 +380,27 @@ export function useAgentStream(
                 })),
               );
             } else if (event.type === 'thinking') {
+              const delta = event.delta;
               setEntries((prev) =>
-                updateEntry(prev, assistantId, (e) => ({
-                  ...e,
-                  thinking: (e.thinking ?? '') + event.delta,
-                })),
+                updateEntry(prev, assistantId, (e) => {
+                  const lastBlock = e.contentBlocks.at(-1);
+                  if (lastBlock?.type === 'thinking') {
+                    // Append to the current thinking block.
+                    const contentBlocks: ContentBlock[] = e.contentBlocks.map((b, i) =>
+                      i === e.contentBlocks.length - 1
+                        ? { ...(b as ThinkingEntry), content: (b as ThinkingEntry).content + delta }
+                        : b,
+                    );
+                    return { ...e, contentBlocks };
+                  }
+                  // Start a new thinking block (first delta, or after a tool call).
+                  const newBlock: ThinkingEntry = {
+                    id: crypto.randomUUID(),
+                    type: 'thinking',
+                    content: delta,
+                  };
+                  return { ...e, contentBlocks: [...e.contentBlocks, newBlock] };
+                }),
               );
             } else if (event.type === 'tool_call_started') {
               const toolEvent: ToolEventEntry = {
@@ -391,7 +413,7 @@ export function useAgentStream(
               setEntries((prev) =>
                 updateEntry(prev, assistantId, (e) => ({
                   ...e,
-                  toolEvents: [...e.toolEvents, toolEvent],
+                  contentBlocks: [...e.contentBlocks, toolEvent],
                 })),
               );
             } else if (event.type === 'tool_call_completed') {

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -1,7 +1,14 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-export type { ConversationEntry, ToolEventEntry, ToolCallStatus, IconMap } from './types.js';
+export type {
+  ConversationEntry,
+  ContentBlock,
+  ThinkingEntry,
+  ToolEventEntry,
+  ToolCallStatus,
+  IconMap,
+} from './types.js';
 export { useAgentStream } from './hooks/useAgentStream.js';
 export type { UseAgentStreamOptions, UseAgentStreamReturn } from './hooks/useAgentStream.js';
 export { AgentProvider, useAgent } from './context.js';

--- a/packages/react-ui/src/types.ts
+++ b/packages/react-ui/src/types.ts
@@ -100,6 +100,33 @@ export interface ToolEventEntry {
 }
 
 /**
+ * A thinking/reasoning block produced during one LLM turn.
+ *
+ * Created when the first `thinking` delta arrives after a tool call (or at
+ * the very start of the stream) and accumulated until the next tool call or
+ * the end of the turn. Multiple `ThinkingEntry` blocks may appear in
+ * `ConversationEntry.contentBlocks` when the model thinks, calls a tool,
+ * then thinks again.
+ */
+export interface ThinkingEntry {
+  /** Stable identifier used as the React `key` for this block. */
+  id: string;
+
+  /** Discriminator. */
+  type: 'thinking';
+
+  /** Accumulated reasoning text. Grows with each `thinking` delta. */
+  content: string;
+}
+
+/**
+ * A single content block within an assistant turn. Either a thinking/reasoning
+ * trace or a tool invocation. The array is ordered by arrival time, so
+ * thinking blocks and tool calls are interleaved in the sequence they occurred.
+ */
+export type ContentBlock = ThinkingEntry | ToolEventEntry;
+
+/**
  * The rendered state of a single turn in the conversation.
  *
  * Each `sendMessage` call produces one user entry and one assistant entry.
@@ -123,17 +150,15 @@ export interface ConversationEntry {
   text: string;
 
   /**
-   * Accumulated thinking/reasoning trace for this assistant turn.
-   * Only present when the model emits `thinking` deltas.
+   * Ordered list of content blocks produced during this assistant turn.
+   *
+   * Each `thinking` delta is accumulated into the last `ThinkingEntry` block,
+   * or starts a new one when the previous block is a tool call. Each
+   * `tool_call_started` event appends a `ToolEventEntry`. The ordering
+   * faithfully reflects the sequence in which thinking and tool calls occurred,
+   * so multi-turn reasoning (think → tool → think again) renders correctly.
    */
-  thinking?: string;
-
-  /**
-   * Ordered list of tool invocations made during this assistant turn.
-   * Each element corresponds to one `tool_call_started` event and is updated
-   * in-place as the tool executes.
-   */
-  toolEvents: ToolEventEntry[];
+  contentBlocks: ContentBlock[];
 
   /**
    * `true` while the assistant is generating this entry; `false` once `done`,


### PR DESCRIPTION
## Summary

- Replaces `ConversationEntry.thinking?: string` + `ConversationEntry.toolEvents: ToolEventEntry[]` with a unified `contentBlocks: ContentBlock[]` array where each element is either a `ThinkingEntry` or a `ToolEventEntry`, ordered by arrival time.
- `useAgentStream` now appends thinking deltas to the last `ThinkingEntry` in `contentBlocks`, or starts a new one when the previous block is a tool call — so reasoning that occurs after a tool returns becomes its own block rather than being concatenated into the pre-call block.
- `AssistantMessage` renders `contentBlocks` in order, producing the correct interleaved layout: `[thinking 1] → [tool call A] → [thinking 2] → [tool call B]`.
- `ThinkingEntry` and `ContentBlock` are now exported from the package root.
- `SPEC.md` data types and streaming state machine table updated.

**Breaking change:** `ConversationEntry.thinking` and `ConversationEntry.toolEvents` are removed. Consumers who read those fields directly must update to filter `contentBlocks` by `block.type`. This is a minor-version bump (per the 0.x semver policy in CLAUDE.md).

## Implementation notes

- The key mechanic in `useAgentStream`: on a `thinking` delta, inspect the last element of `contentBlocks`. If it's already a `ThinkingEntry`, append to its `content`. If it's a `ToolEventEntry` (or the array is empty), push a new `ThinkingEntry`. This means a new thinking block is started automatically whenever thinking resumes after a tool call — no explicit "bump the index" bookkeeping needed.
- `AssistantMessage` passes `isStreaming={entry.isStreaming && isLastBlock}` to each `ThinkingBlock`, so only the block actively being streamed shows a pulse indicator; earlier completed thinking blocks render as static.
- `updateToolEvent` now searches `contentBlocks` filtering `block.type !== 'thinking'` to find `ToolEventEntry` matches — TypeScript narrows the union correctly via the discriminant.

## Test plan

- [x] All 181 existing tests pass (including the previously failing "marks a thrown tool call as 'error'" test, which was fixed by rebuilding the stale `@mast-ai/core` dist that was missing `error?: boolean` on `tool_call_completed`).
- [x] New test: `creates separate ThinkingEntry blocks for thinking before and after a tool call` — verifies the three-block layout (`ThinkingEntry` → `ToolEventEntry` → `ThinkingEntry`).
- [x] Manually verified in the `demos/react-ui/chat` demo with `GoogleGenAIAdapter` and a prompt that causes the model to think, call a tool, then think again — two separate collapsible thinking blocks render in the correct positions relative to the tool call.

Closes #120