### PR TITLE
feat(core): conversation options and createAgentTool propagation

### DIFF
--- a/packages/core/src/agentTool.test.ts
+++ b/packages/core/src/agentTool.test.ts
@@ -5,9 +5,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { createAgentTool } from './agentTool.js';
 import { AgentRunner } from './runner.js';
 import { AgentError } from './error.js';
+import { ApprovalResponse, ToolRegistry } from './tool.js';
 import type { LlmAdapter, AdapterRequest, AdapterStreamChunk } from './adapter/index.js';
 import type { AgentConfig, AgentEvent } from './types.js';
-import type { ToolContext } from './tool.js';
+import type { ApprovalHandler, Tool, ToolContext } from './tool.js';
 
 function streamingAdapter(chunks: AdapterStreamChunk[]): LlmAdapter {
   return {
@@ -120,6 +121,109 @@ describe('createAgentTool', () => {
     });
 
     await expect(tool.call({}, {})).rejects.toBeInstanceOf(AgentError);
+  });
+
+  describe('approvalHandler inheritance', () => {
+    function childToolCallAdapter(toolName: string): LlmAdapter {
+      let turn = 0;
+      return {
+        generate: vi.fn(),
+        generateStream: (_request: AdapterRequest) =>
+          (async function* () {
+            if (turn++ === 0) {
+              yield {
+                type: 'tool_call' as const,
+                toolCall: { id: '1', name: toolName, args: {} },
+              };
+            } else {
+              yield { type: 'text_delta' as const, delta: 'done' };
+            }
+          })(),
+      };
+    }
+
+    function approvalTool(name: string): Tool {
+      return {
+        definition: () => ({
+          name,
+          description: `${name} tool`,
+          parameters: {},
+          scope: 'write' as const,
+          requiresApproval: true,
+        }),
+        call: vi.fn(async () => 'tool-ran'),
+      };
+    }
+
+    function childRunnerWithTool(tool: Tool): AgentRunner {
+      const registry = new ToolRegistry();
+      registry.register(tool);
+      return new AgentRunner(childToolCallAdapter(tool.definition().name), registry);
+    }
+
+    it('forwards ctx.approvalHandler to the child run when the child runner has no default', async () => {
+      const inheritedHandler: ApprovalHandler = {
+        requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+      };
+      const childTool = approvalTool('child_tool');
+      const childRunner = childRunnerWithTool(childTool);
+
+      const tool = createAgentTool(childRunner, childAgent, {
+        name: 'sub',
+        description: 'sub',
+        parameters: {},
+        buildInput: () => 'go',
+      });
+
+      await tool.call({}, { approvalHandler: inheritedHandler });
+
+      expect(inheritedHandler.requestApproval).toHaveBeenCalledWith({
+        name: 'child_tool',
+        args: {},
+      });
+      expect(childTool.call).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the child runner's own approvalHandler instead of inheriting", async () => {
+      const inheritedHandler: ApprovalHandler = {
+        requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject()),
+      };
+      const childOwnHandler: ApprovalHandler = {
+        requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+      };
+      const childTool = approvalTool('child_tool');
+      const childRunner = childRunnerWithTool(childTool);
+      childRunner.approvalHandler = childOwnHandler;
+
+      const tool = createAgentTool(childRunner, childAgent, {
+        name: 'sub',
+        description: 'sub',
+        parameters: {},
+        buildInput: () => 'go',
+      });
+
+      await tool.call({}, { approvalHandler: inheritedHandler });
+
+      expect(childOwnHandler.requestApproval).toHaveBeenCalledTimes(1);
+      expect(inheritedHandler.requestApproval).not.toHaveBeenCalled();
+      expect(childTool.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the child ungated when neither ctx.approvalHandler nor a child runner default is set', async () => {
+      const childTool = approvalTool('child_tool');
+      const childRunner = childRunnerWithTool(childTool);
+
+      const tool = createAgentTool(childRunner, childAgent, {
+        name: 'sub',
+        description: 'sub',
+        parameters: {},
+        buildInput: () => 'go',
+      });
+
+      await tool.call({}, {});
+
+      expect(childTool.call).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('passes the result of buildInput as the child input', async () => {

--- a/packages/core/src/agentTool.ts
+++ b/packages/core/src/agentTool.ts
@@ -48,6 +48,9 @@ export function createAgentTool(
       const input = options.buildInput(args);
       const builder = runner.runBuilder(agent).forwardTo(context);
       if (context.signal) builder.signal(context.signal);
+      if (context.approvalHandler && !runner.approvalHandler) {
+        builder.withApprovalHandler(context.approvalHandler);
+      }
 
       for await (const event of builder.runStream(input)) {
         if (event.type === 'done') {

--- a/packages/core/src/conversation.test.ts
+++ b/packages/core/src/conversation.test.ts
@@ -1,0 +1,144 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { AgentRunner } from './runner.js';
+import { ApprovalResponse, ToolRegistry } from './tool.js';
+import type { LlmAdapter, AdapterRequest } from './adapter/index.js';
+import type { AgentConfig, AgentEvent } from './types.js';
+import type { ApprovalHandler, Tool } from './tool.js';
+
+const agent: AgentConfig = {
+  name: 'Test',
+  instructions: 'Be tested.',
+};
+
+function approvalTool(name: string): Tool {
+  return {
+    definition: () => ({
+      name,
+      description: `${name} tool`,
+      parameters: {},
+      scope: 'write' as const,
+      requiresApproval: true,
+    }),
+    call: vi.fn(async () => 'ok'),
+  };
+}
+
+/**
+ * Adapter that, on each call to `generateStream`, alternates between emitting
+ * a single tool call and a final text turn. Each two-turn cycle represents
+ * one full `runStream` invocation.
+ */
+function alternatingToolCallAdapter(toolName: string): LlmAdapter {
+  let turn = 0;
+  return {
+    generate: vi.fn(),
+    generateStream: (_request: AdapterRequest) =>
+      (async function* () {
+        if (turn++ % 2 === 0) {
+          yield {
+            type: 'tool_call' as const,
+            toolCall: { id: String(turn), name: toolName, args: {} },
+          };
+        } else {
+          yield { type: 'text_delta' as const, delta: 'done' };
+        }
+      })(),
+  };
+}
+
+async function drain(stream: AsyncIterable<AgentEvent>): Promise<void> {
+  for await (const _ of stream) {
+    // drain
+  }
+}
+
+describe('Conversation approval handler propagation', () => {
+  it('propagates the configured handler into every runStream call', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const tool = approvalTool('risky_tool');
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    const runner = new AgentRunner(alternatingToolCallAdapter('risky_tool'), registry);
+
+    const conversation = runner.conversation(agent, { approvalHandler: handler });
+
+    await drain(conversation.runStream('first'));
+    await drain(conversation.runStream('second'));
+
+    expect(handler.requestApproval).toHaveBeenCalledTimes(2);
+    expect(tool.call).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not consult the runner default when a Conversation handler is set', async () => {
+    const conversationHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const runnerHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject()),
+    };
+    const tool = approvalTool('risky_tool');
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    const runner = new AgentRunner(alternatingToolCallAdapter('risky_tool'), registry);
+    runner.approvalHandler = runnerHandler;
+
+    const conversation = runner.conversation(agent, { approvalHandler: conversationHandler });
+    await drain(conversation.runStream('hi'));
+
+    expect(conversationHandler.requestApproval).toHaveBeenCalledTimes(1);
+    expect(runnerHandler.requestApproval).not.toHaveBeenCalled();
+    expect(tool.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the runner default when no Conversation handler is set', async () => {
+    const runnerHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const tool = approvalTool('risky_tool');
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    const runner = new AgentRunner(alternatingToolCallAdapter('risky_tool'), registry);
+    runner.approvalHandler = runnerHandler;
+
+    const conversation = runner.conversation(agent);
+    await drain(conversation.runStream('hi'));
+
+    expect(runnerHandler.requestApproval).toHaveBeenCalledTimes(1);
+    expect(tool.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the handler by reference so swaps take effect on the next run', async () => {
+    const firstHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const secondHandler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.reject()),
+    };
+    const tool = approvalTool('risky_tool');
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    const runner = new AgentRunner(alternatingToolCallAdapter('risky_tool'), registry);
+
+    // The handler is held inside an object whose reference is stable, so the
+    // Conversation reads through to its current value on every run.
+    const ref: { current: ApprovalHandler } = { current: firstHandler };
+    const proxy: ApprovalHandler = {
+      requestApproval: (req) => ref.current.requestApproval(req),
+    };
+    const conversation = runner.conversation(agent, { approvalHandler: proxy });
+
+    await drain(conversation.runStream('one'));
+    ref.current = secondHandler;
+    await drain(conversation.runStream('two'));
+
+    expect(firstHandler.requestApproval).toHaveBeenCalledTimes(1);
+    expect(secondHandler.requestApproval).toHaveBeenCalledTimes(1);
+    // First run approved, second rejected — so tool.call only ran once.
+    expect(tool.call).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/conversation.ts
+++ b/packages/core/src/conversation.ts
@@ -3,6 +3,17 @@
 
 import type { AgentConfig, AgentEvent, AgentResult, Message } from './types.js';
 import type { AgentRunner } from './runner.js';
+import type { ApprovalHandler } from './tool.js';
+
+/** Configuration for {@link Conversation}. */
+export interface ConversationOptions {
+  /**
+   * Approval handler attached to every {@link Conversation.runStream} call.
+   * Read by reference on every run, so consumers may swap the handler
+   * implementation (e.g. via a React ref) without rebuilding the conversation.
+   */
+  approvalHandler?: ApprovalHandler;
+}
 
 /**
  * Stateful wrapper around {@link AgentRunner} that automatically accumulates
@@ -18,6 +29,7 @@ export class Conversation {
   constructor(
     private readonly runner: AgentRunner,
     private readonly agent: AgentConfig,
+    private readonly options: ConversationOptions = {},
   ) {}
 
   private buildStream(
@@ -28,6 +40,9 @@ export class Conversation {
     const builder = this.runner.runBuilder(this.agent).history([...this.history]);
     if (signal) builder.signal(signal);
     if (onToolEvent) builder.onToolEvent(onToolEvent);
+    if (this.options.approvalHandler) {
+      builder.withApprovalHandler(this.options.approvalHandler);
+    }
     return builder.runStream(input);
   }
 

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -11,7 +11,7 @@ import {
   ToolRegistry,
 } from './tool.js';
 import { AgentError } from './error.js';
-import { Conversation } from './conversation.js';
+import { Conversation, type ConversationOptions } from './conversation.js';
 
 type StreamExecutor = (
   input: string,
@@ -156,8 +156,8 @@ export class AgentRunner {
   ) {}
 
   /** Creates a Conversation that automatically tracks history across turns. */
-  conversation(agent: AgentConfig): Conversation {
-    return new Conversation(this, agent);
+  conversation(agent: AgentConfig, options?: ConversationOptions): Conversation {
+    return new Conversation(this, agent, options);
   }
 
   /** Primary entry point for multi-turn use. */


### PR DESCRIPTION
## Summary

Issue 3 of the sub-agents plan. Plumbs the approval handler through the high-level entry points so callers (next: `<AgentProvider>` in #133) can attach a handler at conversation construction time and have it travel into every run, including sub-agent runs spawned via `createAgentTool`.

- `Conversation` accepts `ConversationOptions { approvalHandler? }`. `buildStream` calls `RunBuilder.withApprovalHandler(...)` when set. The handler is read by reference per run so consumers can swap implementations without rebuilding the conversation.
- `AgentRunner.conversation(agent, options?)` forwards options through.
- `createAgentTool` inherits `ctx.approvalHandler` into child runs unless the child runner already defines its own default. Matches the precedence in `docs/sub-agents/SPEC.md` §4: explicit child runner handler > inherited > ungated.

Planning context: `docs/sub-agents/PRD.md` §5.2 / §5.3, `docs/sub-agents/SPEC.md` §2.3 / §2.4 / §4, `docs/sub-agents/PLAN.md` §"Issue 3".

Closes #132.

## Test plan

- [x] `npm run lint` ✓
- [x] `npm run format` ✓
- [x] `npm run build` ✓
- [x] `npm test --workspaces --if-present` ✓ (core: 65, openai: 35, react-ui: 181)
- [x] New tests in `packages/core/src/conversation.test.ts` cover handler propagation, override of runner default, fallback to runner default, and read-by-reference semantics.
- [x] New tests in `packages/core/src/agentTool.test.ts` cover the three inheritance cases (inherit, child-runner override wins, ungated when neither is set).
- [x] Existing `agentTool.test.ts` tests continue to pass.