### PR TITLE
fix(react-ui): render and cancel nested sub-agent approvals

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -143,6 +143,10 @@ export interface Tool<TArgs = unknown, TResult = unknown> {
 export interface ApprovalRequest {
   name: string;
   args: unknown;
+  // Forwarded from the active run. Handlers that block on a UI (a
+  // confirmation dialog, an inline queue) should listen on this signal and
+  // resolve early when it aborts so cancelling the run unblocks the awaiter.
+  signal?: AbortSignal;
 }
 
 // `result` (or APPROVAL_CANCELLED_RESULT, when omitted) is what the model sees as the tool result on a reject.

--- a/docs/react-ui/SPEC.md
+++ b/docs/react-ui/SPEC.md
@@ -697,7 +697,12 @@ ergonomic to relabel one tool while leaving everything else untouched.
 - Tools that are not sub-agents will have no `subThinking` or `subText`; they show
   only the spinner → check transition and args/result.
 - When `entry.nestedToolEvents` is non-empty, each nested tool call renders
-  recursively inside the parent block, indented with a left border.
+  recursively inside the parent block, indented with a left border. When the
+  block is rendered inside an `<AssistantMessage>`, the nested entries flow
+  through the same approval-aware renderer as top-level entries (via the
+  `NestedToolRenderContext`), so an inline approval card surfaces on
+  sub-agent tool calls at any nesting depth. Standalone usage (no provider
+  in scope) falls back to a bare recursive `<ToolCallBlock>`.
 - Uses `<details>/<summary>` for the outer block, args, and result expand/collapse so
   the component is keyboard-accessible without JavaScript.
 
@@ -948,9 +953,9 @@ maintains `ConversationEntry[]` as follows:
 | `onToolEvent` → `thinking`            | Mutate matching `ToolEventEntry`: append `delta` to `subThinking`                                                                                                               |
 | `onToolEvent` → `text_delta`          | Mutate matching `ToolEventEntry`: append `delta` to `subText`                                                                                                                   |
 | `onToolEvent` → `tool_call_started`   | Mutate matching parent `ToolEventEntry`: push `{ id, type: 'tool_call_started', name, args, isStreaming: true }` onto `nestedToolEvents`                                        |
-| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error`                                                     |
-| Approval handler notifies             | Mutate matching `ToolEventEntry` in `contentBlocks`: set `awaitingApproval` to `true`/`false`                                                                                   |
-| Approval handler cancels              | Mutate matching `ToolEventEntry` in `contentBlocks`: set `status: 'cancelled'` (sticky across `tool_call_completed`)                                                            |
+| `onToolEvent` → `tool_call_completed` | Mutate matching nested `ToolEventEntry` (under the parent): set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`)              |
+| Approval handler notifies             | Mutate the deepest matching streaming `ToolEventEntry` (walking `nestedToolEvents` recursively): set `awaitingApproval` to `true`/`false`                                       |
+| Approval handler cancels              | Mutate the deepest matching streaming `ToolEventEntry` (walking `nestedToolEvents` recursively): set `status: 'cancelled'` (sticky across `tool_call_completed`)                |
 | `tool_call_completed`                 | Mutate matching `ToolEventEntry` in `contentBlocks`: set `result`, `isStreaming: false`, `status` from `event.error` (preserving an existing `'cancelled'`)                     |
 | `done`                                | Mutate last entry: set `text = output`, `isStreaming = false`                                                                                                                   |
 | Error / cancel                        | Mutate last entry: set `isStreaming = false`; optionally append error text                                                                                                      |
@@ -1074,6 +1079,13 @@ a handle.
 
 When `reset()` is called while approvals are pending, the library calls `reject()`
 on each so the underlying handler invocations finish and the run terminates cleanly.
+
+When `cancel()` is called while approvals are pending, the inline queue listens
+on the run's `AbortSignal` and resolves each pending entry as a rejection so the
+runner's next loop iteration sees the abort and throws. Approvals are removed
+from `useAgent().pendingApprovals` and the matching `ToolEventEntry.status`
+becomes `'cancelled'`. Without this wiring `cancel()` would strand the runner
+indefinitely on the unresolved approval Promise.
 
 ### 9.4 Runtime override: `approvalOverride`
 

--- a/docs/react-ui/USAGE.md
+++ b/docs/react-ui/USAGE.md
@@ -1122,6 +1122,15 @@ Nesting is currently scoped to a single level (a sub-agent calling its own
 tools). Grandchild events route back to the outermost matching parent; deeper
 disambiguation is a future extension tracked in the SPEC.
 
+Approvals on sub-agent tool calls (tools whose `requiresApproval` is `true`,
+registered on the child runner's registry) surface inline beneath the
+nested entry: the same `<InlineApproval>` card — or your `renderApproval` /
+`renderToolCall` slot — is reused for entries at any depth. Calling
+`cancel()` (or pressing the cancel button in `<ChatInput>`) while a nested
+approval is pending unblocks the run cleanly: the pending entry is removed
+from `useAgent().pendingApprovals`, the matching `ToolEventEntry.status`
+becomes `'cancelled'`, and the runner unwinds.
+
 ### 11.1 Custom sub-agent tools: use `forwardTo(context)`
 
 `createAgentTool` is the canonical wrapper, but some tools need custom logic

--- a/docs/sub-agents/MIGRATION.md
+++ b/docs/sub-agents/MIGRATION.md
@@ -31,6 +31,9 @@ Three primitives are added to `@mast-ai/core` and re-exported from
 interface ApprovalRequest {
   name: string;
   args: unknown;
+  // Forwarded from the active run; handlers that block on a UI should listen
+  // for it and resolve early when it aborts.
+  signal?: AbortSignal;
 }
 
 type ApprovalResponse = { type: 'approve' } | { type: 'reject'; result?: string };

--- a/docs/sub-agents/SPEC.md
+++ b/docs/sub-agents/SPEC.md
@@ -225,6 +225,13 @@ export interface ApprovalRequest {
   name: string;
   /** Arguments the model passed to the tool. */
   args: unknown;
+  /**
+   * Forwarded from the active run. Custom approval handlers that block on a
+   * UI (a confirmation dialog, an inline queue) should listen on this signal
+   * and resolve early when it aborts so a `cancel()` on the run does not
+   * strand the runner waiting on a decision that will never come.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -341,7 +348,11 @@ The decision is applied uniformly:
 const def = tool.definition();
 const handler = builder._approvalHandler ?? this.approvalHandler;
 if (def.requiresApproval && handler) {
-  const response = await handler.requestApproval({ name: call.name, args: call.args });
+  const response = await handler.requestApproval({
+    name: call.name,
+    args: call.args,
+    signal,
+  });
   if (response.type === 'reject') {
     return response.result ?? APPROVAL_CANCELLED_RESULT;
   }

--- a/packages/core/src/runner.test.ts
+++ b/packages/core/src/runner.test.ts
@@ -500,4 +500,59 @@ describe('approval gating', () => {
     expect(handler.requestApproval).not.toHaveBeenCalled();
     expect(receivedCtx?.approvalHandler).toBe(handler);
   });
+
+  it('forwards the run signal to ApprovalRequest so handlers can race their UI against cancel', async () => {
+    const handler: ApprovalHandler = {
+      requestApproval: vi.fn().mockResolvedValue(ApprovalResponse.approve()),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = handler;
+
+    const controller = new AbortController();
+    await drain(runner.runBuilder(agent).signal(controller.signal).runStream('go'));
+
+    expect(handler.requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'risky_tool',
+        signal: controller.signal,
+      }),
+    );
+  });
+
+  it('aborts cleanly when the signal fires while requestApproval is awaiting', async () => {
+    const controller = new AbortController();
+    const handler: ApprovalHandler = {
+      // Race the abort: resolve as 'reject' once the signal fires, mimicking
+      // an inline-approval queue that listens on the signal.
+      requestApproval: vi.fn(({ signal }) => {
+        return new Promise((resolve) => {
+          if (signal?.aborted) {
+            resolve(ApprovalResponse.reject());
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(ApprovalResponse.reject()), {
+            once: true,
+          });
+        });
+      }),
+    };
+    const tool = approvalTool('risky_tool', { requiresApproval: true });
+    const runner = runnerWithTool(singleCallThenDoneAdapter('risky_tool'), tool);
+    runner.approvalHandler = handler;
+
+    const stream = runner.runBuilder(agent).signal(controller.signal).runStream('go');
+    // Kick the loop forward so requestApproval starts awaiting, then abort.
+    const collected: AgentEvent[] = [];
+    const pump = (async () => {
+      for await (const event of stream) collected.push(event);
+    })();
+
+    // Let the runner reach the awaiting requestApproval call.
+    await new Promise((r) => setTimeout(r, 0));
+    controller.abort();
+
+    await expect(pump).rejects.toThrow(AgentError);
+    expect(tool.call).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -286,6 +286,7 @@ export class AgentRunner {
               const decision = await approvalHandler.requestApproval({
                 name: call.name,
                 args: call.args,
+                signal,
               });
               if (decision.type === 'reject') {
                 return {

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -21,6 +21,17 @@ export interface ApprovalRequest {
   name: string;
   /** Arguments the model passed to the tool. */
   args: unknown;
+  /**
+   * Forwarded from the active run. Custom approval handlers that block on a
+   * UI (a confirmation dialog, an inline queue) should listen for this signal
+   * and resolve early when it aborts so a `cancel()` on the run does not
+   * strand the runner waiting on a decision that will never come.
+   *
+   * The handler's response in the abort case is up to it; the runner re-checks
+   * the signal on the next loop iteration and throws regardless, so any
+   * decision returned by the handler is effectively discarded.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/packages/react-ui/src/approval.test.tsx
+++ b/packages/react-ui/src/approval.test.tsx
@@ -753,4 +753,201 @@ describe('AgentProvider — approval flow', () => {
       expect(sensitive.call).toHaveBeenCalledTimes(1);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Nested approval rendering and cancellation — issue #142
+  // -------------------------------------------------------------------------
+
+  describe('nested approval state propagation (issue #142)', () => {
+    function delegateAgent(): AgentConfig {
+      return { name: 'Parent', instructions: 'Parent agent.', tools: ['delegate'] };
+    }
+
+    function childAgent(): AgentConfig {
+      return { name: 'Child', instructions: 'Child agent.', tools: ['sensitive'] };
+    }
+
+    function wrapperWithAgent(props: {
+      runner: AgentRunner;
+      agent: AgentConfig;
+      onApprovalRequired?: OnApprovalRequired;
+    }) {
+      return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+          <AgentProvider
+            runner={props.runner}
+            agent={props.agent}
+            onApprovalRequired={props.onApprovalRequired}
+          >
+            {children}
+          </AgentProvider>
+        );
+      };
+    }
+
+    /**
+     * Builds a parent+child topology where the parent calls `delegate` and the
+     * child calls `sensitive` (which has `requiresApproval: true`). The
+     * scripted adapter ends each role's run on its second turn so the loop
+     * terminates after the approval flow plays out.
+     */
+    function buildDelegateTopology() {
+      const sensitive = new StubTool(SENSITIVE_DEF, 'sensitive-result');
+      const registry = new ToolRegistry().register(sensitive);
+      const adapter = scriptedAdapter([
+        [{ type: 'tool_call', toolCall: { id: 'p1', name: 'delegate', args: { task: 'go' } } }],
+        [{ type: 'tool_call', toolCall: { id: 'c1', name: 'sensitive', args: { x: 1 } } }],
+        [{ type: 'text_delta', delta: 'child-done' }],
+        [{ type: 'text_delta', delta: 'parent-done' }],
+      ]);
+      const runner = new AgentRunner(adapter, registry);
+      registry.register(
+        createAgentTool(runner, childAgent(), {
+          name: 'delegate',
+          description: 'Hand off to the child.',
+          parameters: { type: 'object' },
+          scope: 'write',
+          buildInput: (a) => (a as { task: string }).task,
+        }),
+      );
+      return { runner, sensitive };
+    }
+
+    /** Returns the nested `sensitive` entry under the parent `delegate`, if present. */
+    function findNestedSensitive(result: {
+      current: ReturnType<typeof useAgent>;
+    }): ToolEventEntry | undefined {
+      const lastTurn = result.current.messages.at(-1);
+      const delegate = lastTurn?.contentBlocks.find(
+        (b): b is ToolEventEntry => b.type !== 'thinking' && b.name === 'delegate',
+      );
+      return delegate?.nestedToolEvents?.find((n) => n.name === 'sensitive');
+    }
+
+    it('marks the nested entry as awaitingApproval while the inline queue is pending', async () => {
+      const { runner } = buildDelegateTopology();
+
+      const { result } = renderHook(() => useAgent(), {
+        wrapper: wrapperWithAgent({ runner, agent: delegateAgent() }),
+      });
+
+      act(() => {
+        result.current.sendMessage('plan');
+      });
+      // Let the parent dispatch `delegate`, the child dispatch `sensitive`,
+      // and the approval handler enqueue the inline pending approval.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const nested = findNestedSensitive(result);
+      expect(nested).toBeDefined();
+      expect(nested?.awaitingApproval).toBe(true);
+      expect(nested?.isStreaming).toBe(true);
+      expect(result.current.pendingApprovals).toHaveLength(1);
+      expect(result.current.pendingApprovals[0].toolName).toBe('sensitive');
+    });
+
+    it("clears awaitingApproval and marks status 'cancelled' on the nested entry when reject() is called", async () => {
+      const { runner, sensitive } = buildDelegateTopology();
+
+      const { result } = renderHook(() => useAgent(), {
+        wrapper: wrapperWithAgent({ runner, agent: delegateAgent() }),
+      });
+
+      act(() => {
+        result.current.sendMessage('plan');
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        result.current.pendingApprovals[0].reject();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(sensitive.call).not.toHaveBeenCalled();
+      const nested = findNestedSensitive(result);
+      expect(nested?.awaitingApproval).toBe(false);
+      expect(nested?.status).toBe('cancelled');
+      expect(nested?.isStreaming).toBe(false);
+      expect(nested?.result).toMatch(/cancel/i);
+    });
+
+    it('cancel() during a nested pending approval unblocks the run and removes the pending entry', async () => {
+      const { runner, sensitive } = buildDelegateTopology();
+
+      const { result } = renderHook(() => useAgent(), {
+        wrapper: wrapperWithAgent({ runner, agent: delegateAgent() }),
+      });
+
+      act(() => {
+        result.current.sendMessage('plan');
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.pendingApprovals).toHaveLength(1);
+      expect(result.current.isRunning).toBe(true);
+
+      await act(async () => {
+        result.current.cancel();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(sensitive.call).not.toHaveBeenCalled();
+      expect(result.current.pendingApprovals).toHaveLength(0);
+      expect(result.current.isRunning).toBe(false);
+      const lastTurn = result.current.messages.at(-1);
+      expect(lastTurn?.isStreaming).toBe(false);
+    });
+
+    it('cancel() during a top-level pending approval unblocks the run', async () => {
+      // Same flow but with the sensitive tool called directly by the agent
+      // (no sub-agent wrapping), to confirm abort wiring also works at the
+      // top level — the contract should not be specific to nesting.
+      const sensitive = new StubTool(SENSITIVE_DEF, 'sensitive-result');
+      const registry = new ToolRegistry().register(sensitive);
+      const adapter = scriptedAdapter([
+        [{ type: 'tool_call', toolCall: { id: '1', name: 'sensitive', args: {} } }],
+        [{ type: 'text_delta', delta: 'done' }],
+      ]);
+      const runner = new AgentRunner(adapter, registry);
+
+      const { result } = renderHook(() => useAgent(), { wrapper: wrapper({ runner }) });
+
+      act(() => {
+        result.current.sendMessage('go');
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.pendingApprovals).toHaveLength(1);
+      expect(result.current.isRunning).toBe(true);
+
+      await act(async () => {
+        result.current.cancel();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(sensitive.call).not.toHaveBeenCalled();
+      expect(result.current.pendingApprovals).toHaveLength(0);
+      expect(result.current.isRunning).toBe(false);
+    });
+  });
 });

--- a/packages/react-ui/src/approval.ts
+++ b/packages/react-ui/src/approval.ts
@@ -105,8 +105,16 @@ export interface ApprovalHandlerHooks {
    * Pushes a pending approval onto the queue and returns a promise that
    * resolves once the consumer calls `approve()` (with `true`), `reject()`
    * (with `false`), or `reject(result)` (with the result string).
+   *
+   * When `signal` is provided, the queue resolver also resolves with `false`
+   * if the signal aborts before a decision is reached, so cancelling the run
+   * unblocks the awaiter.
    */
-  enqueueInline?: (toolName: string, args: unknown) => Promise<boolean | string>;
+  enqueueInline?: (
+    toolName: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ) => Promise<boolean | string>;
 }
 
 /**
@@ -143,7 +151,7 @@ export function createApprovalHandler(
   hooks: ApprovalHandlerHooks = {},
 ): ApprovalHandler {
   return {
-    async requestApproval({ name, args }) {
+    async requestApproval({ name, args, signal }) {
       const override = getApprovalOverride();
       // `!name` in the override list short-circuits to approve, matching the
       // suppression rule in `computeNeedsApproval`.
@@ -164,7 +172,7 @@ export function createApprovalHandler(
         let resolved: boolean | string;
         if (initial === INLINE_APPROVAL) {
           // No queue wired — fall through to approve so the run does not deadlock.
-          resolved = hooks.enqueueInline ? await hooks.enqueueInline(name, args) : true;
+          resolved = hooks.enqueueInline ? await hooks.enqueueInline(name, args, signal) : true;
         } else {
           resolved = initial;
         }

--- a/packages/react-ui/src/components/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/AssistantMessage.tsx
@@ -10,7 +10,11 @@ import type { ConversationEntry, ToolEventEntry } from '../types.js';
 import { InlineApproval } from './InlineApproval.js';
 import { ThinkingBlock } from './ThinkingBlock.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
-import { ToolLabelContext, type GetToolLabel } from './ToolLabelContext.js';
+import {
+  NestedToolRenderContext,
+  ToolLabelContext,
+  type GetToolLabel,
+} from './ToolLabelContext.js';
 
 /**
  * Slot for replacing only the inline approval card while keeping the default
@@ -35,8 +39,10 @@ export interface AssistantMessageProps {
    */
   renderMessage?: (text: string) => ReactNode;
   /**
-   * Replaces the default tool-call renderer. Called once per element of
-   * `entry.toolEvents`.
+   * Replaces the default tool-call renderer. Called once per top-level tool
+   * event in `entry.contentBlocks` and once per nested tool event reached
+   * through `nestedToolEvents` (so sub-agent tool calls flow through the
+   * same slot).
    *
    * Receives the tool event and, when the call is awaiting an inline
    * approval decision, a {@link PendingApproval} handle exposing
@@ -55,8 +61,10 @@ export interface AssistantMessageProps {
   /**
    * Replaces only the inline approval card. Called once per tool event whose
    * call is awaiting an inline approval decision (i.e. has a matching
-   * {@link PendingApproval} handle); non-approval tool events fall through to
-   * `renderToolCall` or the default `<ToolCallBlock>`.
+   * {@link PendingApproval} handle), at any nesting depth — sub-agent tool
+   * calls reach this slot via the same path as top-level entries.
+   * Non-approval tool events fall through to `renderToolCall` or the default
+   * `<ToolCallBlock>`.
    *
    * Use this slot to customise the approval prompt without rebuilding the
    * tool-call rendering for every other event. Takes precedence over
@@ -165,34 +173,36 @@ export function AssistantMessage({
 
   return (
     <ToolLabelContext.Provider value={getToolLabel}>
-      <div
-        data-mast-assistant-message
-        data-streaming={entry.isStreaming ? 'true' : undefined}
-        className={rootClass}
-      >
-        {entry.contentBlocks.map((block, index) => {
-          const isLastBlock = index === entry.contentBlocks.length - 1;
-          if (block.type === 'thinking') {
-            return (
-              <ThinkingBlock
-                key={block.id}
-                content={block.content}
-                isStreaming={entry.isStreaming && isLastBlock}
-              />
-            );
-          }
-          return <Fragment key={`${block.id}-${index}`}>{renderToolEvent(block)}</Fragment>;
-        })}
-        {entry.text ? (
-          renderMessage ? (
-            renderMessage(entry.text)
-          ) : (
-            <Suspense fallback={<p className="mast-assistant-message-text">{entry.text}</p>}>
-              <MarkdownText>{entry.text}</MarkdownText>
-            </Suspense>
-          )
-        ) : null}
-      </div>
+      <NestedToolRenderContext.Provider value={renderToolEvent}>
+        <div
+          data-mast-assistant-message
+          data-streaming={entry.isStreaming ? 'true' : undefined}
+          className={rootClass}
+        >
+          {entry.contentBlocks.map((block, index) => {
+            const isLastBlock = index === entry.contentBlocks.length - 1;
+            if (block.type === 'thinking') {
+              return (
+                <ThinkingBlock
+                  key={block.id}
+                  content={block.content}
+                  isStreaming={entry.isStreaming && isLastBlock}
+                />
+              );
+            }
+            return <Fragment key={`${block.id}-${index}`}>{renderToolEvent(block)}</Fragment>;
+          })}
+          {entry.text ? (
+            renderMessage ? (
+              renderMessage(entry.text)
+            ) : (
+              <Suspense fallback={<p className="mast-assistant-message-text">{entry.text}</p>}>
+                <MarkdownText>{entry.text}</MarkdownText>
+              </Suspense>
+            )
+          ) : null}
+        </div>
+      </NestedToolRenderContext.Provider>
     </ToolLabelContext.Provider>
   );
 }

--- a/packages/react-ui/src/components/MessageList.test.tsx
+++ b/packages/react-ui/src/components/MessageList.test.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react';
 import {
   AgentRunner,
   ToolRegistry,
+  createAgentTool,
   type AdapterRequest,
   type AdapterStreamChunk,
   type AgentConfig,
@@ -430,5 +431,100 @@ describe('<MessageList>', () => {
     expect(await screen.findByTestId('approval-slot')).toBeDefined();
     expect(screen.queryByTestId('tool-slot')).toBeNull();
     expect(renderApproval).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Nested approval rendering — issue #142
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds a parent+child topology where the parent calls `delegate` and the
+   * child calls `sensitive` (which has `requiresApproval: true`). Used to
+   * verify that the approval card renders against a nested tool entry.
+   */
+  function makeNestedApprovalRunner(): AgentRunner {
+    const registry = new ToolRegistry().register(new StubTool(SENSITIVE_DEF));
+    const adapter = scriptedAdapter([
+      [{ type: 'tool_call', toolCall: { id: 'p1', name: 'delegate', args: { task: 'go' } } }],
+      [{ type: 'tool_call', toolCall: { id: 'c1', name: 'sensitive', args: { foo: 'bar' } } }],
+      [{ type: 'text_delta', delta: 'child-done' }],
+      [{ type: 'text_delta', delta: 'parent-done' }],
+    ]);
+    const runner = new AgentRunner(adapter, registry);
+    registry.register(
+      createAgentTool(
+        runner,
+        { name: 'Child', instructions: 'Child', tools: ['sensitive'] },
+        {
+          name: 'delegate',
+          description: 'Hand off to the child.',
+          parameters: { type: 'object' },
+          scope: 'write',
+          buildInput: (a) => (a as { task: string }).task,
+        },
+      ),
+    );
+    return runner;
+  }
+
+  const delegateAgentConfig: AgentConfig = {
+    name: 'Parent',
+    instructions: 'Parent.',
+    tools: ['delegate'],
+  };
+
+  it('renders <InlineApproval> for a sub-agent tool call by default', async () => {
+    const user = userEvent.setup();
+    const runner = makeNestedApprovalRunner();
+
+    render(
+      <AgentProvider
+        runner={runner}
+        agent={delegateAgentConfig}
+        onApprovalRequired={async () => INLINE_APPROVAL}
+      >
+        <SendButton text="plan" />
+        <MessageList />
+      </AgentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send plan' }));
+
+    // The bundled <InlineApproval> renders inside the nested entry, beneath
+    // the parent `delegate` block. Without the fix this card never appears.
+    await waitFor(() => {
+      expect(document.querySelector('[data-mast-inline-approval]')).not.toBeNull();
+    });
+    const card = document.querySelector('[data-mast-inline-approval]') as HTMLElement;
+    const nestedContainer = card.closest('.mast-tool-call-block-nested');
+    expect(nestedContainer).not.toBeNull();
+  });
+
+  it('forwards renderApproval to nested tool entries', async () => {
+    const user = userEvent.setup();
+    const runner = makeNestedApprovalRunner();
+    const renderApproval = vi.fn(
+      (entry: ToolEventEntry, _approval: PendingApproval): ReactNode => (
+        <div data-testid="custom-approval">custom: {entry.name}</div>
+      ),
+    );
+
+    render(
+      <AgentProvider
+        runner={runner}
+        agent={delegateAgentConfig}
+        onApprovalRequired={async () => INLINE_APPROVAL}
+      >
+        <SendButton text="plan" />
+        <MessageList renderApproval={renderApproval} />
+      </AgentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'send plan' }));
+
+    const card = await screen.findByTestId('custom-approval');
+    expect(card.textContent).toContain('custom: sensitive');
+    // The bundled card must not also render alongside the custom slot.
+    expect(document.querySelector('[data-mast-inline-approval]')).toBeNull();
   });
 });

--- a/packages/react-ui/src/components/ToolCallBlock.test.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.test.tsx
@@ -3,11 +3,11 @@
 
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { ToolEventEntry } from '../types.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
-import { ToolLabelContext } from './ToolLabelContext.js';
+import { NestedToolRenderContext, ToolLabelContext } from './ToolLabelContext.js';
 
 function makeEntry(overrides: Partial<ToolEventEntry> = {}): ToolEventEntry {
   return {
@@ -234,6 +234,65 @@ describe('<ToolCallBlock>', () => {
       // Nested entry uses the resolver's value.
       expect(screen.getByText('Proofreader')).toBeDefined();
       expect(screen.queryByText('delegate_to_skill')).toBeNull();
+    });
+
+    it('routes nested entries through NestedToolRenderContext when one is provided', () => {
+      const renderNested = vi.fn((entry: ToolEventEntry) => (
+        <span data-testid={`custom-${entry.name}`}>{entry.name}</span>
+      ));
+      const parent: ToolEventEntry = {
+        id: 'parent',
+        type: 'tool_call_started',
+        name: 'agent_tool',
+        args: {},
+        isStreaming: true,
+        nestedToolEvents: [
+          {
+            id: 'nested-a',
+            type: 'tool_call_started',
+            name: 'inner_a',
+            args: {},
+            isStreaming: true,
+          },
+        ],
+      };
+      render(
+        <NestedToolRenderContext.Provider value={renderNested}>
+          <ToolCallBlock entry={parent} />
+        </NestedToolRenderContext.Provider>,
+      );
+      expect(screen.getByTestId('custom-inner_a').textContent).toBe('inner_a');
+      // The bare recursive ToolCallBlock should NOT have rendered for the
+      // nested entry — only the top-level parent block exists.
+      expect(screen.queryAllByTestId('mast-tool-call-status')).toHaveLength(1);
+      expect(renderNested).toHaveBeenCalledWith(parent.nestedToolEvents![0]);
+    });
+
+    it('falls back to bare recursive ToolCallBlock when no NestedToolRenderContext is provided', () => {
+      const parent: ToolEventEntry = {
+        id: 'parent',
+        type: 'tool_call_started',
+        name: 'agent_tool',
+        args: {},
+        isStreaming: true,
+        nestedToolEvents: [
+          {
+            id: 'nested-a',
+            type: 'tool_call_completed',
+            name: 'inner_a',
+            args: {},
+            result: 'a',
+            isStreaming: false,
+            status: 'success',
+          },
+        ],
+      };
+      const { container } = render(<ToolCallBlock entry={parent} />);
+      const nestedBlocks = container.querySelectorAll(
+        '.mast-tool-call-block-nested [data-mast-tool-call-block]',
+      );
+      expect(nestedBlocks).toHaveLength(1);
+      expect(nestedBlocks[0].getAttribute('data-tool-name')).toBe('inner_a');
     });
 
     it('renders multiple nested entries in order', () => {

--- a/packages/react-ui/src/components/ToolCallBlock.tsx
+++ b/packages/react-ui/src/components/ToolCallBlock.tsx
@@ -1,13 +1,13 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useContext } from 'react';
+import { Fragment, useContext } from 'react';
 import type { ReactNode } from 'react';
 
 import { useIcons } from '../icons.js';
 import type { ToolEventEntry } from '../types.js';
 import { ThinkingBlock } from './ThinkingBlock.js';
-import { ToolLabelContext } from './ToolLabelContext.js';
+import { NestedToolRenderContext, ToolLabelContext } from './ToolLabelContext.js';
 
 /**
  * Props accepted by {@link ToolCallBlock}.
@@ -74,7 +74,11 @@ function formatJson(value: unknown): string {
  *
  * When `entry.nestedToolEvents` is non-empty, each nested tool call is rendered
  * recursively inside the parent block so a sub-agent's tool calls appear
- * indented beneath the sub-agent's narration.
+ * indented beneath the sub-agent's narration. When the block is rendered inside
+ * an `<AssistantMessage>`, that parent publishes its approval-aware renderer
+ * via the `NestedToolRenderContext`, so an inline approval card surfaces on
+ * sub-agent tool calls at any nesting depth. Standalone usage (no provider in
+ * scope) falls back to a bare recursive `<ToolCallBlock>`.
  *
  * The outer block, args, and result expand/collapse all use native
  * `<details>/<summary>` so the component is keyboard-accessible without
@@ -108,6 +112,7 @@ export function ToolCallBlock({
 }: ToolCallBlockProps) {
   const icons = useIcons();
   const getToolLabel = useContext(ToolLabelContext);
+  const renderNested = useContext(NestedToolRenderContext);
   const rootClass = ['mast-tool-call-block', className].filter(Boolean).join(' ');
   const hasSubAgentOutput = entry.subThinking !== undefined || entry.subText !== undefined;
   const nestedToolEvents = entry.nestedToolEvents ?? [];
@@ -164,9 +169,13 @@ export function ToolCallBlock({
 
         {nestedToolEvents.length > 0 ? (
           <div className="mast-tool-call-block-nested" data-testid="mast-tool-call-nested">
-            {nestedToolEvents.map((nested) => (
-              <ToolCallBlock key={nested.id} entry={nested} />
-            ))}
+            {nestedToolEvents.map((nested) =>
+              renderNested ? (
+                <Fragment key={nested.id}>{renderNested(nested)}</Fragment>
+              ) : (
+                <ToolCallBlock key={nested.id} entry={nested} />
+              ),
+            )}
           </div>
         ) : null}
 

--- a/packages/react-ui/src/components/ToolLabelContext.tsx
+++ b/packages/react-ui/src/components/ToolLabelContext.tsx
@@ -25,3 +25,17 @@ export type GetToolLabel = (entry: ToolEventEntry) => ReactNode;
  * 3. `entry.name`.
  */
 export const ToolLabelContext = createContext<GetToolLabel | undefined>(undefined);
+
+/**
+ * Renders a single tool event, deciding whether to show the inline approval
+ * card or a regular `<ToolCallBlock>`. The same closure that
+ * `<AssistantMessage>` builds for top-level entries; published via context so
+ * `<ToolCallBlock>` can use it for entries inside `nestedToolEvents` and the
+ * approval-aware branch is reachable at every nesting depth.
+ *
+ * `<ToolCallBlock>` falls back to a bare recursive `<ToolCallBlock>` when no
+ * provider is in scope, so the component still works standalone.
+ */
+export const NestedToolRenderContext = createContext<
+  ((entry: ToolEventEntry) => ReactNode) | undefined
+>(undefined);

--- a/packages/react-ui/src/context.tsx
+++ b/packages/react-ui/src/context.tsx
@@ -211,15 +211,15 @@ export function AgentProvider({
   const notifyAwaitingRef = useRef<((name: string, awaiting: boolean) => void) | null>(null);
   const setStatusRef = useRef<((name: string, status: ToolCallStatus) => void) | null>(null);
   const enqueueInlineRef = useRef<
-    ((toolName: string, args: unknown) => Promise<boolean | string>) | null
+    ((toolName: string, args: unknown, signal?: AbortSignal) => Promise<boolean | string>) | null
   >(null);
 
   const approvalHandler = useMemo<ApprovalHandler>(() => {
     const hooks: ApprovalHandlerHooks = {
       notifyAwaiting: (name, awaiting) => notifyAwaitingRef.current?.(name, awaiting),
       setStatus: (name, status) => setStatusRef.current?.(name, status),
-      enqueueInline: (name, args) =>
-        enqueueInlineRef.current?.(name, args) ?? Promise.resolve(true),
+      enqueueInline: (name, args, signal) =>
+        enqueueInlineRef.current?.(name, args, signal) ?? Promise.resolve(true),
     };
     return createApprovalHandler(
       () => onApprovalRef.current,
@@ -280,12 +280,25 @@ export function AgentProvider({
   const pendingApprovalsRef = useRef<PendingApproval[]>(pendingApprovals);
   pendingApprovalsRef.current = pendingApprovals;
 
-  const enqueueInline = useCallback((toolName: string, args: unknown) => {
+  const enqueueInline = useCallback((toolName: string, args: unknown, signal?: AbortSignal) => {
     return new Promise<boolean | string>((resolve) => {
+      // If the run has already been cancelled before we even enqueue, settle
+      // immediately so the runner's next loop iteration sees the abort and
+      // throws — without ever showing an approval card.
+      if (signal?.aborted) {
+        resolve(false);
+        return;
+      }
+      let settled = false;
+      const onAbort = () => finish(false);
       const finish = (decision: boolean | string) => {
+        if (settled) return;
+        settled = true;
+        if (signal) signal.removeEventListener('abort', onAbort);
         setPendingApprovals((prev) => prev.filter((p) => p !== handle));
         resolve(decision);
       };
+      if (signal) signal.addEventListener('abort', onAbort);
       const handle: PendingApproval = {
         toolName,
         args,

--- a/packages/react-ui/src/hooks/useAgentStream.ts
+++ b/packages/react-ui/src/hooks/useAgentStream.ts
@@ -86,6 +86,76 @@ function updateNestedToolEvent(
   });
 }
 
+/**
+ * Recursively walks `nestedToolEvents` looking for the deepest streaming
+ * `ToolEventEntry` whose `name` matches `toolName`, replacing it with the
+ * result of `updater`. Returns `{ events, patched }` so callers can detect
+ * whether a match was found and avoid creating a fresh array when nothing
+ * changed.
+ *
+ * "Deepest first" matches the runtime semantics of the approval handler:
+ * `notifyAwaiting(name, true)` always refers to the currently-suspended
+ * tool, which is the most deeply nested one with that name still running.
+ */
+function patchToolEventsByName(
+  events: ToolEventEntry[],
+  toolName: string,
+  updater: (t: ToolEventEntry) => ToolEventEntry,
+): { events: ToolEventEntry[]; patched: boolean } {
+  let patched = false;
+  const next = events.map((event) => {
+    if (patched) return event;
+    if (event.nestedToolEvents && event.nestedToolEvents.length > 0) {
+      const r = patchToolEventsByName(event.nestedToolEvents, toolName, updater);
+      if (r.patched) {
+        patched = true;
+        return { ...event, nestedToolEvents: r.events };
+      }
+    }
+    if (event.name === toolName && event.isStreaming) {
+      patched = true;
+      return updater(event);
+    }
+    return event;
+  });
+  return { events: patched ? next : events, patched };
+}
+
+/**
+ * Like {@link updateToolEvent} but walks `nestedToolEvents` recursively so
+ * that approval-state setters can target tool calls fired by sub-agents.
+ *
+ * Used by `setToolAwaitingApproval` and `setToolStatus`, which receive only a
+ * tool name (not the parent path) because the runner's approval gate fires
+ * for whichever tool is currently suspended — at any depth of nesting.
+ */
+function updateToolEventDeep(
+  entries: ConversationEntry[],
+  entryId: string,
+  toolName: string,
+  updater: (t: ToolEventEntry) => ToolEventEntry,
+): ConversationEntry[] {
+  return updateEntry(entries, entryId, (entry) => {
+    let patched = false;
+    const contentBlocks: ContentBlock[] = entry.contentBlocks.map((block) => {
+      if (patched || block.type === 'thinking') return block;
+      if (block.nestedToolEvents && block.nestedToolEvents.length > 0) {
+        const r = patchToolEventsByName(block.nestedToolEvents, toolName, updater);
+        if (r.patched) {
+          patched = true;
+          return { ...block, nestedToolEvents: r.events };
+        }
+      }
+      if (block.name === toolName && block.isStreaming) {
+        patched = true;
+        return updater(block);
+      }
+      return block;
+    });
+    return patched ? { ...entry, contentBlocks } : entry;
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -172,8 +242,10 @@ export interface UseAgentStreamReturn {
   reset: () => void;
 
   /**
-   * Sets the `awaitingApproval` flag on the first matching streaming
+   * Sets the `awaitingApproval` flag on the deepest matching streaming
    * `ToolEventEntry` (by `name`) within the most recent assistant entry.
+   * The traversal walks `nestedToolEvents` recursively so sub-agent tool
+   * calls are reachable.
    *
    * Used by the approval proxy in `AgentProvider` to surface "awaiting human
    * decision" as a first-class state on the entry, so renderers can show a
@@ -182,10 +254,12 @@ export interface UseAgentStreamReturn {
   setToolAwaitingApproval: (name: string, awaiting: boolean) => void;
 
   /**
-   * Sets the `status` field on the first matching streaming `ToolEventEntry`
-   * (by `name`). Used by the approval proxy to mark a call as `'cancelled'`
-   * before the runner emits `tool_call_completed` so the eventual completion
-   * event preserves the cancellation rather than defaulting to `'success'`.
+   * Sets the `status` field on the deepest matching streaming `ToolEventEntry`
+   * (by `name`). The traversal walks `nestedToolEvents` recursively so
+   * sub-agent tool calls are reachable. Used by the approval proxy to mark a
+   * call as `'cancelled'` before the runner emits `tool_call_completed` so
+   * the eventual completion event preserves the cancellation rather than
+   * defaulting to `'success'`.
    */
   setToolStatus: (name: string, status: ToolCallStatus) => void;
 }
@@ -280,7 +354,7 @@ export function useAgentStream(
     setEntries((prev) => {
       const assistantId = findStreamingAssistantId(prev);
       if (assistantId === undefined) return prev;
-      return updateToolEvent(prev, assistantId, name, (t) => ({
+      return updateToolEventDeep(prev, assistantId, name, (t) => ({
         ...t,
         awaitingApproval: awaiting,
       }));
@@ -291,7 +365,7 @@ export function useAgentStream(
     setEntries((prev) => {
       const assistantId = findStreamingAssistantId(prev);
       if (assistantId === undefined) return prev;
-      return updateToolEvent(prev, assistantId, name, (t) => ({ ...t, status }));
+      return updateToolEventDeep(prev, assistantId, name, (t) => ({ ...t, status }));
     });
   }, []);
 
@@ -362,7 +436,10 @@ export function useAgentStream(
                     type: 'tool_call_completed',
                     result: completedEvent.result,
                     isStreaming: false,
-                    status: completedEvent.error ? 'error' : 'success',
+                    // Preserve a status set by the proxy (e.g. 'cancelled');
+                    // only fall back to error/success based on the runner's
+                    // flag. Mirrors the top-level tool_call_completed branch.
+                    status: n.status ?? (completedEvent.error ? 'error' : 'success'),
                   })),
                 );
               }


### PR DESCRIPTION
## Summary

After v0.7.0 enabled approval gating for sub-agent tool calls (#128), three coupled gaps in the React layer left runs unrenderable and unrecoverable when an `INLINE_APPROVAL` fired from a sub-agent. Fixes all three.

- **`useAgentStream`** — `setToolAwaitingApproval` / `setToolStatus` now walk `nestedToolEvents` recursively (deepest streaming match by name) so the approval-state proxy reaches sub-agent calls. The nested `tool_call_completed` handler also preserves a proxy-set `'cancelled'` status, mirroring the top-level branch.
- **`<ToolCallBlock>`** — nested entries route through a new `NestedToolRenderContext` published by `<AssistantMessage>`, so `renderApproval` / `renderToolCall` slots and the bundled `<InlineApproval>` card surface at any nesting depth. Standalone usage (no provider in scope) falls back to bare recursion.
- **`ApprovalRequest`** — gains an optional `signal` forwarded by the runner. The React inline-approval queue attaches an `abort` listener that resolves pending entries as rejections, so `cancel()` unblocks a stranded run cleanly without needing `reset()`.

Closes #142

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test --workspaces --if-present` passes (308 tests; 8 new)
- [x] Manually verified in cobweb: nested approval card renders, approve/reject works, `cancel()` during a pending nested approval unwinds the run

## New test coverage

- `runner.test.ts` — signal forwarded into `ApprovalRequest`; runner aborts cleanly when the signal fires while `requestApproval` is awaiting.
- `approval.test.tsx` — nested `awaitingApproval` flag set; reject propagates `status='cancelled'` to the nested entry; `cancel()` during nested *and* top-level pending approval unblocks the run and clears `pendingApprovals`.
- `MessageList.test.tsx` — bundled `<InlineApproval>` renders for sub-agent tool calls; `renderApproval` slot fires for nested entries.
- `ToolCallBlock.test.tsx` — nested rendering routes through `NestedToolRenderContext`; falls back to bare recursive `<ToolCallBlock>` without context.