### PR TITLE
chore: release v0.7.1

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.7.0"
+    "@mast-ai/core": "^0.7.1"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.7.0"
+    "@mast-ai/core": "^0.7.1"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/openai",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.7.0",
+    "@mast-ai/core": "^0.7.1",
     "openai": "^6.37.0"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.7.0",
+    "@mast-ai/core": "^0.7.1",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
## Summary

Patch release. Ships the fix from #143 (closing #142): nested sub-agent approval rendering and `cancel()` responsiveness.

## Severity

Patch — bug fix in `@mast-ai/react-ui`'s approval flow plus an additive optional `signal?: AbortSignal` field on `ApprovalRequest` (no breaking changes).

## Changes since v0.7.0

- `@mast-ai/core` — additive: `ApprovalRequest.signal` forwarded by the runner so handlers can race their UI against `cancel()`.
- `@mast-ai/react-ui` — fix: approval-state proxy walks `nestedToolEvents` recursively; `<ToolCallBlock>` consumes a new `NestedToolRenderContext` so `<InlineApproval>` / `renderApproval` / `renderToolCall` reach sub-agent tool calls; inline approval queue listens on the run signal and resolves pending entries on abort.
- `@mast-ai/google-genai`, `@mast-ai/built-in-ai`, `@mast-ai/openai` — no source changes; lockstep version bump and refreshed `@mast-ai/core` dep.

## Test plan

- [x] `npm run lint`
- [x] `npm test --workspaces --if-present` (308 tests)
- [x] `npm run build`