### PR TITLE
chore: release v0.8.0

### DIFF
--- a/packages/built-in-ai/package.json
+++ b/packages/built-in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/built-in-ai",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.7.1"
+    "@mast-ai/core": "^0.8.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/google-genai/package.json
+++ b/packages/google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/google-genai",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
-    "@mast-ai/core": "^0.7.1"
+    "@mast-ai/core": "^0.8.0"
   },
   "devDependencies": {
     "typescript": "~6.0.2",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/openai",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
     "format": "prettier --write src"
   },
   "dependencies": {
-    "@mast-ai/core": "^0.7.1",
+    "@mast-ai/core": "^0.8.0",
     "openai": "^6.37.0"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mast-ai/react-ui",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "format": "prettier --write src"
   },
   "peerDependencies": {
-    "@mast-ai/core": "^0.7.1",
+    "@mast-ai/core": "^0.8.0",
     "@tanstack/react-virtual": ">=3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"


### PR DESCRIPTION
Bumps all `@mast-ai/*` packages from `0.7.1` to `0.8.0`.

## Why a minor bump

Per the 0.x semver policy in `CLAUDE.md`, minor is the breaking-change line until 1.0 ships. This release contains a breaking change to `@mast-ai/react-ui`'s `ToolEventEntry` shape (#146 / closes #145):

- `ToolEventEntry.subThinking?: string` — **removed**
- `ToolEventEntry.nestedToolEvents?: ToolEventEntry[]` — **removed**
- `ToolEventEntry.nestedContentBlocks?: ContentBlock[]` — **added** (interleaves sub-agent thinking and tool calls in source order)
- `ToolEventEntry.subText?: string` — unchanged

Apps reading `subThinking` or `nestedToolEvents` directly need to walk `nestedContentBlocks` and dispatch on `block.type`. Apps that only render via the bundled `<ToolCallBlock>` / `<MessageList>` / `<ConversationPanel>` need no code changes. See PR #146 for the full migration notes.

`@mast-ai/core` also changes observable streaming behaviour (`tool_call_started` events are now yielded inline rather than batched after the stream ends), but the event types and signatures are unchanged. No code changes required for consumers; the new ordering is what consumers were already implicitly assuming.

## Changes since v0.7.1

- #146 — fix(core,react-ui): emit `tool_call_started` inline and interleave sub-agent thinking with nested tool calls (closes #145)

## Test plan

- [x] `npm run lint` clean
- [x] `npm test --workspaces --if-present` — 380 tests pass (built-in-ai 67, core 69, google-genai 15, openai 35, react-ui 194)
- [x] `npm run build` clean across all packages

## Release sequence

After merge:
1. `git checkout main && git pull`
2. `git tag v0.8.0`
3. `git push origin v0.8.0` — triggers `.github/workflows/publish.yml` to publish all packages to npm via OIDC trusted publishing.