### PR TITLE
fix(core): suppress events for hallucinated tool calls

### DIFF
--- a/packages/core/src/runner.test.ts
+++ b/packages/core/src/runner.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AgentRunner } from './runner.js';
 import { AgentError } from './error.js';
+import { ToolRegistry } from './tool.js';
 import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index.js';
 import type { AgentConfig, AgentEvent } from './types.js';
 import type { ToolContext } from './tool.js';
@@ -22,6 +23,94 @@ const agent: AgentConfig = {
   name: 'Child',
   instructions: 'Be a child agent.',
 };
+
+describe('hallucinated tool calls', () => {
+  it('does not emit tool_call_started for unregistered tools', async () => {
+    let callCount = 0;
+    const adapter: LlmAdapter = {
+      generate: vi.fn(),
+      generateStream: (_request: AdapterRequest) =>
+        (async function* () {
+          if (callCount++ === 0) {
+            // First turn: LLM calls a real tool and a hallucinated one.
+            yield {
+              type: 'tool_call' as const,
+              toolCall: { id: '1', name: 'real_tool', args: {} },
+            };
+            yield {
+              type: 'tool_call' as const,
+              toolCall: { id: '2', name: 'ghost_tool', args: {} },
+            };
+          } else {
+            yield { type: 'text_delta' as const, delta: 'done' };
+          }
+        })(),
+    };
+
+    const registry = new ToolRegistry();
+    registry.register({
+      definition: () => ({
+        name: 'real_tool',
+        description: 'A real tool',
+        parameters: {},
+        scope: 'read' as const,
+      }),
+      call: async () => 'real result',
+    });
+
+    const runner = new AgentRunner(adapter, registry);
+    const events: AgentEvent[] = [];
+    for await (const event of runner.runStream(agent, 'go')) {
+      events.push(event);
+    }
+
+    const types = events.map((e) => e.type);
+    // tool_call_started must appear exactly once — for real_tool only.
+    expect(types.filter((t) => t === 'tool_call_started')).toHaveLength(1);
+    expect(events.find((e) => e.type === 'tool_call_started')).toMatchObject({
+      name: 'real_tool',
+    });
+    // tool_call_completed must appear exactly once — for real_tool only.
+    expect(types.filter((t) => t === 'tool_call_completed')).toHaveLength(1);
+    expect(events.find((e) => e.type === 'tool_call_completed')).toMatchObject({
+      name: 'real_tool',
+      error: false,
+    });
+  });
+
+  it('feeds an error result back to the LLM for unregistered tools', async () => {
+    const turnRequests: AdapterRequest[] = [];
+    let callCount = 0;
+    const adapter: LlmAdapter = {
+      generate: vi.fn(),
+      generateStream: (request: AdapterRequest) =>
+        (async function* () {
+          turnRequests.push(request);
+          if (callCount++ === 0) {
+            yield {
+              type: 'tool_call' as const,
+              toolCall: { id: '1', name: 'ghost_tool', args: {} },
+            };
+          } else {
+            yield { type: 'text_delta' as const, delta: 'done' };
+          }
+        })(),
+    };
+
+    const runner = new AgentRunner(adapter, new ToolRegistry());
+    for await (const _ of runner.runStream(agent, 'go')) {
+      // drain
+    }
+
+    // Second request's history should contain a tool_result for ghost_tool.
+    const secondRequest = turnRequests[1];
+    const toolResultMsg = secondRequest.messages.find(
+      (m) => m.content.type === 'tool_result' && m.content.name === 'ghost_tool',
+    );
+    expect(toolResultMsg).toBeDefined();
+    expect((toolResultMsg!.content as { result: string }).result).toContain('ghost_tool');
+  });
+});
 
 describe('RunBuilder.forwardTo', () => {
   it('forwards every non-done event to parentContext.onEvent in order', async () => {

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -224,8 +224,12 @@ export class AgentRunner {
       }
 
       if (toolCalls.length > 0) {
+        // Emit tool_call_started only for registered tools so hallucinated
+        // calls never appear in the UI.
         for (const call of toolCalls) {
-          yield { type: 'tool_call_started', name: call.name, args: call.args };
+          if (this.registry.getTool(call.name)) {
+            yield { type: 'tool_call_started', name: call.name, args: call.args };
+          }
         }
 
         const toolResults = await Promise.all(
@@ -234,8 +238,9 @@ export class AgentRunner {
             if (!tool) {
               return {
                 call,
-                result: `Error: Tool '${call.name}' not found.`,
+                result: `Tool '${call.name}' does not exist and was not called.`,
                 error: true as const,
+                hallucinated: true as const,
               };
             }
             try {
@@ -243,17 +248,25 @@ export class AgentRunner {
                 signal,
                 onEvent: onToolEvent ? (event) => onToolEvent(call.name, event) : undefined,
               });
-              return { call, result, error: false as const };
+              return { call, result, error: false as const, hallucinated: false as const };
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
-              return { call, result: `Error executing tool: ${message}`, error: true as const };
+              return {
+                call,
+                result: `Error executing tool: ${message}`,
+                error: true as const,
+                hallucinated: false as const,
+              };
             }
           }),
         );
 
         const resultMessages: Message[] = [];
-        for (const { call, result, error } of toolResults) {
-          yield { type: 'tool_call_completed', name: call.name, result, error };
+        for (const { call, result, error, hallucinated } of toolResults) {
+          // Suppress completed events for hallucinated calls — they had no started event.
+          if (!hallucinated) {
+            yield { type: 'tool_call_completed', name: call.name, result, error };
+          }
           resultMessages.push({
             role: 'user',
             content: { type: 'tool_result', id: call.id, name: call.name, result },


### PR DESCRIPTION
## Summary

- `tool_call_started` is now only emitted for tools that exist in the registry, so hallucinated tool calls never appear in the UI
- `tool_call_completed` is similarly suppressed for hallucinated calls (no orphaned completed event without a started event)
- Valid tool calls in the same turn still execute and emit events normally
- An error result (`Tool 'X' does not exist and was not called.`) is fed back to the LLM so it can self-correct, and the agent loop continues

## Test plan

- [ ] Trigger a scenario where the LLM hallucinates a tool alongside real ones — confirm the UI only shows the real tool calls
- [ ] Confirm the LLM receives the error result and recovers on the next turn
- [ ] `npm test -w packages/core` passes (two new test cases cover both behaviours)

Closes #121