### PR TITLE
docs(sub-agents): PRD, SPEC, PLAN, and migration guide

### DIFF
--- a/docs/sub-agents/MIGRATION.md
+++ b/docs/sub-agents/MIGRATION.md
@@ -1,0 +1,324 @@
+# Migration Guide: Sub-Agent Approval Architecture
+
+Audience: any app using `@mast-ai/core` or `@mast-ai/react-ui` from the
+release that introduces sub-agent approvals (see PLAN.md §"Release strategy").
+
+The architecture change moves approval gating from a `react-ui` registry-wrap
+into core, expressed as a per-run `ApprovalHandler` propagated through
+`ToolContext`. Most apps need no code changes; a handful need a small,
+mechanical rewrite. This guide walks through every scenario.
+
+## TL;DR
+
+| Your app's situation                                              | Action required                                                                                                                                       |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mounts `<AgentProvider>`, no other approval-related code          | None                                                                                                                                                  |
+| Calls `pendingApprovals[i].respondWith(text)`                     | Rename to `reject(text)`                                                                                                                              |
+| `onApprovalRequired` returns a `string`                           | Verify the new semantics fit ([§4](#4-onapprovalrequired-callbacks-that-return-a-string))                                                             |
+| Hit by issue #128 (sub-agent skips approval)                      | Bug auto-fixes — no code changes                                                                                                                      |
+| Uses `createAgentTool` with a child runner on a different adapter | Sub-agent now correctly inherits the UI approval surface ([§6](#6-sub-agents-on-independent-runners)) — no required changes; new capability available |
+| Imports `withApprovalProxy` from `@mast-ai/react-ui`              | Replace with `runner.conversation(agent, { approvalHandler })` ([§7](#7-replacing-withapprovalproxy))                                                 |
+| Builds a custom equivalent of `<AgentProvider>`                   | Replace the registry wrap with handler-on-conversation ([§7](#7-replacing-withapprovalproxy))                                                         |
+
+---
+
+## 1. What's new
+
+Three primitives are added to `@mast-ai/core` and re-exported from
+`@mast-ai/react-ui`:
+
+```ts
+interface ApprovalRequest {
+  name: string;
+  args: unknown;
+}
+
+type ApprovalResponse = { type: 'approve' } | { type: 'reject'; result?: string };
+
+interface ApprovalHandler {
+  requestApproval(req: ApprovalRequest): Promise<ApprovalResponse>;
+}
+```
+
+Plus the helper namespace `ApprovalResponse.approve()` /
+`ApprovalResponse.reject(result?)` for ergonomics.
+
+Three places now accept an `ApprovalHandler`:
+
+1. **`runner.conversation(agent, { approvalHandler })`** — every run on this
+   conversation uses the handler.
+2. **`runner.runBuilder(agent).withApprovalHandler(handler)`** — single-run
+   override.
+3. **`runner.approvalHandler = handler`** — runner-level default for any run
+   without an explicit handler.
+
+When invoking a tool, the runner threads the active handler into
+`ToolContext.approvalHandler`. Tools that internally start a sub-agent run —
+`createAgentTool` and any custom equivalents — forward this to the child run
+unless the child runner has its own default.
+
+---
+
+## 2. No-op migrations
+
+If your app only mounts `<AgentProvider>` and doesn't reach into approval
+internals, you don't need to change any code. Bump the package versions and
+re-run your tests.
+
+```diff
+- "@mast-ai/core": "0.6.0",
+- "@mast-ai/react-ui": "0.6.0",
++ "@mast-ai/core": "0.7.0",
++ "@mast-ai/react-ui": "0.7.0",
+```
+
+(Replace versions with the actual release. See PLAN.md §"Release strategy".)
+
+What you get for free: any `createAgentTool`-mediated sub-agent in your app
+now correctly fires `onApprovalRequired` for child tool calls flagged
+`requiresApproval: true`. This was the bug behind issue #128.
+
+---
+
+## 3. `pendingApprovals[i].respondWith(...)` → `reject(...)`
+
+The `PendingApproval` interface drops the `respondWith` method. The same
+behaviour — "skip execution, supply this string as the tool result" — is
+expressed as `reject(result)`:
+
+```diff
+  // Custom approval card resolving with a synthetic result:
+  function MyCard({ approval }: { approval: PendingApproval }) {
+    return (
+      <button
+-       onClick={() => approval.respondWith('Operation simulated.')}
++       onClick={() => approval.reject('Operation simulated.')}
+      >
+        Use canned response
+      </button>
+    );
+  }
+```
+
+The model still sees the same string as the tool result. The UI status now
+renders as `'cancelled'` instead of going unstyled — see §4 for the
+implications.
+
+---
+
+## 4. `OnApprovalRequired` callbacks that return a string
+
+If your `onApprovalRequired` callback returns a `string`, its meaning shifts
+slightly:
+
+|                         | Before                              | After               |
+| ----------------------- | ----------------------------------- | ------------------- |
+| Tool execution          | Skipped                             | Skipped             |
+| Result the model sees   | The returned string                 | The returned string |
+| `ToolEventEntry.status` | Unstyled (defaulted to `'success'`) | `'cancelled'`       |
+
+For most apps this is fine — the model's behaviour is identical. The
+visible difference is in the UI: the tool entry renders with the cancelled
+styling instead of success styling.
+
+If you were leaning on the previous "string ⇒ looks like success" behaviour
+to express _substituted success_, you have two options:
+
+```ts
+// Option A — accept the cancelled styling:
+onApprovalRequired={async ({ name }) =>
+  name === 'simulate_only' ? 'Operation simulated.' : INLINE_APPROVAL
+}
+
+// Option B — actually run the tool (and have your tool implementation
+// return the canned result internally):
+onApprovalRequired={async ({ name }) =>
+  name === 'simulate_only' ? true : INLINE_APPROVAL
+}
+```
+
+We chose to drop the "substituted success" status because it conflated
+"tool ran and succeeded" with "tool was bypassed and a result was substituted"
+in the rendered timeline — surprising for users auditing what the agent
+actually did. Cancelled-with-result is the honest reading.
+
+---
+
+## 5. Sub-agent approvals (issue #128 fix)
+
+### Before — broken
+
+```tsx
+const runner = new AgentRunner(adapter, registry);
+registry.register(
+  createAgentTool(runner, CODER, {
+    name: 'delegate',
+    description: 'Hand off to the coder.',
+    parameters: {
+      /* ... */
+    },
+    scope: 'write',
+    buildInput: (a) => a.task,
+  }),
+);
+
+<AgentProvider runner={runner} agent={PLANNER}>
+  <ConversationPanel />
+</AgentProvider>;
+```
+
+If `CODER` calls a tool with `requiresApproval: true`, the approval
+_silently bypassed_ — the tool executed without the user being asked.
+
+### After — fixed automatically
+
+The exact same code now correctly fires `onApprovalRequired` for the
+sub-agent's flagged tool calls. The handler attached by `<AgentProvider>` to
+the parent's `Conversation` propagates to the child run via
+`ToolContext.approvalHandler`.
+
+No code change. Bump the version and confirm with your existing test suite
+(or the test we landed in `approval.test.tsx` covering this exact flow).
+
+---
+
+## 6. Sub-agents on independent runners
+
+The architecture also unlocks a previously-broken case: sub-agents whose
+runner is fully independent of the parent's (different adapter, different
+registry, different toolset).
+
+```tsx
+// Parent uses URP-backed remote inference; child uses on-device Gemini Nano.
+const parentRunner = new AgentRunner(urpAdapter, parentRegistry);
+const childRunner = new AgentRunner(nanoAdapter, childRegistry);
+
+parentRegistry.register(
+  createAgentTool(childRunner, CHILD, {
+    name: 'private_classifier',
+    description: 'Classifies sensitive input on-device.',
+    parameters: {
+      /* ... */
+    },
+    scope: 'read',
+    buildInput: (a) => a.text,
+  }),
+);
+
+<AgentProvider runner={parentRunner} agent={PARENT}>
+  <ConversationPanel />
+</AgentProvider>;
+```
+
+Approvals on `childRunner`'s tools surface to the same
+`<AgentProvider>` UI as the parent's, with no additional wiring — the
+handler attached on the parent's `Conversation` propagates through
+`ToolContext`.
+
+If you want the child to enforce its own policy _instead_ of inheriting:
+
+```ts
+childRunner.approvalHandler = {
+  async requestApproval({ name }) {
+    return isAutoApprovedInChild(name)
+      ? ApprovalResponse.approve()
+      : ApprovalResponse.reject('Not allowed in classifier sandbox.');
+  },
+};
+```
+
+When `childRunner.approvalHandler` is set, `createAgentTool` does _not_
+inherit from `ToolContext` — the explicit child policy wins.
+
+---
+
+## 7. Replacing `withApprovalProxy`
+
+`withApprovalProxy`, `ApprovalProxyTool`, and `ApprovalProxyHooks` are
+removed from `@mast-ai/react-ui`. They were internal but reachable for
+anyone building a custom provider. The replacement is the new
+`runner.conversation(agent, { approvalHandler })` API plus a hand-rolled
+`ApprovalHandler`:
+
+### Before
+
+```ts
+import { withApprovalProxy } from '@mast-ai/react-ui';
+
+const wrapped = withApprovalProxy(
+  runner.registry,
+  () => myCallback,
+  () => myOverride,
+  hooks,
+);
+const wrappedRunner = new AgentRunner(runner.adapter, wrapped);
+const conversation = wrappedRunner.conversation(agent);
+```
+
+### After
+
+```ts
+import { type ApprovalHandler, ApprovalResponse, computeNeedsApproval } from '@mast-ai/react-ui';
+
+const approvalHandler: ApprovalHandler = {
+  async requestApproval({ name, args }) {
+    const def = runner.registry.getTool(name)?.definition();
+    if (!def || !computeNeedsApproval(def, myOverride)) {
+      return ApprovalResponse.approve();
+    }
+    const decision = await myCallback({ name, args });
+    if (decision === true) return ApprovalResponse.approve();
+    if (decision === false) return ApprovalResponse.reject();
+    return ApprovalResponse.reject(decision); // string
+  },
+};
+
+const conversation = runner.conversation(agent, { approvalHandler });
+```
+
+The user's `runner` is used directly — no more shadow runner. The handler
+is a closure over whatever React state your provider tracks (callback ref,
+override list, awaiting setters, inline queue).
+
+---
+
+## 8. Verification checklist
+
+After upgrading, confirm:
+
+- [ ] `npm install` resolves the new versions across both packages.
+- [ ] Existing approval flows continue to work — flagged tools still pause
+      for confirmation, the inline queue still fills correctly.
+- [ ] If your app uses `createAgentTool`, a sub-agent calling a flagged tool
+      now triggers the approval UI (it didn't before).
+- [ ] Any `respondWith(text)` call sites have been renamed to `reject(text)`.
+- [ ] If your `onApprovalRequired` returns a string, the cancelled styling
+      on the rendered tool entry is what you want (or fix per §4).
+
+---
+
+## 9. Rolling back
+
+If you need to revert, pin both packages to the previous release together:
+
+```json
+{
+  "dependencies": {
+    "@mast-ai/core": "0.6.0",
+    "@mast-ai/react-ui": "0.6.0"
+  }
+}
+```
+
+Mixing major-feature mismatched versions across `@mast-ai/*` is unsupported —
+the lockstep release policy means consumers always upgrade or downgrade
+the entire family together.
+
+---
+
+## 10. Where to file issues
+
+Bugs in the migration: open an issue on GitHub with the `sub-agents` label
+and a minimal reproduction. The sub-agents PRD/SPEC/PLAN documents are
+archived under `docs/archive/sub-agents/` after the rollout — refer to them
+for the rationale behind the design choices in this guide.

--- a/docs/sub-agents/PLAN.md
+++ b/docs/sub-agents/PLAN.md
@@ -1,0 +1,297 @@
+# Implementation Plan: Sub-Agent Approval Architecture
+
+Each issue below leaves the project in a state that builds, lints, and passes
+tests. Issues land as separate PRs against `main`, sequenced so reviewers can
+trace the refactor in stages — the earliest land additive type changes, the
+later replace the registry-wrap mechanism end-to-end. PRs all carry the
+`sub-agents` GitHub label.
+
+A reproduction test for issue #128 was drafted during planning
+(`it('intercepts approvals for tools called by sub-agents via
+createAgentTool', …)` in `packages/react-ui/src/approval.test.tsx`) and
+verified to fail against the current code. It is held in a working tree —
+not committed to `main` — until Issue 4 brings the rest of the rewrite. It
+lands as part of that PR, going from non-existent to green in a single
+commit.
+
+---
+
+## Issue 1 — Core: approval primitive types
+
+Land the new public types in `@mast-ai/core` without any behavior change. The
+types compile and are exported, but nothing in the runner or tools consumes
+them yet. This is the smallest reviewable starting point.
+
+**`packages/core/src/tool.ts`**
+
+- Add `ApprovalRequest`, `ApprovalResponse` (tagged union with `approve` /
+  `reject`), and the `ApprovalResponse` helper namespace (`approve()`,
+  `reject(result?)`).
+- Add `ApprovalHandler` interface with the single
+  `requestApproval(req): Promise<ApprovalResponse>` method.
+- Extend `ToolContext` with the optional `approvalHandler?: ApprovalHandler`
+  field.
+
+**`packages/core/src/error.ts` (or new file)**
+
+- Add and export `APPROVAL_CANCELLED_RESULT = 'User cancelled the tool call.'`
+  as a documented constant. Place wherever shared constants currently live.
+
+**`packages/core/src/index.ts`**
+
+- Re-export the new types and constant.
+
+**`packages/core/src/tool.test.ts`**
+
+- Type-level smoke tests: assert the helper namespace returns the expected
+  shape, and that `ApprovalResponse` narrows correctly in a `switch`.
+
+No behaviour change. `ToolContext.approvalHandler` is set by no one and read
+by no one; the field exists for Issue 2 to populate.
+
+**Branch:** `feat/sub-agents/approval-types`
+
+---
+
+## Issue 2 — Core: runner-level gating
+
+Wire `AgentRunner` to consult an `ApprovalHandler` for `requiresApproval`
+tools and to thread the handler into `ToolContext`. Adds the gating contract
+that `react-ui` will plug into in Issue 4.
+
+**`packages/core/src/runner.ts`**
+
+- Add `approvalHandler?: ApprovalHandler` field on `AgentRunner` (mutable —
+  consumers may attach a default after construction).
+- Add `_approvalHandler?: ApprovalHandler` field on `RunBuilder` plus
+  `withApprovalHandler(handler): this` setter.
+- In `executeStream`, resolve the active handler via
+  `builder._approvalHandler ?? this.approvalHandler`. Before each tool call:
+  - If `def.requiresApproval` is `true` and a handler is attached, call
+    `handler.requestApproval({ name, args })`.
+  - On `{ type: 'reject', result? }`: return `result ?? APPROVAL_CANCELLED_RESULT`
+    as the tool result; emit `tool_call_completed` with `error: false`.
+    UI status mapping is the consumer's responsibility (react-ui sets
+    `'cancelled'` in Issue 4).
+  - On `{ type: 'approve' }`: proceed to `tool.call`.
+- When invoking `tool.call`, pass `approvalHandler: handler` in the
+  `ToolContext`.
+
+**`packages/core/src/runner.test.ts`**
+
+- `requiresApproval: false` tools never call the handler.
+- `requiresApproval: true` with no handler attached executes as today
+  (ungated).
+- Handler returning `approve` runs the tool; `reject` skips and returns the
+  default cancelled string; `reject(result)` skips and returns `result`.
+- Handler attached via `RunBuilder.withApprovalHandler` overrides the
+  runner's default for that run only.
+- Runner-level default is consulted when no per-run handler is set.
+- `ToolContext.approvalHandler` is set to the active handler when
+  `tool.call` is invoked. Verified by a stub tool that records its
+  context.
+
+**Branch:** `feat/sub-agents/runner-gating`
+**Depends on:** Issue 1
+
+---
+
+## Issue 3 — Core: Conversation options and `createAgentTool` propagation
+
+Plumb the handler through the high-level entry points. `Conversation` carries
+the handler from its creation site (where `AgentProvider` will attach it in
+Issue 4) into every `runStream` call. `createAgentTool` forwards
+`ctx.approvalHandler` into child runs unless the child runner defines its own.
+
+**`packages/core/src/conversation.ts`**
+
+- Add `ConversationOptions { approvalHandler?: ApprovalHandler }`.
+- Constructor accepts `options: ConversationOptions = {}`; store as a
+  private field.
+- `buildStream` calls `builder.withApprovalHandler(this.options.approvalHandler)`
+  when set.
+
+**`packages/core/src/runner.ts`**
+
+- `AgentRunner.conversation(agent, options?: ConversationOptions)` overload.
+
+**`packages/core/src/agentTool.ts`**
+
+- In `tool.call`, after constructing the child `RunBuilder` and forwarding
+  the context:
+  ```ts
+  if (context.approvalHandler && !runner.approvalHandler) {
+    builder.withApprovalHandler(context.approvalHandler);
+  }
+  ```
+
+**`packages/core/src/conversation.test.ts`** (new tests)
+
+- `runner.conversation(agent, { approvalHandler })` propagates the handler
+  to every `runStream` call.
+
+**`packages/core/src/agentTool.test.ts`** (new tests)
+
+- Sub-agent inherits `ctx.approvalHandler` when the child runner has no
+  default. A `requiresApproval: true` tool registered on the child
+  triggers the inherited handler.
+- Sub-agent uses the child runner's own `approvalHandler` when set —
+  inherited handler is _not_ called for child tools.
+- Sub-agent runs ungated when neither `ctx.approvalHandler` nor the child
+  runner's handler is present (today's behaviour for unattached runs).
+
+**Branch:** `feat/sub-agents/conversation-and-agenttool`
+**Depends on:** Issue 2
+
+---
+
+## Issue 4 — react-ui: switch `AgentProvider` to handler-based gating
+
+Replace the `withApprovalProxy` registry-wrap mechanism with a per-run
+`ApprovalHandler`. Removes the shadow `AgentRunner` construction. Updates
+`PendingApproval` to its simpler shape.
+
+**`packages/react-ui/src/approval.ts`**
+
+- Delete `ApprovalProxyTool`.
+- Delete `ApprovalProxyHooks`.
+- Delete `withApprovalProxy`.
+- Keep `INLINE_APPROVAL`, `OnApprovalRequired`, `computeNeedsApproval` —
+  their public contracts are unchanged.
+- Update `PendingApproval`:
+  - Drop `respondWith`.
+  - Change `reject` to `(result?: string) => void`.
+- Add a small factory that builds an `ApprovalHandler` from the React-side
+  refs (callback prop, override prop, inline queue resolver, awaiting/state
+  setters). The factory's `requestApproval` body is the logic currently
+  living inside `ApprovalProxyTool.call`, retargeted to return
+  `ApprovalResponse`.
+
+**`packages/react-ui/src/context.tsx`**
+
+- Remove the `wrappedRunner = new AgentRunner(runner.adapter, provider)`
+  block. Use the user's `runner` directly.
+- Build the `ApprovalHandler` once via `useMemo` and pass it as
+  `runner.conversation(agent, { approvalHandler })`.
+- Inline approval enqueue resolves with `boolean | string`; the handler
+  factory translates that into `ApprovalResponse` (true → approve, false
+  → reject(), string → reject(string)).
+- `reset()` keeps the existing semantics: reject in-flight approvals so
+  the run terminates.
+
+**`packages/react-ui/src/approval.test.tsx`**
+
+- All existing tests retained and updated for the new mechanism. The two
+  semantic changes the suite must reflect:
+  - A string returned from `OnApprovalRequired` now lands as
+    `status: 'cancelled'` (was previously not status-tagged). Existing
+    tests asserting "respondWith string ⇒ status success" become
+    "reject string ⇒ status cancelled".
+  - `pendingApprovals[i].respondWith(text)` test cases migrate to
+    `pendingApprovals[i].reject(text)`.
+- The pre-landed regression test for #128 flips from failing to passing.
+- Two new tests:
+  - **Independent runner inherits**: child runner with its own
+    `AgentRunner` instance and no `approvalHandler` of its own surfaces
+    approvals to the parent's `<AgentProvider>` (handler attached on the
+    parent `Conversation`, propagated through `ToolContext`).
+  - **Isolated child handler wins**: child runner's
+    `approvalHandler` is consulted (and the parent's is not) when set.
+
+**`packages/react-ui/src/index.ts`**
+
+- Stop re-exporting any of the removed proxy types (verify nothing did so
+  already; clean up if it did).
+
+**Branch:** `feat/sub-agents/react-ui-rewrite`
+**Depends on:** Issue 3
+
+---
+
+## Issue 5 — Documentation refresh
+
+Update the library-level and react-ui-level docs so they describe the new
+architecture. The sub-agents subdirectory PRD and SPEC stay where they are
+during this issue; they move to `docs/archive/` in Issue 6.
+
+**`docs/PRD.md`**
+
+- §3 (Recursive Sub-Agents): clarify that approval policy travels with the
+  _run_, not the runner — sub-agents on independent runners still surface
+  approvals to the parent's UI.
+
+**`docs/SPEC.md`**
+
+- `ToolContext` section: document `approvalHandler` field and its
+  propagation contract.
+- Add a brief note that `requiresApproval` gating is enforced by the
+  runner when a handler is attached, replacing the previous "react-ui
+  enforces this via a registry wrap" framing.
+
+**`docs/react-ui/SPEC.md`**
+
+- §9.1–9.3: rewrite to describe the per-run handler model. Replace the
+  "proxy intercepts the registry" prose with the runner-gating prose.
+- Update the `PendingApproval` shape (drop `respondWith`).
+- Note the semantic change for `OnApprovalRequired` returning a string.
+
+**`docs/react-ui/USAGE.md`**
+
+- Audit for any reference to `respondWith` or the legacy "string ⇒
+  substituted success" behaviour. Update to match.
+
+**`docs/sub-agents/MIGRATION.md`**
+
+- Pin the version numbers in §2 ("No-op migrations") and §9 ("Rolling
+  back") to the actual release tags now that we know them.
+- Cross-link the release notes once the tag exists.
+
+No code changes in this issue. Doc-only PR.
+
+**Branch:** `docs/sub-agents/refresh`
+**Depends on:** Issue 4
+
+---
+
+## Issue 6 — Archive sub-agents docs and close out
+
+Final housekeeping. Run after all earlier issues have shipped to `main` and
+the next release is cut.
+
+- Move `docs/sub-agents/` to `docs/archive/sub-agents/` (per the CLAUDE.md
+  rule about archived feature docs).
+- Verify the `gh issue close #128` happened automatically via the
+  `Closes #128` line in the Issue 4 PR body.
+- Remove the `sub-agents` label from open issues if any drift remains.
+
+**Branch:** `chore/sub-agents/archive`
+**Depends on:** Issue 5 + a release cut that includes Issues 1–4
+
+---
+
+## Release strategy
+
+The cumulative effect of Issues 1–4 is a coordinated breaking change to
+`@mast-ai/core` (new `ToolContext` field, new exports) and `@mast-ai/react-ui`
+(`PendingApproval` shape change, internal proxy removal). Per the lockstep
+release policy, a single minor version bump covers both packages once Issue 4
+is merged. Cut the release after Issue 5 lands so the published docs match
+the published code.
+
+The `OnApprovalRequired` callback-string semantic change is a
+behaviour-level breaking change but a typing-level minor change (the return
+type union is unchanged). Call out in the release notes.
+
+---
+
+## Out-of-scope follow-ups
+
+These are not part of this plan but worth noting for future work:
+
+- A standalone `<SubAgentProvider>` for declarative attachment of independent
+  sub-agent runners to the same UI surface.
+- Approval events on the `AgentEvent` stream (an alternative to the callback
+  shape — explored in PRD §8 and rejected for v1).
+- Multi-tenant approval surfaces (one runner reporting to multiple UIs).
+- Migration to strict semver post-1.0; today the minor-version bump covers
+  the breaking surface change.

--- a/docs/sub-agents/PRD.md
+++ b/docs/sub-agents/PRD.md
@@ -1,0 +1,201 @@
+# Product Requirements Document: Sub-Agent Approval Architecture
+
+## 1. Summary
+
+Approvals — the human-in-the-loop confirmation step that gates execution of
+tools flagged `requiresApproval: true` — are currently implemented as a wrapper
+around a single `AgentRunner`'s registry. The wrap is invisible to anything
+that captured the original runner reference, so a sub-agent invoked through
+`createAgentTool` bypasses the policy entirely.
+
+This document scopes a refactor that moves approval handling out of the
+registry-wrap layer and into the runner itself, with the policy propagated to
+sub-agent runs through `ToolContext`. The goal is an architecture where
+sub-agents are first-class — fully independent runners with their own adapter,
+registry, and tools — yet approvals still surface to the same UI surface as
+the parent's tool calls.
+
+The work is tracked in `gh issue #128`. The bug is a symptom; this PRD scopes
+the architectural change that fixes it cleanly.
+
+## 2. Problem Statement
+
+Today's approval flow looks like this:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                          User code                               │
+│                                                                  │
+│   const tool = createAgentTool(runner, CHILD, { ... });          │
+│   registry.register(tool);          captures `runner` ─────┐     │
+│                                                            │     │
+│   <AgentProvider runner={runner} agent={PARENT}>           │     │
+│             │                                              │     │
+│             │ wraps registry, builds NEW runner            │     │
+│             ▼                                              │     │
+│        wrappedRunner = new AgentRunner(adapter, W(reg))    │     │
+│        ▲                                                   │     │
+│        │ runs PARENT through wrap                          │     │
+│        │                                                   │     │
+│   PARENT calls `delegate` → tool.call(args, ctx) ──────────┘     │
+│                                  │                               │
+│                                  ▼                               │
+│                  runner.runBuilder(CHILD)  ← UNWRAPPED runner    │
+│                  CHILD's tools resolve through original registry │
+│                  → sensitive tools execute WITHOUT approval      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Three architectural shortcomings cause this:
+
+1. **Approval lives at the registry layer.** `AgentProvider` wraps
+   `runner.registry` with a `ToolProvider` that intercepts `getTool(name)` and
+   decorates flagged tools. The wrap is bound to one specific runner instance.
+2. **`createAgentTool` captures the runner at factory time.** The reference is
+   the _unwrapped_ one, so sub-agent runs bypass the wrap.
+3. **Sub-agent runners are not independent.** The current shape effectively
+   forces sub-agents to share the parent's runner if they want approvals to
+   flow. Configuring a sub-agent with its own adapter and registry breaks the
+   approval path entirely.
+
+The library's PRD §3 promises "Recursive Sub-Agents… each sub-agent may run in
+any execution mode independently of its parent." Approval policy is currently
+the load-bearing exception to that promise.
+
+## 3. Goals
+
+- **Independent sub-agent runners.** A sub-agent must be able to use its own
+  adapter, registry, and toolset, fully decoupled from the parent runner, and
+  still surface approvals to the same UI.
+- **Approval as a per-run policy.** The decision of "should this tool call
+  pause for human confirmation?" is configured at run time, not bolted onto
+  the registry.
+- **Inheritance through `ToolContext`.** A sub-agent run inherits the active
+  approval handler from the tool call that invoked it, so the common case
+  (one UI, many runners) works with zero extra wiring.
+- **Explicit override.** A consumer can attach a different handler to a child
+  run when they want isolation between parent and child approval surfaces.
+- **Drop the wrapped-runner pattern.** `AgentProvider` no longer constructs a
+  shadow `AgentRunner`. The user's runner reference is the runner that runs.
+
+## 4. Non-Goals
+
+- **Changing the user-facing `AgentProvider` props.** `onApprovalRequired`,
+  `approvalOverride`, `INLINE_APPROVAL`, and `useAgent().pendingApprovals` keep
+  their current shapes and semantics.
+- **Backwards compatibility for internals.** The library is pre-1.0 and the
+  internal `withApprovalProxy` / `ApprovalProxyTool` types are not part of the
+  public surface (they are not re-exported from `react-ui/src/index.ts`).
+- **Multi-conversation provider.** Mounting one `<AgentProvider>` per
+  conversation remains the supported pattern.
+- **A registry of "all runners in the app."** The provider does not maintain a
+  catalogue of runners. Sub-agent runners inherit through `ToolContext`; if a
+  consumer wants explicit attachment, they call the runner's own configuration
+  method.
+
+## 5. User Stories
+
+### 5.1 Same runner, sub-agent through `createAgentTool` (the #128 bug)
+
+> As a developer building a planner+coder topology where both agents share a
+> runner, I want approvals on the coder's tools to surface to the same UI as
+> the planner's tools, with no extra wiring beyond the existing
+> `<AgentProvider>` mount.
+
+```ts
+const runner = new AgentRunner(adapter, registry);
+registry.register(createAgentTool(runner, CODER, { name: 'delegate', ... }));
+
+<AgentProvider runner={runner} agent={PLANNER}>
+  <ConversationPanel />
+</AgentProvider>
+```
+
+The CODER's `requiresApproval: true` tools must trigger
+`onApprovalRequired` — currently they do not.
+
+### 5.2 Independent runner, shared approval surface
+
+> As a developer running a sub-agent on a different adapter (e.g. a privacy-
+> sensitive child on Gemini Nano while the parent runs on Gemini 2.5 Flash via
+> URP), I want both runs to surface approvals to the same `<AgentProvider>`
+> UI without coupling their adapters.
+
+```ts
+const parentRunner = new AgentRunner(remoteAdapter, parentRegistry);
+const childRunner  = new AgentRunner(nanoAdapter,   childRegistry);
+
+parentRegistry.register(createAgentTool(childRunner, CHILD, { ... }));
+
+<AgentProvider runner={parentRunner} agent={PARENT}>
+  <ConversationPanel />
+</AgentProvider>
+```
+
+The CHILD's flagged tool calls must surface in `pendingApprovals` of the same
+provider as the parent's, even though the runners share nothing else.
+
+### 5.3 Independent runner, isolated approval surface
+
+> As a developer embedding a sub-agent with its own approval policy (e.g.
+> a tool-builder that auto-approves everything because it runs in a sandbox),
+> I want to attach a separate handler to the child runner that takes
+> precedence over the parent's.
+
+The child run uses the explicitly configured handler; the parent's handler is
+not consulted for the child's tool calls.
+
+## 6. Functional Requirements
+
+1. **Approval gating moves into `AgentRunner`.** Before invoking a tool flagged
+   `requiresApproval: true` (with the runtime `approvalOverride` rules
+   applied), the runner consults the active handler and acts on its decision.
+2. **Approval policy is attached to a run.** `RunBuilder.withApprovalHandler`
+   sets the handler for that run. `Conversation` accepts the handler at
+   construction time and threads it through every `runStream` call.
+3. **Policy propagation through `ToolContext`.** When the runner invokes a
+   tool, it passes `approvalHandler` in `ToolContext`. `createAgentTool`
+   forwards the inherited handler to the child run unless an explicit handler
+   is configured on the child runner.
+4. **`createAgentTool` keeps its current signature.** It still takes
+   `(runner, agent, options)`. The runner argument continues to mean "the
+   adapter+registry the child will use." Approval policy is no longer the
+   runner's job to capture.
+5. **`AgentProvider` no longer constructs a shadow runner.** The user's
+   `runner` is the one that runs. `AgentProvider` configures the handler on
+   each run it kicks off via the `Conversation` it owns.
+6. **Sub-agents not invoked from a parent run still work.** A standalone
+   `runner.run(...)` with no approval handler attached either auto-approves
+   `requiresApproval` tools (preserving today's "no callback ⇒ enqueue inline"
+   default behavior is the responsibility of the consumer that attached the
+   handler).
+
+## 7. Success Criteria
+
+1. **#128 reproduction test passes.** A `createAgentTool`-mediated sub-agent
+   with a `requiresApproval: true` tool fires `onApprovalRequired` for the
+   inner call.
+2. **Independent-runner test passes.** A sub-agent on a different runner
+   instance (different adapter, different registry) still surfaces approvals
+   to the parent's `<AgentProvider>`.
+3. **Isolated-handler test passes.** A child runner with an explicitly
+   configured handler does not consult the parent's handler.
+4. **No registry mutation.** `AgentProvider` does not modify the user's
+   `runner.registry`. The `registry` field stays `readonly`.
+5. **`withApprovalProxy` is removed** from `@mast-ai/react-ui`. Equivalent
+   tests in `approval.test.tsx` continue to pass against the new mechanism.
+6. **Public surface preserved.** `AgentProvider` props, `useAgent()` return
+   shape, `INLINE_APPROVAL` sentinel, and `PendingApproval` interface are
+   unchanged.
+
+## 8. Out of Scope (this revision)
+
+- A standalone `<SubAgentProvider>` component for declarative attachment of
+  child runners. Inheritance through `ToolContext` covers the common cases;
+  declarative attachment can be added later without API churn.
+- An `approval` event in the `AgentEvent` stream. The current callback shape
+  is sufficient; emitting events instead would require defining back-channel
+  semantics for the decision and risks introducing stream-consumer
+  responsibility for resolution.
+- Multi-tenant approval surfaces (one runner reporting to multiple UIs).
+  Consumers needing this can fan out from a single handler.

--- a/docs/sub-agents/SPEC.md
+++ b/docs/sub-agents/SPEC.md
@@ -1,0 +1,647 @@
+# Technical Specification: Sub-Agent Approval Architecture
+
+## 1. Architectural Overview
+
+### 1.1 Today (the broken topology)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                            @mast-ai/core                             │
+│                                                                      │
+│   ┌──────────────────┐    ┌────────────────┐                         │
+│   │   AgentRunner    │───▶│  ToolProvider  │  ToolDefinition[]       │
+│   │   (adapter,      │    │  (registry)    │  + getTool(name)        │
+│   │    registry)     │    └────────────────┘                         │
+│   └──────────────────┘                                               │
+│                                                                      │
+│   ┌──────────────────────────────────────┐                           │
+│   │   createAgentTool(runner, agent, …)  │  captures `runner`        │
+│   │   returns Tool whose call() runs      │  at factory time          │
+│   │   `runner.runBuilder(agent)…`        │                           │
+│   └──────────────────────────────────────┘                           │
+└──────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                          @mast-ai/react-ui                           │
+│                                                                      │
+│   ┌────────────────────┐                                             │
+│   │   AgentProvider    │   on mount:                                 │
+│   │                    │     wrappedReg = withApprovalProxy(         │
+│   │                    │                    runner.registry, …)     │
+│   │                    │     wrappedRunner = new AgentRunner(        │
+│   │                    │                       runner.adapter,       │
+│   │                    │                       wrappedReg)           │
+│   │                    │     conv = wrappedRunner.conversation(…)   │
+│   └────────────────────┘                                             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The wrap is _not visible_ to anything that captured `runner` before the
+provider mounted. The sub-agent path calls `runner.runBuilder(...)` on the
+unwrapped runner, so its tool resolution skips the approval proxy.
+
+### 1.2 After (per-run policy through context)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                            @mast-ai/core                             │
+│                                                                      │
+│   ┌──────────────────┐                                               │
+│   │   AgentRunner    │   gates `requiresApproval` tools by           │
+│   │                  │   consulting the run's approvalHandler;       │
+│   │                  │   propagates the handler into ToolContext     │
+│   └──────────────────┘                                               │
+│                                                                      │
+│   ┌────────────────────────────────────────────────────────┐         │
+│   │   RunBuilder.withApprovalHandler(handler)             │         │
+│   │   Conversation accepts handler at construction        │         │
+│   └────────────────────────────────────────────────────────┘         │
+│                                                                      │
+│   ┌────────────────────────────────────────────────────────┐         │
+│   │   createAgentTool(runner, agent, options)             │         │
+│   │   tool.call(args, ctx):                                │         │
+│   │     builder = runner.runBuilder(agent).forwardTo(ctx) │         │
+│   │     // inherit unless child runner has its own handler│         │
+│   │     if (ctx.approvalHandler && !runner.approvalHandler)│        │
+│   │       builder.withApprovalHandler(ctx.approvalHandler)│         │
+│   └────────────────────────────────────────────────────────┘         │
+└──────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                          @mast-ai/react-ui                           │
+│                                                                      │
+│   ┌────────────────────┐                                             │
+│   │   AgentProvider    │   uses the user's runner directly           │
+│   │                    │   (no shadow runner, no registry wrap)      │
+│   │                    │   conv = runner.conversation(agent, {       │
+│   │                    │            approvalHandler: uiHandler })    │
+│   └────────────────────┘                                             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 1.3 Inheritance flow at run time
+
+```
+   User clicks "Send" in <ChatInput>
+            │
+            ▼
+   conversation.runStream(input)
+            │
+            │   builder = runner.runBuilder(PARENT).history(…)
+            │   builder.withApprovalHandler(uiHandler)        ← attached by
+            │                                                   AgentProvider
+            ▼
+   AgentRunner.executeStream  (PARENT)
+            │
+            │  for each tool call:
+            │    if (def.requiresApproval && handler)
+            │       decision = await handler({name, args})
+            │       …gate execution…
+            │    else
+            │       tool.call(args, {
+            │         signal, onEvent,
+            │         approvalHandler: handler              ← propagated
+            │       })
+            ▼
+   delegate.call(args, ctx)         (a createAgentTool tool)
+            │
+            │  childBuilder = childRunner.runBuilder(CHILD).forwardTo(ctx)
+            │  if (ctx.approvalHandler && !childRunner.approvalHandler)
+            │     childBuilder.withApprovalHandler(ctx.approvalHandler)
+            ▼
+   AgentRunner.executeStream  (CHILD)
+            │
+            │  same handler is consulted for CHILD's tool calls,
+            │  even though CHILD runs on a completely different
+            │  AgentRunner instance.
+            ▼
+   sensitive.call → gated by uiHandler → user sees inline approval card
+```
+
+Two important properties of this flow:
+
+1. **`childRunner` can be entirely independent.** It can have a different
+   adapter, a different registry, and a different toolset. Inheritance is
+   through `ctx.approvalHandler`, a value, not through a runner reference.
+2. **An explicit handler on the child wins.** `createAgentTool` only
+   inherits when the child runner does not already have one configured.
+
+## 2. Type Changes
+
+### 2.0 Type relationships at a glance
+
+```mermaid
+classDiagram
+    direction TB
+
+    class AgentRunner {
+        +adapter: LlmAdapter
+        +registry: ToolProvider
+        +approvalHandler?: ApprovalHandler
+        +runBuilder(agent) RunBuilder
+        +conversation(agent, opts) Conversation
+    }
+
+    class RunBuilder {
+        -_approvalHandler?: ApprovalHandler
+        +withApprovalHandler(h) RunBuilder
+        +runStream(input) AsyncIterable
+    }
+
+    class Conversation {
+        +runStream(input) AsyncIterable
+    }
+
+    class ConversationOptions {
+        +approvalHandler?: ApprovalHandler
+    }
+
+    class Tool {
+        <<interface>>
+        +definition() ToolDefinition
+        +call(args, ctx) Promise
+    }
+
+    class ToolContext {
+        +signal?: AbortSignal
+        +onEvent?: function
+        +approvalHandler?: ApprovalHandler
+    }
+
+    class ApprovalHandler {
+        <<interface>>
+        +requestApproval(req) Promise~ApprovalResponse~
+    }
+
+    class ApprovalRequest {
+        +name: string
+        +args: unknown
+    }
+
+    class ApprovalResponse {
+        <<tagged union>>
+        +type: approve or reject
+        +result?: string
+    }
+
+    AgentRunner ..> RunBuilder : creates
+    AgentRunner ..> Conversation : creates
+    AgentRunner ..> ToolContext : constructs per tool.call
+    AgentRunner --> ApprovalHandler : default (optional)
+
+    RunBuilder --> ApprovalHandler : per-run override (optional)
+    Conversation ..> ConversationOptions : configured by
+    ConversationOptions --> ApprovalHandler : carries (optional)
+
+    Tool ..> ToolContext : receives in call()
+    ToolContext --> ApprovalHandler : propagates (optional)
+
+    ApprovalHandler ..> ApprovalRequest : input
+    ApprovalHandler ..> ApprovalResponse : output
+```
+
+Reading the diagram:
+
+- **`ApprovalHandler` is a single-interface concept** consumed in three places:
+  attached to a runner as a default, attached to a single run via
+  `RunBuilder.withApprovalHandler`, or threaded into tool execution through
+  `ToolContext.approvalHandler`.
+- **`ToolContext` is the runtime conduit.** Every `tool.call(args, ctx)` sees
+  it; `createAgentTool`-style tools forward `ctx.approvalHandler` into the
+  child run's `RunBuilder` so sub-agents inherit the same policy.
+- **`ApprovalRequest` and `ApprovalResponse` are the ask/answer primitives.**
+  The request describes _which tool wants to run with what args_; the
+  response is a tagged union of `approve` or `reject` (with optional
+  custom result string on rejection).
+
+### 2.1 `@mast-ai/core/src/tool.ts`
+
+```typescript
+/** A request from the runner asking the consumer to gate a tool call. */
+export interface ApprovalRequest {
+  /** Name of the tool whose call is being requested. */
+  name: string;
+  /** Arguments the model passed to the tool. */
+  args: unknown;
+}
+
+/**
+ * Decision returned by an {@link ApprovalHandler}. Two variants — the
+ * fundamental question is whether the tool runs.
+ *
+ * - `approve` — proceed with normal tool execution.
+ * - `reject` — skip execution. The model sees `result` as the tool result, or
+ *   {@link APPROVAL_CANCELLED_RESULT} when omitted. UI status is always
+ *   `'cancelled'` for rejected calls.
+ *
+ * Substituting a synthetic result on rejection (the use case the previous
+ * `respondWith` variant served) is expressed as `{ type: 'reject', result }`.
+ */
+export type ApprovalResponse = { type: 'approve' } | { type: 'reject'; result?: string };
+
+/**
+ * Helper constructors. Optional ergonomic sugar — handlers may also return
+ * the literal shape directly.
+ *
+ * @example
+ * async requestApproval({ name }) {
+ *   if (isAutoApproved(name)) return ApprovalResponse.approve();
+ *   if (name === 'sandboxed_only') return ApprovalResponse.reject('Disabled in sandbox.');
+ *   return ApprovalResponse.reject();
+ * }
+ */
+export const ApprovalResponse = {
+  approve(): ApprovalResponse {
+    return { type: 'approve' };
+  },
+  reject(result?: string): ApprovalResponse {
+    return { type: 'reject', result };
+  },
+};
+
+/**
+ * Decides whether to proceed with a tool call flagged `requiresApproval`.
+ *
+ * Modeled as an interface (rather than a bare function type) so future
+ * extensions — e.g. a `dispose()` lifecycle hook, observers for awaiting
+ * state, or a streaming-decision channel — can be added without breaking
+ * existing implementations.
+ */
+export interface ApprovalHandler {
+  /**
+   * Called by the runner before invoking any tool whose definition has
+   * `requiresApproval: true`. Resolve with the {@link ApprovalResponse}
+   * dictating what happens next.
+   */
+  requestApproval(request: ApprovalRequest): Promise<ApprovalResponse>;
+}
+
+export interface ToolContext {
+  signal?: AbortSignal;
+  onEvent?: (event: AgentEvent) => void;
+  /**
+   * The approval handler attached to the currently-running run. Tools that
+   * internally start sub-agent runs should forward this to the child's
+   * `RunBuilder.withApprovalHandler` unless the child runner already has its
+   * own handler configured. Set by `AgentRunner` when invoking tools.
+   */
+  approvalHandler?: ApprovalHandler;
+}
+```
+
+### 2.2 `@mast-ai/core/src/runner.ts`
+
+`AgentRunner` gains an optional default handler and the gating logic.
+`RunBuilder` exposes `withApprovalHandler`.
+
+```typescript
+export class AgentRunner {
+  /**
+   * Optional default approval handler consulted by every run on this runner
+   * unless overridden via `RunBuilder.withApprovalHandler`. Mainly useful for
+   * sub-agent runners that want a fixed policy regardless of who invokes
+   * them.
+   */
+  approvalHandler?: ApprovalHandler;
+
+  constructor(
+    public readonly adapter: LlmAdapter,
+    public readonly registry: ToolProvider = new ToolRegistry(),
+  ) {}
+  // ... unchanged factories ...
+}
+
+export class RunBuilder {
+  // existing fields …
+  private _approvalHandler?: ApprovalHandler;
+
+  /**
+   * Attach an approval handler for this run. The handler is consulted before
+   * every tool call whose `requiresApproval` flag is `true`, and is
+   * propagated to sub-agent runs through {@link ToolContext.approvalHandler}.
+   */
+  withApprovalHandler(handler: ApprovalHandler): this {
+    this._approvalHandler = handler;
+    return this;
+  }
+}
+```
+
+In `AgentRunner.executeStream`, the resolution order for the handler is:
+
+1. The handler set on the active `RunBuilder` via `withApprovalHandler`.
+2. Otherwise, `this.approvalHandler` (the runner's default).
+3. Otherwise, no gating — the tool runs as if it had no `requiresApproval` flag.
+
+The decision is applied uniformly:
+
+```typescript
+const def = tool.definition();
+const handler = builder._approvalHandler ?? this.approvalHandler;
+if (def.requiresApproval && handler) {
+  const response = await handler.requestApproval({ name: call.name, args: call.args });
+  if (response.type === 'reject') {
+    return response.result ?? APPROVAL_CANCELLED_RESULT;
+  }
+  // 'approve' — fall through to tool.call
+}
+return tool.call(call.args, { signal, onEvent, approvalHandler: handler });
+```
+
+The default cancelled-result string moves from `react-ui` into core as an
+exported constant, used when a `reject` decision omits an explicit `result`:
+
+```typescript
+export const APPROVAL_CANCELLED_RESULT = 'User cancelled the tool call.';
+```
+
+### 2.3 `@mast-ai/core/src/conversation.ts`
+
+`Conversation` accepts the handler at construction. Each call to `runStream`
+attaches it via `RunBuilder.withApprovalHandler`.
+
+```typescript
+export interface ConversationOptions {
+  approvalHandler?: ApprovalHandler;
+}
+
+export class Conversation {
+  history: Message[] = [];
+
+  constructor(
+    private readonly runner: AgentRunner,
+    private readonly agent: AgentConfig,
+    private readonly options: ConversationOptions = {},
+  ) {}
+
+  // buildStream attaches the handler if present.
+}
+
+// AgentRunner factory:
+export class AgentRunner {
+  conversation(agent: AgentConfig, options?: ConversationOptions): Conversation {
+    return new Conversation(this, agent, options);
+  }
+}
+```
+
+The handler stored on the `Conversation` is read by reference on every run, so
+React refs in the consumer can keep it pointing at the latest prop value
+without rebuilding the conversation.
+
+### 2.4 `@mast-ai/core/src/agentTool.ts`
+
+`createAgentTool` keeps its public signature. The implementation forwards
+`ctx.approvalHandler` to the child run unless the child runner has its own
+default configured.
+
+```typescript
+export function createAgentTool(
+  runner: AgentRunner,
+  agent: AgentConfig,
+  options: AgentToolOptions,
+): Tool {
+  // unchanged definition()
+
+  return {
+    definition: () => definition,
+    async call(args, context) {
+      const input = options.buildInput(args);
+      const builder = runner.runBuilder(agent).forwardTo(context);
+      if (context.signal) builder.signal(context.signal);
+
+      // Inherit unless the child runner has its own default. An explicit
+      // handler on the child wins.
+      if (context.approvalHandler && !runner.approvalHandler) {
+        builder.withApprovalHandler(context.approvalHandler);
+      }
+
+      for await (const event of builder.runStream(input)) {
+        if (event.type === 'done') return event.output;
+      }
+      throw new AgentError(`Sub-agent '${agent.name}' stream ended without a 'done' event.`);
+    },
+  };
+}
+```
+
+## 3. `@mast-ai/react-ui` Changes
+
+### 3.1 Removed
+
+- `withApprovalProxy` factory (`approval.ts`).
+- `ApprovalProxyTool` class (`approval.ts`).
+- `ApprovalProxyHooks` interface (`approval.ts`).
+
+### 3.2 Replaced — `AgentProvider`
+
+`AgentProvider` no longer constructs a shadow runner. It builds an
+`ApprovalHandler` from its props and the inline-queue plumbing, then passes it
+to `runner.conversation(agent, { approvalHandler })`.
+
+```typescript
+// pseudocode for the relevant parts of AgentProvider
+const approvalHandler = useMemo<ApprovalHandler>(
+  () => ({
+    async requestApproval({ name, args }) {
+      const def = runner?.registry.getTool(name)?.definition();
+      if (!def) return ApprovalResponse.approve(); // unknown tool — let the runner handle it
+      const override = approvalOverrideRef.current;
+      if (!computeNeedsApproval(def, override)) return ApprovalResponse.approve();
+
+      notifyAwaitingRef.current?.(name, true);
+      try {
+        const callback = onApprovalRef.current ?? DEFAULT_ON_APPROVAL_REQUIRED;
+        const initial = await callback({
+          id: '',
+          type: 'tool_call_started',
+          name,
+          args,
+          isStreaming: true,
+        });
+        const resolved =
+          initial === INLINE_APPROVAL ? await enqueueInlineRef.current!(name, args) : initial;
+        // `OnApprovalRequired`'s public boolean | string contract is
+        // translated into the new ApprovalResponse shape here. A string
+        // becomes a reject-with-custom-result rather than a "substituted
+        // success" — UI status for non-true outcomes is uniformly
+        // 'cancelled', as documented in §3.5.
+        if (resolved === true) return ApprovalResponse.approve();
+        setStatusRef.current?.(name, 'cancelled');
+        return ApprovalResponse.reject(resolved === false ? undefined : resolved);
+      } finally {
+        notifyAwaitingRef.current?.(name, false);
+      }
+    },
+  }),
+  [runner],
+);
+
+const conversation = useMemo(
+  () => (runner === null ? null : runner.conversation(agent, { approvalHandler })),
+  [runner, agent, approvalHandler],
+);
+```
+
+The handler reads its dependencies (`onApprovalRef`, `approvalOverrideRef`,
+the inline-queue resolver) through refs, so the same handler instance can be
+reused for the lifetime of the conversation — no rebuild on prop change.
+
+The handler must consult the _registry's_ tool definitions to apply
+`computeNeedsApproval` (the override-prefix logic). It looks up the
+definition through `runner.registry.getTool(name)?.definition()`.
+
+### 3.3 `useAgent()` return shape
+
+Unchanged.
+
+### 3.4 `INLINE_APPROVAL` sentinel and `OnApprovalRequired` callback
+
+Sentinel and callback signature are unchanged in shape (`boolean | string |
+typeof INLINE_APPROVAL`). One semantic change: a returned `string` is now
+interpreted as **reject with custom result** (status `'cancelled'`), where
+previously it was interpreted as "substituted success" (status unchanged).
+The model still sees the string as the tool result in both cases — only the
+UI status differs.
+
+### 3.5 `PendingApproval` interface
+
+Drops the `respondWith` method. `reject(result?)` covers the same use case:
+
+```typescript
+export interface PendingApproval {
+  toolName: string;
+  args: unknown;
+  approve: () => void; // resolves with ApprovalResponse.approve()
+  reject: (result?: string) => void; // resolves with ApprovalResponse.reject(result)
+}
+```
+
+Callers that previously used `respondWith('text')` migrate to
+`reject('text')`.
+
+## 4. Inheritance and Override Rules
+
+```
+                                  ┌───────────────────────────┐
+                                  │ active run's handler       │
+                                  │ (RunBuilder.withApproval-  │
+                                  │  Handler, set by caller)   │
+                                  └─────────────┬─────────────┘
+                                                │ propagates
+                                                ▼
+                                  ┌───────────────────────────┐
+                                  │   ToolContext.            │
+                                  │   approvalHandler          │
+                                  └─────────────┬─────────────┘
+                                                │ inherited by
+                                                ▼
+   tools that internally start a sub-agent run pass it to the child's
+   RunBuilder unless the child runner has `runner.approvalHandler` set.
+
+   ┌────────────────────────────┐         ┌──────────────────────────┐
+   │  Child runner has          │   YES   │  Child uses               │
+   │  approvalHandler set?      │ ──────▶ │  runner.approvalHandler   │
+   └────────────────────────────┘         └──────────────────────────┘
+                │ NO
+                ▼
+   ┌────────────────────────────┐         ┌──────────────────────────┐
+   │  ctx.approvalHandler       │   YES   │  Child inherits the       │
+   │  present?                  │ ──────▶ │  parent's handler         │
+   └────────────────────────────┘         └──────────────────────────┘
+                │ NO
+                ▼
+   ┌────────────────────────────┐
+   │  Child runs ungated         │
+   │  (requiresApproval ignored) │
+   └────────────────────────────┘
+```
+
+The "ungated" leaf is the documented behavior for a runner used outside any
+React context: `requiresApproval` flags become advisory metadata only. Using
+`AgentProvider` (or attaching a handler manually) opts a run into gating.
+
+## 5. Test Plan
+
+Tests live where they are most legible per layer.
+
+### 5.1 `@mast-ai/core` (`runner.test.ts`, `agentTool.test.ts`)
+
+- Runner gates `requiresApproval` tools when a handler is attached:
+  `{ type: 'approve' }` runs the tool, `{ type: 'reject' }` skips and returns
+  `APPROVAL_CANCELLED_RESULT`, `{ type: 'reject', result }` skips and returns
+  `result`.
+- Runner skips gating when no handler is attached (current behavior — flagged
+  tools execute as ungated).
+- Runner threads `approvalHandler` into `ToolContext`.
+- `createAgentTool` forwards `ctx.approvalHandler` to the child's
+  `RunBuilder` when the child runner has no default.
+- `createAgentTool` does _not_ forward when the child runner has its own
+  `approvalHandler` (override wins).
+- `createAgentTool` runs ungated when neither context nor child runner has a
+  handler.
+
+### 5.2 `@mast-ai/react-ui` (`approval.test.tsx`)
+
+- All existing tests pass against the new mechanism (handler-on-conversation
+  instead of registry-wrap).
+- New: regression test for #128 — `createAgentTool` sub-agent fires
+  `onApprovalRequired` for the inner call. (Already added; flips from
+  failing to passing with the refactor.)
+- New: independent-runner test — a sub-agent on a different `AgentRunner`
+  instance with no handler of its own surfaces approvals to the parent's
+  `<AgentProvider>`.
+- New: isolated-handler test — a child runner with its own
+  `approvalHandler` does not consult the parent's handler.
+
+### 5.3 Demos
+
+`demos/core/basic-chat` does not exercise `createAgentTool`; no changes
+needed. The cobweb integration (downstream consumer) picks up the fix
+without code changes when it bumps to the new MAST version.
+
+## 6. Migration
+
+For consumers of `@mast-ai/core` and `@mast-ai/react-ui`:
+
+| Use case                                                                             | Action                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| App that mounts `<AgentProvider>` only                                               | None                                                                                                                                                                              |
+| App that uses `createAgentTool`                                                      | None                                                                                                                                                                              |
+| App whose `onApprovalRequired` returns a `string`                                    | Verify the new semantics fit. The string still reaches the model as the tool result, but UI status becomes `'cancelled'` rather than the previous unstyled "substituted success." |
+| App that calls `pendingApprovals[i].respondWith(text)`                               | Replace with `pendingApprovals[i].reject(text)`                                                                                                                                   |
+| App that imports `withApprovalProxy`                                                 | Remove the import — it was internal and the wrap is no longer needed                                                                                                              |
+| App that builds a custom equivalent of `<AgentProvider>` against `withApprovalProxy` | Switch to `runner.conversation(agent, { approvalHandler })` and pass the handler at construction                                                                                  |
+
+For developers building sub-agents on a separate runner instance, the new
+contract is simply:
+
+```ts
+// Sub-agent inherits parent's UI approval surface — zero wiring.
+const childRunner = new AgentRunner(adapter, registry);
+parentRegistry.register(createAgentTool(childRunner, CHILD, { ... }));
+
+// Sub-agent uses its own policy — set it on the child runner.
+childRunner.approvalHandler = {
+  async requestApproval({ name }) {
+    return isAutoApproved(name) ? ApprovalResponse.approve() : ApprovalResponse.reject();
+  },
+};
+// Reject with a custom message visible to the model:
+//   ApprovalResponse.reject('This tool is disabled in sandbox mode.')
+```
+
+## 7. Rollout
+
+1. Land core changes (`tool.ts`, `runner.ts`, `conversation.ts`,
+   `agentTool.ts`) with their unit tests.
+2. Land `react-ui` changes (`AgentProvider` rewrite, `approval.ts` cleanup)
+   with the existing approval test suite green plus the three new tests.
+3. Update top-level `docs/PRD.md` §3 (Recursive Sub-Agents) and `docs/SPEC.md`
+   tool-context section to reflect the new `approvalHandler` field.
+4. Move this `docs/sub-agents/` directory to `docs/archive/` once shipped.
+5. Cut a minor release (the surface change is a tightened contract for
+   `requiresApproval` gating that consumers already implicitly relied on,
+   plus removal of internal `withApprovalProxy`).


### PR DESCRIPTION
## Summary

Lands the planning docs for the sub-agent approval architecture refactor that fixes #128. No code changes.

- **PRD**: Frames the architectural problem (approval is bound to a single runner via the registry-wrap), goals (independent sub-agent runners, per-run policy, propagation through ToolContext), and three user stories covering the same-runner / shared-surface / isolated-surface cases.
- **SPEC**: Type definitions for `ApprovalRequest`, `ApprovalResponse`, `ApprovalHandler`, plus the `ToolContext.approvalHandler` field. Diagrams (ASCII for the runtime topology, Mermaid for the type relationships) explain how the handler propagates from `Conversation` -> `RunBuilder` -> `ToolContext` -> sub-agent runs. Rejected alternatives (registry mutation, runner getter, runtime context override with adapter-match guard) are documented with their footguns.
- **PLAN**: Six sequenced issues, each leaving the repo green. Issue 1 (additive types) -> Issue 2 (runner gating) -> Issue 3 (Conversation + createAgentTool) -> Issue 4 (react-ui rewrite, where #128 fixes) -> Issue 5 (doc refresh) -> Issue 6 (archive).
- **MIGRATION**: Per-scenario guide for downstream consumers, covering the no-op case, the `respondWith` -> `reject` rename, the `OnApprovalRequired` string-return semantic shift, the #128 fix, the new "independent runner with shared approval surface" capability, and the `withApprovalProxy` removal.

The reproduction test for #128 was drafted during planning and verified to fail; it lands as part of Issue 4 (where it goes green).

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run format` produces no changes
- [ ] `npm run build` passes
- [ ] `npm test --workspaces --if-present` passes (181 tests)
- [ ] Mermaid diagram in SPEC §2.0 renders cleanly (validated locally via @mermaid-js/mermaid-cli)
- [ ] Reviewers concur on the architecture before Issue 1 is started