### PR TITLE
chore: release v0.6.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.5.0"
+    "@mast-ai/core": "^0.6.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.5.0"
+    "@mast-ai/core": "^0.6.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/openai",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.5.0",
+    "@mast-ai/core": "^0.6.0",
     "openai": "^6.37.0"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.5.0",
+    "@mast-ai/core": "^0.6.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
## Summary

Lockstep release of all `@mast-ai/*` packages to **v0.6.0**.

### Changes since v0.5.0

- **`@mast-ai/core`** — minor: round-trip an opaque `provider_metadata` field on tool calls so Gemini 2.5+ thinking models work end-to-end behind `UrpAdapter` (#125 / #126). Field is optional everywhere, so backends/clients that don't speak it are unaffected.
- **`@mast-ai/google-genai`**, **`@mast-ai/built-in-ai`**, **`@mast-ai/openai`**, **`@mast-ai/react-ui`** — no source changes; bumped only to keep version drift at zero (per CLAUDE.md).

Severity: **minor** (new public API field, no breaking changes).

## Test plan

- [x] `npm run bump-version 0.6.0` + `npm install`
- [x] `npm run format`, `npm run lint`, `npm test --workspaces`, `npm run build` — all clean
- [ ] Tag `v0.6.0` after merge → `Publish` workflow ships all five packages via OIDC