### PR TITLE
feat(core): approval primitive types

### DIFF
--- a/packages/core/src/tool.test.ts
+++ b/packages/core/src/tool.test.ts
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi } from 'vitest';
-import { ToolRegistry, ToolRegistryView, type ToolProvider } from './tool.js';
+import {
+  ToolRegistry,
+  ToolRegistryView,
+  ApprovalResponse,
+  APPROVAL_CANCELLED_RESULT,
+  type ApprovalHandler,
+  type ApprovalRequest,
+  type ToolContext,
+  type ToolProvider,
+} from './tool.js';
 import type { Tool, ToolDefinition } from './tool.js';
 
 function makeTool(name: string, scope: 'read' | 'write'): Tool {
@@ -217,6 +226,72 @@ describe('ToolRegistry events', () => {
 
     expect(a).toHaveBeenCalledTimes(1);
     expect(b).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ApprovalResponse', () => {
+  it('approve() returns the approve variant', () => {
+    const decision = ApprovalResponse.approve();
+    expect(decision).toEqual({ type: 'approve' });
+  });
+
+  it('reject() returns the reject variant with no result', () => {
+    const decision = ApprovalResponse.reject();
+    expect(decision).toEqual({ type: 'reject', result: undefined });
+  });
+
+  it('reject(result) carries the custom result string', () => {
+    const decision = ApprovalResponse.reject('Disabled in sandbox.');
+    expect(decision).toEqual({ type: 'reject', result: 'Disabled in sandbox.' });
+  });
+
+  it('narrows correctly in a switch on type', () => {
+    const decisions: ApprovalResponse[] = [
+      ApprovalResponse.approve(),
+      ApprovalResponse.reject(),
+      ApprovalResponse.reject('custom'),
+    ];
+
+    const labels = decisions.map((decision) => {
+      switch (decision.type) {
+        case 'approve':
+          return 'approve';
+        case 'reject':
+          return decision.result ?? APPROVAL_CANCELLED_RESULT;
+      }
+    });
+
+    expect(labels).toEqual(['approve', APPROVAL_CANCELLED_RESULT, 'custom']);
+  });
+
+  it('APPROVAL_CANCELLED_RESULT is the documented default string', () => {
+    expect(APPROVAL_CANCELLED_RESULT).toBe('User cancelled the tool call.');
+  });
+
+  it('ApprovalHandler conforms to the documented shape', async () => {
+    const handler: ApprovalHandler = {
+      async requestApproval(request: ApprovalRequest): Promise<ApprovalResponse> {
+        return request.name === 'safe' ? ApprovalResponse.approve() : ApprovalResponse.reject();
+      },
+    };
+
+    await expect(handler.requestApproval({ name: 'safe', args: {} })).resolves.toEqual({
+      type: 'approve',
+    });
+    await expect(handler.requestApproval({ name: 'risky', args: {} })).resolves.toEqual({
+      type: 'reject',
+      result: undefined,
+    });
+  });
+
+  it('ToolContext accepts an approvalHandler', () => {
+    const handler: ApprovalHandler = {
+      async requestApproval() {
+        return ApprovalResponse.approve();
+      },
+    };
+    const ctx: ToolContext = { approvalHandler: handler };
+    expect(ctx.approvalHandler).toBe(handler);
   });
 });
 

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -15,6 +15,71 @@ export interface ToolDefinition {
   requiresApproval?: boolean;
 }
 
+/** A request from the runner asking the consumer to gate a tool call. */
+export interface ApprovalRequest {
+  /** Name of the tool whose call is being requested. */
+  name: string;
+  /** Arguments the model passed to the tool. */
+  args: unknown;
+}
+
+/**
+ * Decision returned by an {@link ApprovalHandler}. Two variants — the
+ * fundamental question is whether the tool runs.
+ *
+ * - `approve` — proceed with normal tool execution.
+ * - `reject` — skip execution. The model sees `result` as the tool result, or
+ *   {@link APPROVAL_CANCELLED_RESULT} when omitted. UI status is always
+ *   `'cancelled'` for rejected calls.
+ *
+ * Substituting a synthetic result on rejection is expressed as
+ * `{ type: 'reject', result }`.
+ */
+export type ApprovalResponse = { type: 'approve' } | { type: 'reject'; result?: string };
+
+/**
+ * Helper constructors. Optional ergonomic sugar; handlers may also return the
+ * literal shape directly.
+ *
+ * @example
+ * async requestApproval({ name }) {
+ *   if (isAutoApproved(name)) return ApprovalResponse.approve();
+ *   if (name === 'sandboxed_only') return ApprovalResponse.reject('Disabled in sandbox.');
+ *   return ApprovalResponse.reject();
+ * }
+ */
+export const ApprovalResponse = {
+  approve(): ApprovalResponse {
+    return { type: 'approve' };
+  },
+  reject(result?: string): ApprovalResponse {
+    return { type: 'reject', result };
+  },
+};
+
+/**
+ * Default tool result used when an {@link ApprovalHandler} rejects a call
+ * without supplying its own `result` string. Visible to the model as the tool
+ * output for the cancelled call.
+ */
+export const APPROVAL_CANCELLED_RESULT = 'User cancelled the tool call.';
+
+/**
+ * Decides whether to proceed with a tool call flagged `requiresApproval`.
+ *
+ * Modeled as an interface (rather than a bare function type) so future
+ * extensions, such as a `dispose()` lifecycle hook or observers for awaiting
+ * state, can be added without breaking existing implementations.
+ */
+export interface ApprovalHandler {
+  /**
+   * Called by the runner before invoking any tool whose definition has
+   * `requiresApproval: true`. Resolve with the {@link ApprovalResponse}
+   * dictating what happens next.
+   */
+  requestApproval(request: ApprovalRequest): Promise<ApprovalResponse>;
+}
+
 /** Runtime context passed to every {@link Tool.call} invocation. */
 export interface ToolContext {
   /** Forwarded from the runner; allows long-running tools to be cancelled. */
@@ -26,6 +91,13 @@ export interface ToolContext {
    * to avoid leaking child conversation history to the parent's consumers.
    */
   onEvent?: (event: AgentEvent) => void;
+  /**
+   * The approval handler attached to the currently-running run. Tools that
+   * internally start sub-agent runs should forward this to the child's
+   * `RunBuilder.withApprovalHandler` unless the child runner already has its
+   * own handler configured. Set by `AgentRunner` when invoking tools.
+   */
+  approvalHandler?: ApprovalHandler;
 }
 
 /**


### PR DESCRIPTION
## Summary

Issue 1 of the sub-agents architecture refactor (see `docs/sub-agents/PLAN.md` §"Issue 1"). Lands the public types in `@mast-ai/core` with **no behavior change** — types compile and are exported, but nothing in the runner or tools consumes them yet. Smallest reviewable starting point for the rest of the series.

### Changes

`packages/core/src/tool.ts`
- `ApprovalRequest` interface (`{ name, args }`).
- `ApprovalResponse` tagged union (`{ type: 'approve' } | { type: 'reject', result? }`) plus the same-named const namespace exposing `approve()` / `reject(result?)`.
- `ApprovalHandler` interface with `requestApproval(req): Promise<ApprovalResponse>`.
- `APPROVAL_CANCELLED_RESULT = 'User cancelled the tool call.'` constant.
- `ToolContext.approvalHandler?: ApprovalHandler` (set by no one, read by no one — Issue 2 will populate it).

`packages/core/src/tool.test.ts`
- Type-level smoke tests for the helper namespace, switch-narrowing, the default-result constant, an `ApprovalHandler` conformance check, and `ToolContext.approvalHandler` assignability.

`packages/core/src/index.ts` is unchanged — `export * from './tool.js'` already re-exports the new symbols.

### Out of scope

- Runner-level gating (Issue 2).
- Conversation / `createAgentTool` propagation (Issue 3).
- `react-ui` rewrite (Issue 4).

## Test plan

- [x] `npm run lint`
- [x] `npm run format -- --check`
- [x] `npm run build`
- [x] `npm test --workspaces --if-present` (core: 48 passing; full workspace counts unchanged)
- [x] Verified `executeStream` and surrounding runner code untouched (`ToolContext.approvalHandler` referenced only in `tool.ts` + `tool.test.ts`).

Closes #130