### PR TITLE
chore: release v0.5.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.4.0"
+    "@mast-ai/core": "^0.5.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.4.0"
+    "@mast-ai/core": "^0.5.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/openai",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.4.0",
+    "@mast-ai/core": "^0.5.0",
     "openai": "^6.37.0"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.4.0",
+    "@mast-ai/core": "^0.5.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
## Summary

- Bumps all `@mast-ai/*` packages from `0.4.0` → `0.5.0` in lockstep

## Changes since v0.4.0

**`@mast-ai/core`** (patch)
- `fix(core)`: suppress `tool_call_started`/`tool_call_completed` events for hallucinated tool calls (#123)

**`@mast-ai/react-ui`** (minor — breaking)
- `fix(react-ui)`: interleave thinking blocks with tool calls per LLM turn (#122)
  - `ConversationEntry.thinking?: string` and `ConversationEntry.toolEvents: ToolEventEntry[]` replaced by `ConversationEntry.contentBlocks: ContentBlock[]`
  - New exports: `ContentBlock`, `ThinkingEntry`

**`@mast-ai/google-genai`, `@mast-ai/built-in-ai`, `@mast-ai/openai`** — no source changes; bumped in lockstep per release policy.

## Version rationale

Pre-1.0 policy: minor bump = breaking-change line. The `ConversationEntry` API change in `react-ui` is breaking → `0.5.0`.