### PR TITLE
docs(sub-agents): refresh for handler-based approval architecture

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -16,7 +16,7 @@ Existing agent frameworks are server-centric, which presents three major hurdles
 
 - **Client-Led Orchestration:** Shift the agentic "think-act" loop to the browser.
 - **Environment Agnostic Inference:** Allow the client to use any backend (Python, Go, Rust, Ruby) for LLM reasoning.
-- **Recursive Sub-Agents:** Enable agents to call other agents as tools. Each sub-agent may run in any execution mode — client-side, server-side, or hybrid — independently of its parent.
+- **Recursive Sub-Agents:** Enable agents to call other agents as tools. Each sub-agent may run in any execution mode — client-side, server-side, or hybrid — independently of its parent. Approval policy travels with the _run_, not the runner: a sub-agent invoked from a parent run inherits the parent's `ApprovalHandler` through `ToolContext`, so flagged tool calls inside an independent child runner still surface to the parent's UI unless the child runner declares its own handler.
 - **Native Tool Integration:** Provide a seamless way to wrap TypeScript functions and Browser APIs as agent tools.
 - **Automatic History Management:** Provide a `Conversation` abstraction that tracks conversation history automatically across turns, so developers building multi-turn chatbots do not need to maintain a `Message[]` array manually.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -131,6 +131,8 @@ export interface ToolDefinition {
   name: string;
   description: string;
   parameters: Record<string, unknown>; // JSON Schema object
+  scope: 'read' | 'write'; // 'read' is non-mutating; 'write' modifies state
+  requiresApproval?: boolean; // tool author declares this tool is sensitive
 }
 
 export interface Tool<TArgs = unknown, TResult = unknown> {
@@ -138,9 +140,24 @@ export interface Tool<TArgs = unknown, TResult = unknown> {
   call(args: TArgs, context: ToolContext): Promise<TResult>;
 }
 
+export interface ApprovalRequest {
+  name: string;
+  args: unknown;
+}
+
+// `result` (or APPROVAL_CANCELLED_RESULT, when omitted) is what the model sees as the tool result on a reject.
+export type ApprovalResponse = { type: 'approve' } | { type: 'reject'; result?: string };
+
+export interface ApprovalHandler {
+  requestApproval(request: ApprovalRequest): Promise<ApprovalResponse>;
+}
+
+export const APPROVAL_CANCELLED_RESULT: string;
+
 export interface ToolContext {
   signal?: AbortSignal; // forwarded from the runner; allows long-running tools to be cancelled
   onEvent?: (event: AgentEvent) => void; // optional; tools wrapping sub-agents call this to surface child events
+  approvalHandler?: ApprovalHandler; // active handler for the current run; set by the runner when invoking tools
 }
 
 export class ToolRegistry {
@@ -162,6 +179,24 @@ export type ToolRegistryEventMap = {
 `ToolDefinition` is the runtime metadata forwarded to the remote backend in a URP request. It is never stored inside `AgentConfig`.
 
 Mutation events fire synchronously from `register()` and `unregister()` after the internal map is updated. `register()` throwing on a duplicate name does not fire `tool-registered`; `unregister()` for an unknown name is a silent no-op. `ToolRegistryView` forwards events from its parent registry but delivers only those for tools whose `scope` matches the view's scope.
+
+#### Approval gating
+
+`requiresApproval` gating is enforced by `AgentRunner` itself. Before invoking any tool whose definition has `requiresApproval: true`, the runner consults the active `ApprovalHandler` (resolved as `RunBuilder._approvalHandler ?? AgentRunner.approvalHandler`):
+
+- `{ type: 'approve' }` — the tool runs as normal.
+- `{ type: 'reject', result }` — execution is skipped; the model receives `result` (or `APPROVAL_CANCELLED_RESULT` when omitted) as the synthetic tool result, and a `tool_call_completed` event is emitted with `error: false`. The UI consumer is responsible for any cancelled-status styling.
+
+Tools without `requiresApproval: true` never invoke the handler. When no handler is attached, flagged tools execute ungated — the gate is opt-in at the consumer.
+
+The active handler is also threaded into `ToolContext.approvalHandler` so tools that internally start sub-agent runs (notably `createAgentTool`) can forward the handler to the child run. The propagation contract:
+
+- `Conversation` — accepts `{ approvalHandler }` via `runner.conversation(agent, options)`; `Conversation.runStream` calls `RunBuilder.withApprovalHandler` for every turn so the same handler covers the whole conversation.
+- `RunBuilder.withApprovalHandler(handler)` — overrides the runner-level default for a single run.
+- `AgentRunner.approvalHandler` — runner-level default consulted when no per-run handler is set.
+- `createAgentTool` — when `context.approvalHandler` is present and the child runner has no `approvalHandler` of its own, attaches the parent's handler to the child's `RunBuilder`. If the child runner has a handler, it wins (explicit child policy beats inheritance).
+
+The result is that approval policy travels with the _run_ rather than the runner: a sub-agent on an independent runner still surfaces approvals to whichever UI built the parent's `Conversation`, unless the child runner declares its own policy.
 
 ### `LlmAdapter` (`src/adapter/index.ts`)
 
@@ -219,8 +254,14 @@ export interface AgentResult {
 export class AgentRunner {
   constructor(adapter: LlmAdapter, registry?: ToolRegistry);
 
+  /**
+   * Default ApprovalHandler consulted for `requiresApproval` tools when no
+   * per-run handler is attached via RunBuilder.withApprovalHandler.
+   */
+  approvalHandler?: ApprovalHandler;
+
   /** Creates a Conversation that automatically tracks history across turns. */
-  conversation(agent: AgentConfig): Conversation;
+  conversation(agent: AgentConfig, options?: ConversationOptions): Conversation;
 
   /** Primary entry point for manual multi-turn use. */
   runBuilder(agent: AgentConfig): RunBuilder;
@@ -240,11 +281,12 @@ The agentic loop lives in `RunBuilder.runStream`:
 2. Prepend `history` to the new user `Message` and construct an `AdapterRequest` with resolved `ToolDefinition`s.
 3. Call `adapter.generateStream` (or fall back to `generate`) and forward `text_delta` chunks as `AgentEvent`.
 4. Collect `tool_call` chunks. When the turn ends with tool calls, emit all `tool_call_started` events.
-5. Execute all tool calls **concurrently** using `Promise.all`. Each tool receives a `ToolContext` containing the runner's `AbortSignal` and, when registered, an `onEvent` callback that forwards child events to the `onToolEvent` handler on `RunBuilder`.
-6. Emit all `tool_call_completed` events in original call order.
-7. Append assistant tool-call message and one user tool-result message per result to the internal history.
-8. Repeat from step 3 until the model returns a text-only turn.
-9. Emit `{ type: 'done', output }`.
+5. For each tool whose definition has `requiresApproval: true`, consult the active `ApprovalHandler` (`RunBuilder._approvalHandler ?? AgentRunner.approvalHandler`). On `{ type: 'reject', result }` the call is skipped and `result` (or `APPROVAL_CANCELLED_RESULT`) is used as the synthetic tool result. Tools without `requiresApproval: true` and runs without a handler skip this step.
+6. Execute approved tool calls **concurrently** using `Promise.all`. Each tool receives a `ToolContext` containing the runner's `AbortSignal`, the active `approvalHandler` (when set), and — when registered — an `onEvent` callback that forwards child events to the `onToolEvent` handler on `RunBuilder`.
+7. Emit all `tool_call_completed` events in original call order.
+8. Append assistant tool-call message and one user tool-result message per result to the internal history.
+9. Repeat from step 3 until the model returns a text-only turn.
+10. Emit `{ type: 'done', output }`.
 
 ### `RunBuilder` (`src/runner.ts`)
 
@@ -272,6 +314,12 @@ export class RunBuilder {
    * is undefined.
    */
   forwardTo(parentContext: ToolContext): this;
+
+  /**
+   * Attach an ApprovalHandler that gates `requiresApproval` tools for this run.
+   * Overrides the runner-level default (AgentRunner.approvalHandler).
+   */
+  withApprovalHandler(handler: ApprovalHandler): this;
 
   runStream(input: string): AsyncIterable<AgentEvent>;
   run(input: string): Promise<AgentResult>;
@@ -306,6 +354,11 @@ The runner remains stateless; the caller owns and extends the history. For the c
 ### `Conversation` (`src/conversation.ts`)
 
 ```typescript
+export interface ConversationOptions {
+  /** Approval handler attached to every Conversation.runStream call. */
+  approvalHandler?: ApprovalHandler;
+}
+
 export class Conversation {
   /** Full conversation history, updated automatically after each completed turn.
    *  Mutate directly to trim or compress history before the next turn. */
@@ -316,7 +369,7 @@ export class Conversation {
 }
 ```
 
-Created via `AgentRunner.conversation(agent)` — not constructed directly by callers.
+Created via `AgentRunner.conversation(agent, options?)` — not constructed directly by callers. When `options.approvalHandler` is supplied, every turn is gated by that handler, and the handler propagates through `ToolContext.approvalHandler` into any sub-agent run started via `createAgentTool`. UI layers (e.g. `@mast-ai/react-ui`'s `<AgentProvider>`) attach a handler here once and rely on `ToolContext` propagation for sub-agents.
 
 `Conversation` wraps a `RunBuilder` pair and automatically appends the updated history after each completed turn. History is taken from the `done` event's `history` field, which includes the full turn: user message, any tool call/result pairs, and the final assistant message.
 
@@ -375,12 +428,13 @@ The returned tool's `call(args, context)`:
 1. Builds the child input via `options.buildInput(args)`.
 2. Calls `runner.runBuilder(agent).forwardTo(context).signal(context.signal).runStream(input)`.
 3. `forwardTo(context)` automatically forwards every non-`done` child event to `context.onEvent`.
-4. Returns the `done.output` string as the tool result.
-5. Throws `AgentError` if the stream ends without a `done` event.
+4. When `context.approvalHandler` is set and the child runner has no `approvalHandler` of its own, calls `RunBuilder.withApprovalHandler(context.approvalHandler)` so the parent's approval surface gates the sub-agent's flagged tool calls. A child runner that defines its own `approvalHandler` wins — the explicit child policy is _not_ overridden.
+5. Returns the `done.output` string as the tool result.
+6. Throws `AgentError` if the stream ends without a `done` event.
 
 `done` events are filtered because they carry the child's full conversation `history`, which must not leak to parent UI consumers registered via `RunBuilder.onToolEvent` (see [Tool Event Streaming](./tool-event-streaming/PLAN.md#consumer-integration)).
 
-Because `runner` and `agent` are passed in separately, the child can use a different adapter, registry, instructions, or tool allowlist than the parent — true decoupling between parent and child execution modes.
+Because `runner` and `agent` are passed in separately, the child can use a different adapter, registry, instructions, or tool allowlist than the parent — true decoupling between parent and child execution modes. Approval policy is the one cross-cutting concern that travels with the run rather than the runner: a parent UI's handler reaches the child by default, with opt-out via the child runner's own handler.
 
 **Usage pattern (hybrid parent → on-device child):**
 

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -986,14 +986,20 @@ per-app.
 
 ### 9.2 Mechanism: `onApprovalRequired` callback
 
-`AgentProvider` pauses the run before executing any tool whose effective approval flag
-is `true` and calls `onApprovalRequired`. The consuming app renders its own confirmation
-UI and returns:
+Approval is enforced inside `@mast-ai/core`'s `AgentRunner`: before invoking any tool
+whose `ToolDefinition.requiresApproval` is `true`, the runner consults the `ApprovalHandler`
+attached to the active run and waits for an `ApprovalResponse` (`approve` or `reject`).
+`<AgentProvider>` builds that handler from `onApprovalRequired` (and `approvalOverride`)
+and attaches it once via `runner.conversation(agent, { approvalHandler })`. The user's
+`AgentRunner` is used directly — no shadow runner or registry wrap is constructed.
 
-- `true` — proceed with the tool call as normal
-- `false` — cancel the tool call; the runner receives a synthetic "user cancelled" result and the UI marks the call as `'cancelled'`
-- `string` — skip execution and inject this string as the tool result directly; the UI marks the call as `'cancelled'`
-- `INLINE_APPROVAL` — defer to the inline approval queue (see §9.3)
+The consuming app renders its own confirmation UI inside `onApprovalRequired` and
+returns:
+
+- `true` — proceed with the tool call as normal (handler resolves with `{ type: 'approve' }`).
+- `false` — cancel the tool call; the runner receives the default `APPROVAL_CANCELLED_RESULT` string as the synthetic tool result and the UI marks the call as `'cancelled'`.
+- `string` — skip execution and inject this string as the tool result directly; the UI marks the call as `'cancelled'` (semantic change from earlier releases — see [`MIGRATION.md` §4](../sub-agents/MIGRATION.md#4-onapprovalrequired-callbacks-that-return-a-string)).
+- `INLINE_APPROVAL` — defer to the inline approval queue (see §9.3).
 
 ```tsx
 <AgentProvider
@@ -1011,18 +1017,34 @@ While `onApprovalRequired` (or the inline queue) is pending, the matching
 indicator. The flag is cleared in a `try/finally` so it always resets, including when
 the callback throws.
 
+**Sub-agent propagation.** Because the handler is attached at the run level (via
+`Conversation`) and threaded into `ToolContext.approvalHandler` by the runner,
+`createAgentTool` automatically forwards it to child runs. A `requiresApproval: true`
+tool registered on the child surfaces approvals to the same `<AgentProvider>` UI as the
+parent's, even when the child uses an independent `AgentRunner` with a different adapter
+or registry. A child runner that sets its own `approvalHandler` opts out of inheritance
+and enforces its own policy.
+
 ### 9.3 Inline approval queue
 
 Returning `INLINE_APPROVAL` from `onApprovalRequired` enqueues a `PendingApproval`
 handle on `useAgent().pendingApprovals` and pauses the runner until the consumer
-calls `approve()` or `reject()`:
+calls `approve()` or `reject()`. The handler bridge translates the resolved value
+into the runner's `ApprovalResponse` (`approve()` → `{ type: 'approve' }`,
+`reject()` → `{ type: 'reject' }`, `reject(result)` → `{ type: 'reject', result }`):
 
 ```typescript
 interface PendingApproval {
   toolName: string;
   args: unknown;
-  approve: () => void; // resolves with `true`
-  reject: (result?: string) => void; // resolves with `false`, or with the string
+  /** Approve and run the tool normally. */
+  approve: () => void;
+  /**
+   * Reject the call. With no argument the runner receives the default cancelled
+   * result; with a string the runner receives that string as the tool result.
+   * In both cases the UI marks the call as `'cancelled'`.
+   */
+  reject: (result?: string) => void;
 }
 ```
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -888,7 +888,9 @@ const onApprovalRequired: OnApprovalRequired = async (toolCall) => {
 
 The callback can also return:
 
-- a `string` to skip execution and inject that string as the tool result, or
+- a `string` to skip execution and inject that string as the tool result; the
+  rendered tool entry shows the cancelled status (see [`MIGRATION.md` §4](../sub-agents/MIGRATION.md#4-onapprovalrequired-callbacks-that-return-a-string)
+  for the rationale and migration tips), or
 - `INLINE_APPROVAL` to defer to the inline approval queue (next section).
 
 While the callback is pending, the matching `ToolEventEntry.awaitingApproval`

--- a/docs/sub-agents/MIGRATION.md
+++ b/docs/sub-agents/MIGRATION.md
@@ -72,7 +72,9 @@ re-run your tests.
 + "@mast-ai/react-ui": "0.7.0",
 ```
 
-(Replace versions with the actual release. See PLAN.md §"Release strategy".)
+The architecture lands in `@mast-ai/*` v0.7.0 — see the
+[v0.7.0 release notes](https://github.com/andreban/mast-ai/releases/tag/v0.7.0)
+for the full changelog.
 
 What you get for free: any `createAgentTool`-mediated sub-agent in your app
 now correctly fires `onApprovalRequired` for child tool calls flagged
@@ -299,7 +301,7 @@ After upgrading, confirm:
 
 ## 9. Rolling back
 
-If you need to revert, pin both packages to the previous release together:
+If you need to revert from v0.7.0, pin both packages to v0.6.0 together:
 
 ```json
 {
@@ -312,7 +314,9 @@ If you need to revert, pin both packages to the previous release together:
 
 Mixing major-feature mismatched versions across `@mast-ai/*` is unsupported —
 the lockstep release policy means consumers always upgrade or downgrade
-the entire family together.
+the entire family together. See the
+[v0.7.0 release notes](https://github.com/andreban/mast-ai/releases/tag/v0.7.0)
+for the full set of changes you are reverting.
 
 ---
 

--- a/skills/mast-ai/references/core-api.md
+++ b/skills/mast-ai/references/core-api.md
@@ -21,7 +21,9 @@ export interface AgentConfig {
 export interface ToolDefinition {
   name: string;
   description: string;
-  parameters: Record<string, unknown>;  // JSON Schema object
+  parameters: Record<string, unknown>; // JSON Schema object
+  scope: 'read' | 'write'; // 'read' is non-mutating; 'write' modifies state
+  requiresApproval?: boolean; // tool author declares this tool is sensitive
 }
 
 export interface ToolContext {
@@ -29,6 +31,11 @@ export interface ToolContext {
   // Tools wrapping sub-agents call this to surface child events to the parent consumer.
   // Filter out 'done' events before forwarding to avoid leaking child history.
   onEvent?: (event: AgentEvent) => void;
+  // Active approval handler for the current run; set by the runner. Tools that
+  // start sub-agent runs forward this to the child's RunBuilder.withApprovalHandler
+  // unless the child runner has its own approvalHandler. createAgentTool does this
+  // automatically.
+  approvalHandler?: ApprovalHandler;
 }
 
 export interface Tool<TArgs = unknown, TResult = unknown> {
@@ -49,6 +56,32 @@ registry.addEventListener('tool-unregistered', ({ name }) => { /* ... */ });
 // addEventListener / removeEventListener API, scoped to the view's filter.
 ```
 
+## Approval Gating
+
+The runner consults an `ApprovalHandler` before invoking any tool whose definition has `requiresApproval: true`. Tools without the flag, and runs without an attached handler, skip the gate entirely.
+
+```typescript
+export interface ApprovalRequest {
+  name: string;
+  args: unknown;
+}
+
+export type ApprovalResponse = { type: 'approve' } | { type: 'reject'; result?: string };
+
+export const ApprovalResponse: {
+  approve(): ApprovalResponse;
+  reject(result?: string): ApprovalResponse;
+};
+
+export interface ApprovalHandler {
+  requestApproval(request: ApprovalRequest): Promise<ApprovalResponse>;
+}
+
+export const APPROVAL_CANCELLED_RESULT: string;
+```
+
+Resolution order for the active handler on a run: `RunBuilder._approvalHandler ?? AgentRunner.approvalHandler`. The runner threads the active handler into `ToolContext.approvalHandler` so tools that start sub-agent runs can forward it (`createAgentTool` does this automatically when `context.approvalHandler` is set and the child runner has no `approvalHandler` of its own — explicit child policy wins).
+
 ## AgentRunner
 
 The stateless execution engine. Owns the adapter and registry.
@@ -57,11 +90,14 @@ The stateless execution engine. Owns the adapter and registry.
 export class AgentRunner {
   constructor(adapter: LlmAdapter, registry?: ToolRegistry);
 
+  /** Default ApprovalHandler consulted when no per-run handler is attached. */
+  approvalHandler?: ApprovalHandler;
+
   /** Primary entry point for multi-turn use. Returns a RunBuilder. */
   runBuilder(agent: AgentConfig): RunBuilder;
 
   /** Creates a Conversation that automatically tracks history across turns. */
-  conversation(agent: AgentConfig): Conversation;
+  conversation(agent: AgentConfig, options?: ConversationOptions): Conversation;
 
   /** Single-turn convenience methods (no onToolEvent support). */
   runStream(agent: AgentConfig, input: string): AsyncIterable<AgentEvent>;
@@ -98,6 +134,12 @@ export class RunBuilder {
    */
   forwardTo(parentContext: ToolContext): this;
 
+  /**
+   * Attach an ApprovalHandler that gates `requiresApproval` tools for this run.
+   * Overrides the runner-level default (AgentRunner.approvalHandler).
+   */
+  withApprovalHandler(handler: ApprovalHandler): this;
+
   runStream(input: string): AsyncIterable<AgentEvent>;
   run(input: string): Promise<AgentResult>;
   runTyped<T>(input: string): Promise<T>;
@@ -126,6 +168,11 @@ async call(args, context: ToolContext): Promise<string> {
 Wraps `AgentRunner` to track state automatically across turns.
 
 ```typescript
+export interface ConversationOptions {
+  /** Approval handler attached to every Conversation.runStream call. */
+  approvalHandler?: ApprovalHandler;
+}
+
 export class Conversation {
   /** Full conversation history, updated automatically after each completed turn. */
   history: Message[];
@@ -135,7 +182,8 @@ export class Conversation {
 }
 
 // Usage
-const conv = runner.conversation(agent);
+const conv = runner.conversation(agent, { approvalHandler });
 const result = await conv.run('Hello!');
-// conv.history is automatically updated.
+// conv.history is automatically updated. The handler propagates through
+// ToolContext.approvalHandler into any sub-agent run started via createAgentTool.
 ```

--- a/skills/mast-ai/references/react-ui.md
+++ b/skills/mast-ai/references/react-ui.md
@@ -31,7 +31,7 @@ interface AgentProviderProps {
   children: ReactNode;
   icons?: IconMap;
   onApprovalRequired?: OnApprovalRequired;
-  approvalOverride?: string[]; // bare names add approval; '!name' suppresses it
+  approvalOverride?: string[]; // '!name' suppresses approval for that tool; bare names are accepted for symmetry but no longer add approval (set `requiresApproval: true` on the definition instead)
   initialHistory?: Message[]; // read once on mount
   initialEntries?: ConversationEntry[]; // read once on mount
   onConversationChange?: (history: Message[], entries: ConversationEntry[]) => void;
@@ -40,7 +40,7 @@ interface AgentProviderProps {
 }
 ```
 
-Internally creates a `Conversation` via `runner.conversation(agent)`. To switch conversations at runtime, remount with a React `key` and seed via `initialHistory` / `initialEntries`. `onConversationChange` fires only after a successful `done` event (not on cancel or error).
+Internally creates a `Conversation` via `runner.conversation(agent, { approvalHandler })`, where `approvalHandler` bridges `onApprovalRequired` and `approvalOverride` into the runner's per-run gating contract. The user's `runner` is used directly (no shadow runner). To switch conversations at runtime, remount with a React `key` and seed via `initialHistory` / `initialEntries`. `onConversationChange` fires only after a successful `done` event (not on cancel or error).
 
 `runner={null}` is the "agent not yet configured" state for chat UIs that mount before the user has supplied an API key, signed in, etc. `useAgent()` returns disabled-state defaults (`isReady: false`, empty messages/history, no-op `sendMessage` with a console warning), and `<ChatInput>` greys out automatically. Switching `null` → real runner does not require remounting; the conversation starts fresh on the next `sendMessage` (and picks up `initialHistory` if provided). Prefer this over constructing a stub runner whose adapter throws.
 
@@ -131,11 +131,11 @@ interface ToolEventEntry {
 
 ## Approval Flow
 
-Three pieces:
+Approval is enforced inside `@mast-ai/core`'s `AgentRunner`: before invoking any tool whose `ToolDefinition.requiresApproval` is `true`, the runner consults the `ApprovalHandler` `<AgentProvider>` attached to the run. Three pieces:
 
 1. Tool author sets `requiresApproval: true` on the tool definition.
 2. By default, the library routes such calls through the inline approval queue (`useAgent().pendingApprovals`) rendered by `<InlineApproval>`. Apps may supply `onApprovalRequired` on `<AgentProvider>` to plug in a different confirmation UI, auto-approve specific tools, inject canned results, or short-circuit cancellations.
-3. Optional: `approvalOverride={['!safe_tool', 'third_party_tool']}` adjusts policy at runtime.
+3. Optional: `approvalOverride={['!safe_tool']}` suppresses approval for a flagged tool at runtime. To _add_ approval to a tool that does not declare it, set `requiresApproval: true` on the definition at registration — the runner only consults the handler for flagged tools.
 
 ```typescript
 import { INLINE_APPROVAL } from '@mast-ai/react-ui';
@@ -149,9 +149,11 @@ type OnApprovalRequired = (toolCall: {
 Return values:
 
 - `true`: run the tool normally.
-- `false`: runner receives a synthetic "user cancelled" result.
-- `string`: skip execution and inject the string as the tool result.
+- `false`: skip execution; runner receives the default cancelled string and the UI marks the call as `'cancelled'`.
+- `string`: skip execution and inject the string as the tool result; the UI marks the call as `'cancelled'`.
 - `INLINE_APPROVAL`: defer to the inline approval queue (see below).
+
+Sub-agents started via `createAgentTool` automatically inherit the parent's `ApprovalHandler` through `ToolContext.approvalHandler`, so a `requiresApproval: true` tool registered on a child runner surfaces approvals to the same `<AgentProvider>` UI — even when the child uses an independent `AgentRunner` with a different adapter or registry. A child runner that sets its own `approvalHandler` opts out of inheritance and enforces its own policy.
 
 ### Inline approvals
 


### PR DESCRIPTION
## Summary

- Rewrites the library-level and react-ui-level docs to describe runner-level approval gating with an `ApprovalHandler` propagated through `ToolContext` (replacing the old react-ui registry-wrap framing).
- Pins `docs/sub-agents/MIGRATION.md` to v0.7.0 and cross-links the release notes.
- Brings the mast-ai skill references (`core-api.md`, `react-ui.md`) in line with the new public surface so future skill-driven code generation produces correct call sites.

### Files

- `docs/PRD.md` §3 — clarifies that approval policy travels with the *run* via `ToolContext`, so sub-agents on independent runners still surface approvals to the parent UI.
- `docs/SPEC.md` — adds `ApprovalRequest` / `ApprovalResponse` / `ApprovalHandler` / `APPROVAL_CANCELLED_RESULT` to the type listings, adds `ToolContext.approvalHandler`, adds a new "Approval gating" subsection covering runner-level enforcement and the propagation contract; updates `AgentRunner`, `RunBuilder`, `Conversation`, and `createAgentTool` accordingly.
- `docs/react-ui/SPEC.md` §9.2–9.3 — describes runner-side enforcement plus the `<AgentProvider>`-built handler, calls out the string-return semantic change with a link into the migration guide, adds a sub-agent propagation note, tightens the `PendingApproval` doc.
- `docs/react-ui/USAGE.md` §10.2 — string-return bullet now flags the `'cancelled'` styling and links to `MIGRATION.md` §4.
- `docs/sub-agents/MIGRATION.md` §2 and §9 — pinned to v0.7.0; cross-linked the v0.7.0 release notes URL.
- `skills/mast-ai/references/core-api.md` — adds the new approval primitives, updates `ToolDefinition` / `ToolContext` / `AgentRunner` / `RunBuilder` / `Conversation` to match the new surface.
- `skills/mast-ai/references/react-ui.md` — fixes the `approvalOverride` comment (bare names no longer add approval), reframes the Approval Flow section for runner-level enforcement, adds the sub-agent inheritance note, and clarifies the cancelled-status semantics for `false` and string returns.

No code changes — doc-only PR.

Closes #134

## Test plan

- [x] `npm run format` — no changes
- [x] `npm run lint` — clean
- [x] `npm run build` — passes
- [x] `npm test --workspaces --if-present` — 183 tests pass
- [x] Spot-check rendered Markdown for headings, table layout, and migration cross-links