### PR TITLE
feat(core): runner-level approval gating

### DIFF
--- a/packages/core/src/runner.test.ts
+++ b/packages/core/src/runner.test.ts
@@ -4,10 +4,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AgentRunner } from './runner.js';
 import { AgentError } from './error.js';
-import { ToolRegistry } from './tool.js';
+import { APPROVAL_CANCELLED_RESULT, ApprovalResponse, ToolRegistry } from './tool.js';
 import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index.js';
 import type { AgentConfig, AgentEvent } from './types.js';
-import type { ToolContext } from './tool.js';
+import type { ApprovalHandler, Tool, ToolContext, ToolDefinition } from './tool.js';
 
 function streamingAdapter(chunks: AdapterStreamChunk[]): LlmAdapter {
   return {
@@ -249,5 +249,255 @@ describe('RunBuilder.forwardTo', () => {
         }
       })(),
     ).rejects.toBeInstanceOf(AgentError);
+  });
+});
+
+describe('approval gating', () => {
+  function singleCallThenDoneAdapter(
+    toolName: string,
+    args: unknown = {},
+    finalText = 'done',
+  ): LlmAdapter {
+    let turn = 0;
+    return {
+      generate: vi.fn(),
+      generateStream: (_request: AdapterRequest) =>
+        (async function* () {
+          if (turn++ === 0) {
+            yield {
+              type: 'tool_call' as const,
+              toolCall: { id: '1', name: toolName, args },
+            };
+          } else {
+            yield { type: 'text_delta' as const, delta: finalText };
+          }
+        })(),
+    };
+  }
+
+  function approvalTool(
+    name: string,
+    options: {
+      requiresApproval?: boolean;
+      result?: string;
+      onCall?: (args: unknown, ctx: ToolContext) => void;
+    } = {},
+  ): Tool {
+    return {
+      definition: (): ToolDefinition => ({
+        name,
+        description: `${name} tool`,
+        parameters: {},
+        scope: 'write',
+        requiresApproval: options.requiresApproval ?? false,
+      }),
+      call: vi.fn(async (args: unknown, ctx: ToolContext) => {
+        options.onCall?.(args, ctx);
+        return options.result ?? 'ok';
+      }),
+    };
+  }
+
+  function runnerWithTool(adapter: LlmAdapter, tool: Tool): AgentRunner {
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    return new AgentRunner(adapter, registry);
+  }
+
+  async function drain(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+    const events: AgentEvent[] = [];
+    for await (const event of stream) events.push(event);
+    return events;
+  }
+
+  it('does not call the handler for tools with requiresApproval: false', async () => {
+    const handler: ApprovalHandler = { requestApproval: vi.fn() };
+    const tool = approvalTool('safe_tool', { requiresApproval: false });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('safe_tool'), tool);
+    runner.approvalHandler = handler;
+
+    await drain(runner.runStream(agent, 'go'));
+
+    expect(handler.requestApproval).not.toHaveBeenCalled();
+    expect(tool.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes ungated when requiresApproval is true but no handler is attached', async () => {
+    const tool = approvalTool('risky_tool', { requiresApproval: true, result: 'ran' });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+
+    const events = await drain(runner.runStream(agent, 'go'));
+
+    expect(tool.call).toHaveBeenCalledTimes(1);
+    const completed = events.find((e) => e.type === 'tool_call_completed');
+    expect(completed).toMatchObject({ name: 'risky_tool', result: 'ran', error: false });
+  });
+
+  it('runs the tool when the handler returns approve', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true, result: 'ran' });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool', { x: 1 }), tool);
+    runner.approvalHandler = handler;
+
+    const events = await drain(runner.runStream(agent, 'go'));
+
+    expect(handler.requestApproval).toHaveBeenCalledWith({ name: 'risky_tool', args: { x: 1 } });
+    expect(tool.call).toHaveBeenCalledTimes(1);
+    expect(events.find((e) => e.type === 'tool_call_completed')).toMatchObject({
+      name: 'risky_tool',
+      result: 'ran',
+      error: false,
+    });
+  });
+
+  it('skips the tool and returns the default cancelled result on reject() with no result', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject()),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = handler;
+
+    const events = await drain(runner.runStream(agent, 'go'));
+
+    expect(tool.call).not.toHaveBeenCalled();
+    expect(events.find((e) => e.type === 'tool_call_completed')).toMatchObject({
+      name: 'risky_tool',
+      result: APPROVAL_CANCELLED_RESULT,
+      error: false,
+    });
+  });
+
+  it('skips the tool and returns the supplied result on reject(result)', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject('Disabled in sandbox.')),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = handler;
+
+    const events = await drain(runner.runStream(agent, 'go'));
+
+    expect(tool.call).not.toHaveBeenCalled();
+    expect(events.find((e) => e.type === 'tool_call_completed')).toMatchObject({
+      name: 'risky_tool',
+      result: 'Disabled in sandbox.',
+      error: false,
+    });
+  });
+
+  it('per-run handler set via RunBuilder.withApprovalHandler overrides the runner default', async () => {
+    const runnerHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const perRunHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject()),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = runnerHandler;
+
+    await drain(runner.runBuilder(agent).withApprovalHandler(perRunHandler).runStream('go'));
+
+    expect(perRunHandler.requestApproval).toHaveBeenCalledTimes(1);
+    expect(runnerHandler.requestApproval).not.toHaveBeenCalled();
+    expect(tool.call).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the runner's default handler when no per-run handler is attached", async () => {
+    const runnerHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = runnerHandler;
+
+    await drain(runner.runStream(agent, 'go'));
+
+    expect(runnerHandler.requestApproval).toHaveBeenCalledTimes(1);
+    expect(tool.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('per-run override only applies to that builder; subsequent runs use the runner default', async () => {
+    const runnerHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const perRunHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject()),
+    };
+
+    const adapter: LlmAdapter = {
+      generate: vi.fn(),
+      // Each call to generateStream is a fresh adapter cycle: tool call -> done.
+      generateStream: (() => {
+        let turn = 0;
+        return (_request: AdapterRequest) =>
+          (async function* () {
+            if (turn++ % 2 === 0) {
+              yield {
+                type: 'tool_call' as const,
+                toolCall: { id: String(turn), name: 'risky_tool', args: {} },
+              };
+            } else {
+              yield { type: 'text_delta' as const, delta: 'done' };
+            }
+          })();
+      })(),
+    };
+
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    const runner = new AgentRunner(adapter, registry);
+    runner.approvalHandler = runnerHandler;
+
+    await drain(runner.runBuilder(agent).withApprovalHandler(perRunHandler).runStream('go'));
+    await drain(runner.runStream(agent, 'go'));
+
+    expect(perRunHandler.requestApproval).toHaveBeenCalledTimes(1);
+    expect(runnerHandler.requestApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the active handler to ToolContext.approvalHandler when invoking tool.call', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+
+    let receivedCtx: ToolContext | undefined;
+    const tool = approvalTool('risky_tool', {
+      requiresApproval: true,
+      onCall: (_args, ctx) => {
+        receivedCtx = ctx;
+      },
+    });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = handler;
+
+    await drain(runner.runStream(agent, 'go'));
+
+    expect(receivedCtx?.approvalHandler).toBe(handler);
+  });
+
+  it('passes the handler to ToolContext even for tools that do not require approval', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+
+    let receivedCtx: ToolContext | undefined;
+    const tool = approvalTool('safe_tool', {
+      requiresApproval: false,
+      onCall: (_args, ctx) => {
+        receivedCtx = ctx;
+      },
+    });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('safe_tool'), tool);
+    runner.approvalHandler = handler;
+
+    await drain(runner.runStream(agent, 'go'));
+
+    expect(handler.requestApproval).not.toHaveBeenCalled();
+    expect(receivedCtx?.approvalHandler).toBe(handler);
   });
 });

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -3,7 +3,13 @@
 
 import type { AgentConfig, AgentEvent, AgentResult, Message, ToolCall } from './types.js';
 import type { LlmAdapter, AdapterRequest } from './adapter/index.js';
-import { type ToolContext, type ToolProvider, ToolRegistry } from './tool.js';
+import {
+  APPROVAL_CANCELLED_RESULT,
+  type ApprovalHandler,
+  type ToolContext,
+  type ToolProvider,
+  ToolRegistry,
+} from './tool.js';
 import { AgentError } from './error.js';
 import { Conversation } from './conversation.js';
 
@@ -12,6 +18,7 @@ type StreamExecutor = (
   history: Message[],
   signal?: AbortSignal,
   onToolEvent?: (toolName: string, event: AgentEvent) => void,
+  approvalHandler?: ApprovalHandler,
 ) => AsyncIterable<AgentEvent>;
 
 /**
@@ -25,6 +32,8 @@ export class RunBuilder {
   private _signal?: AbortSignal;
   private _onToolEvent?: (toolName: string, event: AgentEvent) => void;
   private _forwardContext?: ToolContext;
+  /** @internal Read by {@link AgentRunner} to resolve the per-run handler. */
+  _approvalHandler?: ApprovalHandler;
 
   constructor(
     private readonly agent: AgentConfig,
@@ -70,9 +79,24 @@ export class RunBuilder {
     return this;
   }
 
+  /**
+   * Attach an {@link ApprovalHandler} that gates `requiresApproval` tools for
+   * this run. Overrides any handler set on the runner.
+   */
+  withApprovalHandler(handler: ApprovalHandler): this {
+    this._approvalHandler = handler;
+    return this;
+  }
+
   /** Executes the run and returns a stream of {@link AgentEvent} objects. */
   runStream(input: string): AsyncIterable<AgentEvent> {
-    const stream = this.execute(input, this._history, this._signal, this._onToolEvent);
+    const stream = this.execute(
+      input,
+      this._history,
+      this._signal,
+      this._onToolEvent,
+      this._approvalHandler,
+    );
     const onEvent = this._forwardContext?.onEvent;
     if (!onEvent) return stream;
     return (async function* () {
@@ -117,6 +141,13 @@ export class RunBuilder {
  * {@link AgentRunner.run} / {@link AgentRunner.runStream} (single-turn).
  */
 export class AgentRunner {
+  /**
+   * Default {@link ApprovalHandler} consulted for `requiresApproval` tools when
+   * a per-run handler is not attached via {@link RunBuilder.withApprovalHandler}.
+   * Mutable so consumers may attach a handler after construction.
+   */
+  approvalHandler?: ApprovalHandler;
+
   constructor(
     /** The LLM adapter used to generate responses. */
     public readonly adapter: LlmAdapter,
@@ -131,8 +162,15 @@ export class AgentRunner {
 
   /** Primary entry point for multi-turn use. */
   runBuilder(agent: AgentConfig): RunBuilder {
-    return new RunBuilder(agent, (input, history, signal, onToolEvent) =>
-      this.executeStream(agent, input, history, signal, onToolEvent),
+    return new RunBuilder(agent, (input, history, signal, onToolEvent, approvalHandler) =>
+      this.executeStream(
+        agent,
+        input,
+        history,
+        signal,
+        onToolEvent,
+        approvalHandler ?? this.approvalHandler,
+      ),
     );
   }
 
@@ -161,6 +199,7 @@ export class AgentRunner {
     history: Message[],
     signal?: AbortSignal,
     onToolEvent?: (toolName: string, event: AgentEvent) => void,
+    approvalHandler?: ApprovalHandler,
   ): AsyncIterable<AgentEvent> {
     // Use the explicit tool list when provided; otherwise expose all registered tools.
     const toolDefinitions = agent.tools
@@ -243,10 +282,25 @@ export class AgentRunner {
                 hallucinated: true as const,
               };
             }
+            if (tool.definition().requiresApproval && approvalHandler) {
+              const decision = await approvalHandler.requestApproval({
+                name: call.name,
+                args: call.args,
+              });
+              if (decision.type === 'reject') {
+                return {
+                  call,
+                  result: decision.result ?? APPROVAL_CANCELLED_RESULT,
+                  error: false as const,
+                  hallucinated: false as const,
+                };
+              }
+            }
             try {
               const result = await tool.call(call.args, {
                 signal,
                 onEvent: onToolEvent ? (event) => onToolEvent(call.name, event) : undefined,
+                approvalHandler,
               });
               return { call, result, error: false as const, hallucinated: false as const };
             } catch (err) {


### PR DESCRIPTION
## Summary

Wires `AgentRunner` to consult an `ApprovalHandler` before invoking any tool flagged `requiresApproval`, and threads the active handler into `ToolContext` so sub-agents can inherit the same policy. This is Issue 2 of the sub-agents refactor (`docs/sub-agents/PLAN.md`); the runtime contract react-ui plugs into in #133.

- `AgentRunner.approvalHandler` (mutable) — runner-level default.
- `RunBuilder.withApprovalHandler(handler)` — per-run override. Per-run beats runner default.
- In `executeStream`, before each tool call: if `def.requiresApproval` and a handler is attached, await `requestApproval({ name, args })`. On `reject`, the tool is skipped and the model sees `result ?? APPROVAL_CANCELLED_RESULT`; `tool_call_completed` is emitted with `error: false` so the consumer can map UI status themselves (react-ui maps to `'cancelled'` in #133).
- `tool.call` now receives `approvalHandler` on `ToolContext` for every call (not only approval-required ones), since sub-agents need it regardless of the parent tool's flag.

With no handler attached, `requiresApproval` remains advisory and tools run as today, so existing consumers see no behavior change.

## Test plan

- [x] 11 new tests in `runner.test.ts` under `approval gating`, covering every scenario from #131:
  - `requiresApproval: false` tools never call the handler
  - No handler attached → ungated execution
  - `approve` runs the tool; `reject()` returns the default cancelled string; `reject(result)` returns the custom string
  - Per-run handler overrides runner default
  - Per-run override is for that builder only (subsequent runs use the runner default)
  - Runner-level default is consulted as fallback
  - `ToolContext.approvalHandler` is set to the active handler when `tool.call` is invoked, both for approval-required and non-approval tools
- [x] `npm run lint`, `npm run format`, `npm run build`, `npm test` all green
- [x] All existing tests across `core`, `built-in-ai`, `google-genai`, `openai`, and `react-ui` still pass — react-ui tests in particular confirm no regression for consumers not yet using the new contract

Closes #131