### PR TITLE
feat(core): round-trip provider_metadata on tool calls

### DIFF
--- a/demos/core/rust-server/Cargo.lock
+++ b/demos/core/rust-server/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "agent-rig"
 version = "0.1.0"
-source = "git+https://github.com/andreban/agent-rig.git#59dbc5df554f83909626735f22619ba5a5eeb370"
+source = "git+https://github.com/andreban/agent-rig.git#537cd5e9c06e7ec266451c14e4d47fbddc3bfb6d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "geologia"
 version = "0.1.0"
-source = "git+https://github.com/andreban/geologia.git#08ad998601db705bda409a445a83251c462597d3"
+source = "git+https://github.com/andreban/geologia.git#a70cb53eee11b239ab135038fbc72f5dcf9dadab"
 dependencies = [
  "reqwest",
  "serde",
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "ollama-rs"
 version = "0.1.0"
-source = "git+https://github.com/andreban/ollama-rs#08c2dccbb4dbbda0d5f68aae0a47686e99459074"
+source = "git+https://github.com/andreban/ollama-rs#e8c2fb73fbaa8bf0a90b27798215d9199c444436"
 dependencies = [
  "async-stream",
  "futures-util",

--- a/demos/core/rust-server/src/provider.rs
+++ b/demos/core/rust-server/src/provider.rs
@@ -63,15 +63,25 @@ fn build_model_request(payload: UrpRequest) -> Result<(ModelRequest, bool), (Sta
             UrpMessageContent::ToolCalls { calls } => {
                 let rig_calls = calls
                     .into_iter()
-                    .map(|c| ToolCall::new(c.id, c.name, c.arguments))
+                    .map(|c| ToolCall {
+                        id: c.id,
+                        name: c.name,
+                        args: c.arguments,
+                        provider_metadata: c.provider_metadata,
+                    })
                     .collect();
                 rig_messages.push(Message {
                     role,
                     content: MessageContent::ToolCalls(rig_calls),
                 });
             }
-            UrpMessageContent::ToolResult { id, name, result } => {
-                rig_messages.push(Message::tool_result(id, name, result, None));
+            UrpMessageContent::ToolResult {
+                id,
+                name,
+                result,
+                provider_metadata,
+            } => {
+                rig_messages.push(Message::tool_result(id, name, result, provider_metadata));
             }
         }
     }
@@ -102,6 +112,7 @@ async fn handle_streaming(
                         id: tc.id,
                         name: tc.name,
                         arguments: tc.args,
+                        provider_metadata: tc.provider_metadata,
                     },
                 },
                 Err(e) => {

--- a/demos/core/rust-server/src/types.rs
+++ b/demos/core/rust-server/src/types.rs
@@ -47,6 +47,8 @@ pub enum UrpMessageContent {
         id: String,
         name: String,
         result: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider_metadata: Option<Value>,
     },
 }
 
@@ -56,6 +58,8 @@ pub struct UrpToolCall {
     pub name: String,
     #[serde(default)]
     pub arguments: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_metadata: Option<Value>,
 }
 
 #[derive(Serialize, Debug)]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -63,7 +63,13 @@ export type Role = 'user' | 'assistant';
 export type MessageContent =
   | { type: 'text'; text: string }
   | { type: 'tool_calls'; calls: ToolCall[] }
-  | { type: 'tool_result'; id: string; name: string; result: unknown };
+  | {
+      type: 'tool_result';
+      id: string;
+      name: string;
+      result: unknown;
+      provider_metadata?: unknown;
+    };
 
 export interface Message {
   role: Role;
@@ -73,6 +79,8 @@ export interface Message {
 
 `MessageContent` is a discriminated union. A single assistant turn that requests one or more tools uses `type: 'tool_calls'`. Each tool result is a separate user-role message with `type: 'tool_result'`. The runner inserts these automatically; callers never construct tool messages manually.
 
+`tool_result.provider_metadata` is an opaque value copied verbatim from the originating `ToolCall.provider_metadata`. MAST never inspects it; adapters and backends use it to round-trip per-call data they need on the next turn (e.g. Gemini `thoughtSignature`).
+
 ### `ToolCall` (`src/types.ts`)
 
 ```typescript
@@ -80,8 +88,11 @@ export interface ToolCall {
   id: string; // opaque identifier echoed back to the adapter
   name: string;
   args: unknown; // parsed JSON object matching the tool's parameters schema
+  provider_metadata?: unknown; // opaque per-call metadata, round-tripped unchanged
 }
 ```
+
+`provider_metadata` is a generic, provider-agnostic escape hatch for opaque per-call data the adapter or backend needs to see again on the next turn. Examples include Gemini's `thoughtSignature` (which thinking models require on every replayed `functionCall` / `functionResponse` part). MAST treats the value as opaque: it is not parsed, validated, or merged. The runner copies it from `ToolCall` onto the matching `tool_result` message verbatim.
 
 ### `AgentEvent` (`src/types.ts`)
 
@@ -494,8 +505,19 @@ The URP is a language-agnostic JSON protocol that decouples the browser agent lo
   "id": "call_abc123",
   "name": "calculator",
   "arguments": { "expression": "2 + 2" },
+  // Optional: opaque per-call metadata (e.g. Gemini `thoughtSignature`).
+  // The server controls the shape; the client round-trips it unchanged
+  // on the matching tool_result message in the next turn.
+  "provider_metadata": { "thought_signature": "..." },
 }
 ```
+
+| Field               | Type     | Required | Notes                                                                                               |
+| ------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `id`                | `string` | Yes      | Opaque identifier echoed back on the matching `tool_result`                                         |
+| `name`              | `string` | Yes      | Tool name                                                                                           |
+| `arguments`         | `object` | Yes      | Parsed JSON object matching the tool's `parameters` schema                                          |
+| `provider_metadata` | `any`    | No       | Server-controlled opaque blob; client copies it verbatim onto the next turn's `tool_result` message |
 
 ### `UrpAdapter` (`src/adapter/urp.ts`)
 

--- a/packages/core/src/adapter/urp.test.ts
+++ b/packages/core/src/adapter/urp.test.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { UrpAdapter } from './urp.js';
+import type { UrpRequest, UrpResponse, UrpStreamChunk, UrpTransport } from './urp.js';
+import type { AdapterRequest } from './index.js';
+
+const baseRequest: AdapterRequest = {
+  messages: [],
+  tools: [],
+};
+
+describe('UrpAdapter provider_metadata round-trip', () => {
+  it('exposes provider_metadata on tool calls returned by generate()', async () => {
+    const sentinel = { thought_signature: 'abc' };
+    const transport: UrpTransport = {
+      send: async (): Promise<UrpResponse> => ({
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'search',
+            arguments: { q: 'hi' },
+            provider_metadata: sentinel,
+          },
+        ],
+      }),
+    };
+
+    const adapter = new UrpAdapter(transport);
+    const response = await adapter.generate(baseRequest);
+
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls[0].provider_metadata).toBe(sentinel);
+  });
+
+  it('exposes provider_metadata on tool calls returned by generateStream()', async () => {
+    const sentinel = { thought_signature: 'xyz' };
+    const transport: UrpTransport = {
+      send: async () => ({ tool_calls: [] }),
+      sendStream: (): AsyncIterable<UrpStreamChunk> =>
+        (async function* () {
+          yield {
+            type: 'tool_call',
+            tool_call: {
+              id: 'call_1',
+              name: 'search',
+              arguments: { q: 'hi' },
+              provider_metadata: sentinel,
+            },
+          };
+        })(),
+    };
+
+    const adapter = new UrpAdapter(transport);
+    const chunks = [];
+    for await (const chunk of adapter.generateStream(baseRequest)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({
+      type: 'tool_call',
+      toolCall: { provider_metadata: sentinel },
+    });
+  });
+
+  it('forwards provider_metadata from outgoing tool_result messages over the wire', async () => {
+    let captured: UrpRequest | undefined;
+    const transport: UrpTransport = {
+      send: async (req): Promise<UrpResponse> => {
+        captured = req;
+        return { tool_calls: [] };
+      },
+    };
+
+    const sentinel = { thought_signature: 'replay' };
+    const adapter = new UrpAdapter(transport);
+    await adapter.generate({
+      ...baseRequest,
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'tool_result',
+            id: 'call_1',
+            name: 'search',
+            result: 'ok',
+            provider_metadata: sentinel,
+          },
+        },
+      ],
+    });
+
+    const sent = captured!.messages[0];
+    expect(sent.content.type).toBe('tool_result');
+    expect((sent.content as { provider_metadata?: unknown }).provider_metadata).toBe(sentinel);
+  });
+});

--- a/packages/core/src/adapter/urp.ts
+++ b/packages/core/src/adapter/urp.ts
@@ -18,6 +18,12 @@ export interface UrpToolCall {
   id: string;
   name: string;
   arguments: unknown;
+  /**
+   * Opaque per-call metadata controlled by the server (e.g. Gemini
+   * `thoughtSignature`). Round-tripped unchanged on the matching
+   * `tool_result` message in the next turn.
+   */
+  provider_metadata?: unknown;
 }
 
 /** Wire format for a non-streaming URP response. */
@@ -89,6 +95,7 @@ export class UrpAdapter implements LlmAdapter {
             id: tc.id,
             name: tc.name,
             args: tc.arguments,
+            provider_metadata: tc.provider_metadata,
           }))
         : [],
     };
@@ -121,6 +128,7 @@ export class UrpAdapter implements LlmAdapter {
             id: chunk.tool_call.id,
             name: chunk.tool_call.name,
             args: chunk.tool_call.arguments,
+            provider_metadata: chunk.tool_call.provider_metadata,
           },
         };
       }

--- a/packages/core/src/runner.test.ts
+++ b/packages/core/src/runner.test.ts
@@ -112,6 +112,66 @@ describe('hallucinated tool calls', () => {
   });
 });
 
+describe('provider_metadata round-trip', () => {
+  it('copies provider_metadata from tool call onto matching tool_result message', async () => {
+    const turnRequests: AdapterRequest[] = [];
+    let callCount = 0;
+    const sentinel = { thought_signature: 'sig-abc' };
+
+    const adapter: LlmAdapter = {
+      generate: vi.fn(),
+      generateStream: (request: AdapterRequest) =>
+        (async function* () {
+          turnRequests.push(request);
+          if (callCount++ === 0) {
+            yield {
+              type: 'tool_call' as const,
+              toolCall: {
+                id: '1',
+                name: 'real_tool',
+                args: {},
+                provider_metadata: sentinel,
+              },
+            };
+          } else {
+            yield { type: 'text_delta' as const, delta: 'done' };
+          }
+        })(),
+    };
+
+    const registry = new ToolRegistry();
+    registry.register({
+      definition: () => ({
+        name: 'real_tool',
+        description: 'A real tool',
+        parameters: {},
+        scope: 'read' as const,
+      }),
+      call: async () => 'ok',
+    });
+
+    const runner = new AgentRunner(adapter, registry);
+    for await (const _ of runner.runStream(agent, 'go')) {
+      // drain
+    }
+
+    // The second request's history must carry both the tool_calls message
+    // (with provider_metadata on each call) and the matching tool_result
+    // message (with provider_metadata copied verbatim).
+    const secondRequest = turnRequests[1];
+    const toolCallsMsg = secondRequest.messages.find((m) => m.content.type === 'tool_calls');
+    expect(toolCallsMsg).toBeDefined();
+    const calls = (toolCallsMsg!.content as { calls: { provider_metadata?: unknown }[] }).calls;
+    expect(calls[0].provider_metadata).toBe(sentinel);
+
+    const toolResultMsg = secondRequest.messages.find((m) => m.content.type === 'tool_result');
+    expect(toolResultMsg).toBeDefined();
+    expect((toolResultMsg!.content as { provider_metadata?: unknown }).provider_metadata).toBe(
+      sentinel,
+    );
+  });
+});
+
 describe('RunBuilder.forwardTo', () => {
   it('forwards every non-done event to parentContext.onEvent in order', async () => {
     const runner = new AgentRunner(

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -269,7 +269,13 @@ export class AgentRunner {
           }
           resultMessages.push({
             role: 'user',
-            content: { type: 'tool_result', id: call.id, name: call.name, result },
+            content: {
+              type: 'tool_result',
+              id: call.id,
+              name: call.name,
+              result,
+              provider_metadata: call.provider_metadata,
+            },
           });
         }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,13 @@ export interface ToolCall {
   id: string; // opaque identifier echoed back to the adapter
   name: string;
   args: unknown; // parsed JSON object matching the tool's parameters schema
+  /**
+   * Opaque per-call metadata controlled by the adapter / backend
+   * (e.g. Gemini `thoughtSignature`). MAST round-trips this value
+   * unchanged on the matching `tool_result`; it has no schema and
+   * is never inspected by the runner.
+   */
+  provider_metadata?: unknown;
 }
 
 /**
@@ -21,7 +28,14 @@ export interface ToolCall {
 export type MessageContent =
   | { type: 'text'; text: string }
   | { type: 'tool_calls'; calls: ToolCall[] }
-  | { type: 'tool_result'; id: string; name: string; result: unknown };
+  | {
+      type: 'tool_result';
+      id: string;
+      name: string;
+      result: unknown;
+      /** Copied verbatim from the originating tool call. */
+      provider_metadata?: unknown;
+    };
 
 /**
  * A single message in a conversation history.


### PR DESCRIPTION
## Summary

- Add an opaque `provider_metadata?: unknown` field to `ToolCall` and the `tool_result` message variant. MAST never inspects the value; the runner copies it from each tool call onto the matching tool result, and `UrpAdapter` round-trips it across both streaming and non-streaming wire paths.
- This unblocks Gemini 2.5+ thinking models behind `UrpAdapter`: they attach a `thoughtSignature` to every emitted `functionCall` and reject any subsequent turn whose replayed `functionCall` (or matching `functionResponse`) is missing it. Without a place to carry that opaque per-call blob, multi-turn tool use was broken end-to-end.
- The same field accommodates analogous needs from other providers (Anthropic tool-use ids, OpenAI Responses round-trip ids, etc.) without growing a Gemini-specific surface.

## Wire format

Optional in all three places (`ToolCall`, `tool_result`, `UrpToolCall`), so existing clients/servers that don't emit or read it continue to work — the 0.5.0 behaviour for backends that don't speak it is preserved exactly.

## Demo backend

Also updates `demos/core/rust-server` so the demo actually exercises the round-trip:

- Bumps `agent-rig` from `59dbc5d` to `537cd5e` (exposes `ToolCall::provider_metadata` as `pub`).
- Adds the field to `UrpToolCall` and `UrpMessageContent::ToolResult`.
- Forwards it in the replay, tool-result, and streaming-output paths. Non-streaming output is automatic via serde derive on `agent_rig::model::ToolCall`.

`basic-chat` needs no changes — it consumes `AgentEvent`s and uses `Conversation` for history; the round-trip is fully internal to `@mast-ai/core`.

## Test plan

- [x] `npm run lint`, `npm run format`, `npm run build`, `npm test --workspaces`
- [x] New `runner.test.ts` case asserts `provider_metadata` is copied onto the matching `tool_result` message and survives replay in the next turn
- [x] New `adapter/urp.test.ts` covers the round-trip across `generate()`, `generateStream()`, and outbound `tool_result` messages
- [x] `cargo build` + `cargo clippy -- -D warnings` clean on the rust-server demo
- [x] Manual end-to-end test with Gemini thinking + tool calls

Closes #125