### PR TITLE
chore: release v0.7.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.6.0"
+    "@mast-ai/core": "^0.7.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.6.0"
+    "@mast-ai/core": "^0.7.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/openai",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.6.0",
+    "@mast-ai/core": "^0.7.0",
     "openai": "^6.37.0"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.6.0",
+    "@mast-ai/core": "^0.7.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
## Summary

Cuts release **v0.7.0**. Bumps every `@mast-ai/*` package from `0.6.0` to `0.7.0` in lockstep.

## Why minor

Under the project's 0.x policy, breaking changes are minor bumps. `@mast-ai/react-ui` had behaviour changes in #139 (`PendingApproval.respondWith` dropped, `OnApprovalRequired` string-return now lands as `status: 'cancelled'`, `approvalOverride` no longer auto-adds approval), so this release is at minimum minor.

## Changes since v0.6.0

**`@mast-ai/core`** — additive
- New approval primitives: `ApprovalRequest`, `ApprovalResponse` (tagged union + helper namespace), `ApprovalHandler`, `APPROVAL_CANCELLED_RESULT` (#136)
- Runner-level approval gating: `RunBuilder.withApprovalHandler()`, `AgentRunner.approvalHandler` field, `ToolContext.approvalHandler` propagated to tools (#137)
- `Conversation` accepts `ConversationOptions { approvalHandler? }`; `createAgentTool` inherits the handler into child runs (#138)

**`@mast-ai/react-ui`** — breaking + additive
- Handler-based approval gating replaces the registry-wrap mechanism (#139). `AgentProvider` no longer constructs a shadow `AgentRunner`; sub-agent runs created via `createAgentTool` now inherit the approval handler through `ToolContext` regardless of which runner the child is attached to. Closes #128.
- New exports: `computeNeedsApproval`; re-exports `ApprovalResponse`, `ApprovalHandler`, `ApprovalRequest` from `@mast-ai/core`.
- Breaking: `PendingApproval.respondWith` removed (use `reject(result?)` for synthetic cancelled-result substitution). String-return from `OnApprovalRequired` now produces `status: 'cancelled'`. `approvalOverride` no longer adds approval to tools whose definition has `requiresApproval: false`.

**`@mast-ai/google-genai`, `@mast-ai/built-in-ai`, `@mast-ai/openai`** — no source changes; republished in lockstep.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test --workspaces --if-present` — 298 tests pass across all packages
- [x] `npm run build` — all packages and demos build successfully
- [ ] After merge, tag `v0.7.0` from `main` and push to trigger the publish workflow